### PR TITLE
(fix):don't eval empty condition array

### DIFF
--- a/DemoSwiftApp/AppDelegate.swift
+++ b/DemoSwiftApp/AppDelegate.swift
@@ -33,7 +33,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     let datafileName = "demoTestDatafile"
     let experimentKey = "background_experiment"
     let eventKey = "sample_conversion"
-    let attributes = ["browser_type": "safari"]
+    let attributes = ["browser_type": "safari", "bool_attr": false] as [String : Any?]
     let sdkKey = "FCnSegiEkRry9rhVMroit4"
     
     var storyboard: UIStoryboard {

--- a/OptimizelySDK/Implementation/DefaultDecisionService.swift
+++ b/OptimizelySDK/Implementation/DefaultDecisionService.swift
@@ -84,8 +84,11 @@ class DefaultDecisionService : OPTDecisionService {
     }
     
     func isInExperiment(experiment:Experiment, userId:String, attributes: OptimizelyAttributes) -> Bool? {
-        if let conditions = experiment.audienceConditions {
-            
+        if let conditions = experiment.audienceConditions, case .array(let arrConditions) = conditions, arrConditions.count > 0  {
+            // TODO: [Jae] fix with OptimizelyError
+            return try? conditions.evaluate(project: config.project, attributes: attributes)
+        }
+        else if let conditions = experiment.audienceConditions, case .leaf(_) = conditions {
             // TODO: [Jae] fix with OptimizelyError
             return try? conditions.evaluate(project: config.project, attributes: attributes)
         }

--- a/OptimizelySDK/OptimizelySwiftSDK.xcodeproj/project.pbxproj
+++ b/OptimizelySDK/OptimizelySwiftSDK.xcodeproj/project.pbxproj
@@ -100,6 +100,7 @@
 		0B7B9EC421F2ACB100056589 /* DataStoreFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B7B9EC221F2ACB100056589 /* DataStoreFile.swift */; };
 		0B7B9EC521F51AF600056589 /* DataStoreFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B7B9EC221F2ACB100056589 /* DataStoreFile.swift */; };
 		0B7B9EC621F51AF700056589 /* DataStoreFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B7B9EC221F2ACB100056589 /* DataStoreFile.swift */; };
+		0BB5889D22399FC200B6D274 /* OptimizelyManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E4DD99321E6BAA700B0C2C7 /* OptimizelyManagerTests.swift */; };
 		0BC48EA32203764E003AFD71 /* DataStoreQueueStackImpl+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BC48EA22203764E003AFD71 /* DataStoreQueueStackImpl+Extension.swift */; };
 		0BC48EA522038491003AFD71 /* ArrayEventForDispatch+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BC48EA422038491003AFD71 /* ArrayEventForDispatch+Extension.swift */; };
 		0BE644ED223821D3009A5D1D /* AtomicProperty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BE644EC223821D3009A5D1D /* AtomicProperty.swift */; };
@@ -2745,6 +2746,7 @@
 				6EA425BE2218E74D00B074B5 /* DefaultDatafileHandler.swift in Sources */,
 				6EA425C22218E74D00B074B5 /* OPTDatafileHandler.swift in Sources */,
 				6EA425BB2218E74D00B074B5 /* DefaultBucketer.swift in Sources */,
+				0BB5889D22399FC200B6D274 /* OptimizelyManagerTests.swift in Sources */,
 				6EA425D52218E74D00B074B5 /* Variation.swift in Sources */,
 				6EA425C42218E74D00B074B5 /* JSONParse.swift in Sources */,
 				6ED1B8FA2225AA6500C4C774 /* DefaultUserProfileServiceTests.swift in Sources */,

--- a/OptimizelySDK/OptimizelyTests/OptimizelyTests-APIs/OptimizelyManagerTests.swift
+++ b/OptimizelySDK/OptimizelyTests/OptimizelyTests-APIs/OptimizelyManagerTests.swift
@@ -71,6 +71,49 @@ class OptimizelyManagerTests: XCTestCase {
             }
         }
     }
+    
+    func testActivateWithInvalidAttribute() {
+        let optimizely = OTUtils.createOptimizely(datafileName: "audience_targeting", clearUserProfileService: true)
+        
+        /*
+         experiment_key: ab_running_exp_typed_audiences_gt_41_and_lt_43
+         user_id: test_user_1
+         attributes:
+         i_42: false
+         */
+        let variation = try? optimizely?.activate(experimentKey:
+            "ab_running_exp_typed_audiences_gt_41_and_lt_43",
+                                                  userId: "test_user_1",
+                                                  attributes:
+            ["i_42": false])
+        
+        XCTAssertNil(variation as Any?)
+    }
+
+    func testActivateWithEmptyConditions() {
+        let optimizely = OTUtils.createOptimizely(datafileName: "audience_targeting", clearUserProfileService: true)
+        
+        /*
+         "experiment_key": "ab_running_exp_audience_combo_empty_conditions",
+         "user_id": "test_user_1",
+         "attributes": {
+         "s_foo": "foo",
+         "b_true": "N/A",
+         "i_42": 44,
+         "d_4_2": "N/A"
+
+         */
+        let variation = try? optimizely?.activate(experimentKey:
+            "ab_running_exp_audience_combo_empty_conditions",
+                                                  userId: "test_user_1",
+                                                  attributes:
+            ["s_foo": "foo",
+             "b_true": "N/A",
+             "i_42": 44,
+             "d_4_2": "N/A"])
+        
+        XCTAssertEqual(variation, "all_traffic_variation")
+    }
 
     func testPerformanceInitialize() {
         // This is an example of a performance test case.


### PR DESCRIPTION
added unit tests that match failures in the swift-testapp