### PR TITLE
ci(travis): add travisci-tools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,5 +42,4 @@ jobs:
         - mkdir $HOME/travisci-tools && pushd $HOME/travisci-tools && git init && git pull https://$CI_USER_TOKEN@github.com/optimizely/travisci-tools.git && popd
       script:
         - "$HOME/travisci-tools/fsc-trigger/trigger_fullstack-sdk-compat.sh"
-      # travis_terminate not supported by darwin
-      after_success: skip
+      after_success: travis_terminate 0


### PR DESCRIPTION
this PR is for fixing https://github.com/optimizely/swift-sdk/pull/66 so that travisci-tools is obtained from the right location (not s3)