### PR TITLE
(fix): Support for Float80

### DIFF
--- a/OptimizelySDK/OptimizelyTests/OptimizelyTests-DataModel/AttributeValueTests.swift
+++ b/OptimizelySDK/OptimizelyTests/OptimizelyTests-DataModel/AttributeValueTests.swift
@@ -77,7 +77,7 @@ class AttributeValueTests: XCTestCase {
         // Float80 is not supported JSON parser (it's not expected to see this from datafile, but it still
         // can be passed as attribute values from client app
         let testsAttributesOnly = [
-            [Float80(value), Double(value)]
+            [CLongDouble(value), Double(value)]
         ]
         
         for (idx, test) in testsAttributesOnly.enumerated() {

--- a/OptimizelySDK/OptimizelyTests/OptimizelyTests-DataModel/AttributeValueTests_Evaluate.swift
+++ b/OptimizelySDK/OptimizelyTests/OptimizelyTests-DataModel/AttributeValueTests_Evaluate.swift
@@ -251,7 +251,7 @@ extension AttributeValueTests_Evaluate {
     }
 
     func allNumTypes(value: Double) -> [Any] {
-        return [Double(value), Float(value), Float32(value), Float64(value), Float80(value)]
+        return [Double(value), Float(value), Float32(value), Float64(value), CLongDouble(value)]
     }
     
     func allValueTypes(value: Double) -> [Any] {

--- a/OptimizelySDK/Utils/Utils.swift
+++ b/OptimizelySDK/Utils/Utils.swift
@@ -32,7 +32,7 @@ class Utils {
     static func isDoubleType(_ value: Any) -> Bool {
         // Float32 === Float, Float64 ==== Double
         let allSwiftNumTypes: [Any.Type] = [Double.self,
-                                            Float.self, Float80.self]
+                                            Float.self, CLongDouble.self]
         
         let isSwiftNumType = allSwiftNumTypes.contains{ $0 == type(of: value) }
         let isNSNumberNumType = (value is Double) && !isNSNumberBoolType(value)
@@ -78,7 +78,7 @@ class Utils {
         switch value {
         case is Double: finalValue = Double(value as! Double)
         case is Float: finalValue = Double(value as! Float)
-        case is Float80: finalValue = Double(value as! Float80)
+        case is CLongDouble: finalValue = Double(value as! CLongDouble)
         default: finalValue = nil
         }
         


### PR DESCRIPTION
error: 'Float80' is unavailable: Float80 is only available on non-Windows x86 targets.
This fixes the above issue which occurs when building the test-app for full-stack compat.

This solution is also defined in official swift documentation:
https://github.com/apple/swift/blob/master/stdlib/public/core/CTypes.swift#L66

Build Failure can be seen here:
https://travis-ci.com/optimizely/swift-testapp/builds/106299426

Full-stack response with this fix:
https://travis-ci.com/optimizely/fullstack-sdk-compatibility-suite/jobs/188800739