### PR TITLE
(fix): add an objective c version of the default event dispatcher to set tim…

### DIFF
--- a/DemoObjCApp/AppDelegate.m
+++ b/DemoObjCApp/AppDelegate.m
@@ -58,7 +58,9 @@ static NSString * const kOptimizelyEventKey = @"sample_conversion";
 // MARK: - Initialization Examples
 
 -(void)initializeOptimizelySDKAsynchronous {
-    self.optimizely = [[OptimizelyClient alloc] initWithSdkKey:kOptimizelySdkKey];
+    DefaultEventDispatcher *eventDispacher = [[DefaultEventDispatcher alloc] initWithTimerInterval:1];
+    
+    self.optimizely = [[OptimizelyClient alloc] initWithSdkKey:kOptimizelySdkKey logger:nil eventDispatcher:eventDispacher userProfileService:nil periodicDownloadInterval:@(5) defaultLogLevel:OptimizelyLogLevelDebug];
     
     [self.optimizely startWithCompletion:^(NSData *data, NSError *error) {
         if (error == nil) {


### PR DESCRIPTION
…e interval.

I'm not sure we need or want to expose this.  If objective c folks want to use the default event handler they can just create a swift file and use it in their objective-c app.  Thoughts?