### PR TITLE
fix deployment target to iOS/tvOS 9.0

### DIFF
--- a/OptimizelySwiftSDK.podspec
+++ b/OptimizelySwiftSDK.podspec
@@ -5,8 +5,8 @@ Pod::Spec.new do |s|
   s.homepage                = "http://developers.optimizely.com/server/reference/index.html?language=objectivec"
   s.license                 = { :type => "Apache License, Version 2.0", :file => "LICENSE" }
   s.author                  = { "Optimizely" => "support@optimizely.com" }
-  s.ios.deployment_target   = "10.0"
-  s.tvos.deployment_target  = "10.0"
+  s.ios.deployment_target   = "9.0"
+  s.tvos.deployment_target  = "9.0"
   s.source                  = {
     :git => "https://github.com/optimizely/swift-sdk.git",
     :tag => "v"+s.version.to_s


### PR DESCRIPTION
This fix is to support Cocoapod default setting ("pod init" set to 9.0, so it breaks on the 1st try).
We'll revisit the min OS version issue later.