### PR TITLE
(chore): Udate travis os builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ jobs:
       name: PLATFORM='iOS Simulator' OS=12.1 NAME='iPhone 7'
     - <<: *unittests
       env: SCHEME=OptimizelySwiftSDK-tvOS TEST_SDK=appletvsimulator PLATFORM='tvOS Simulator' OS=12.1 NAME='Apple TV 1080p'
-      name: PLATFORM='tvOS Simulator' OS=12.2 NAME='Apple TV 1080p'
+      name: PLATFORM='tvOS Simulator' OS=12.1 NAME='Apple TV 1080p'
 
     - stage: 'Prepare for release'
       name: Prepare for release

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,8 +65,8 @@ jobs:
       env: SCHEME=OptimizelySwiftSDK-iOS TEST_SDK=iphonesimulator PLATFORM='iOS Simulator' OS=12.1 NAME='iPhone 7'
       name: PLATFORM='iOS Simulator' OS=12.1 NAME='iPhone 7'
     - <<: *unittests
-      env: SCHEME=OptimizelySwiftSDK-tvOS TEST_SDK=appletvsimulator PLATFORM='tvOS Simulator' OS=12.1 NAME='Apple TV 1080p'
-      name: PLATFORM='tvOS Simulator' OS=12.1 NAME='Apple TV 1080p'
+      env: SCHEME=OptimizelySwiftSDK-tvOS TEST_SDK=appletvsimulator PLATFORM='tvOS Simulator' OS=12.1 NAME='Apple TV 4k'
+      name: PLATFORM='tvOS Simulator' OS=12.1 NAME='Apple TV 4k'
 
     - stage: 'Prepare for release'
       name: Prepare for release

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ jobs:
       name: PLATFORM='iOS Simulator' OS=12.1 NAME='iPhone 7'
     - <<: *unittests
       env: SCHEME=OptimizelySwiftSDK-tvOS TEST_SDK=appletvsimulator PLATFORM='tvOS Simulator' OS=12.1 NAME='Apple TV 1080p'
-      name: PLATFORM='tvOS Simulator' OS=10.2 NAME='Apple TV 1080p'
+      name: PLATFORM='tvOS Simulator' OS=12.2 NAME='Apple TV 1080p'
 
     - stage: 'Prepare for release'
       name: Prepare for release

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,13 +59,13 @@ jobs:
         - slather
         - sleep 5 # https://github.com/travis-ci/travis-ci/issues/4725
     - <<: *unittests
-      env: SCHEME=OptimizelySwiftSDK-iOS TEST_SDK=iphonesimulator PLATFORM='iOS Simulator' OS=10.1 NAME='iPhone 7 Plus'
-      name: PLATFORM='iOS Simulator' OS=10.1 NAME='iPhone 7 Plus'
+      env: SCHEME=OptimizelySwiftSDK-iOS TEST_SDK=iphonesimulator PLATFORM='iOS Simulator' OS=11.4 NAME='iPhone 7 Plus'
+      name: PLATFORM='iOS Simulator' OS=11.4 NAME='iPhone 7 Plus'
     - <<: *unittests
-      env: SCHEME=OptimizelySwiftSDK-iOS TEST_SDK=iphonesimulator PLATFORM='iOS Simulator' OS=10.3.1 NAME='iPhone 7'
-      name: PLATFORM='iOS Simulator' OS=10.3.1 NAME='iPhone 7'
+      env: SCHEME=OptimizelySwiftSDK-iOS TEST_SDK=iphonesimulator PLATFORM='iOS Simulator' OS=12.1 NAME='iPhone 7'
+      name: PLATFORM='iOS Simulator' OS=12.1 NAME='iPhone 7'
     - <<: *unittests
-      env: SCHEME=OptimizelySwiftSDK-tvOS TEST_SDK=appletvsimulator PLATFORM='tvOS Simulator' OS=10.2 NAME='Apple TV 1080p'
+      env: SCHEME=OptimizelySwiftSDK-tvOS TEST_SDK=appletvsimulator PLATFORM='tvOS Simulator' OS=12.1 NAME='Apple TV 1080p'
       name: PLATFORM='tvOS Simulator' OS=10.2 NAME='Apple TV 1080p'
 
     - stage: 'Prepare for release'

--- a/OptimizelySDK/OptimizelyTests/OptimizelyTests-Common/DatafileHandlerTests.swift
+++ b/OptimizelySDK/OptimizelyTests/OptimizelyTests-Common/DatafileHandlerTests.swift
@@ -161,7 +161,7 @@ class DatafileHandlerTests: XCTestCase {
     
     func testDownloadWithoutTimeout() {
         let handler = DefaultDatafileHandler()
-        handler.endPointStringFormat = "https://httpstat.us/200?sleep=5000&datafile=%@"
+        handler.endPointStringFormat = "https://httpstat.us/200?sleep=3000&datafile=%@"
         
         let expectation = XCTestExpectation(description: "will wait for response.")
         handler.downloadDatafile(sdkKey: "invalidKeyXXXXX") { (result) in


### PR DESCRIPTION
use iOS 12.1, 11.4 and 9.1.  Also use tvoOS 12.1.  This targets the OSs with the most market share.