### PR TITLE
fix(event processor): change ep behavior when timerInterval is negative value

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,8 @@ jobs:
       script:
         - if [[ "$TRAVIS_BRANCH" == "master" ]]; then xcodebuild test -workspace OptimizelySwiftSDK.xcworkspace -scheme $SCHEME -configuration Release CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO -sdk $TEST_SDK -destination "platform=$PLATFORM,OS=$OS,name=$NAME" ONLY_ACTIVE_ARCH=YES | tee buildoutput | xcpretty && test ${PIPESTATUS[0]} -eq 0; fi
       after_success:
-        - slather
+        # coverage collect for iOS only (.slather.yml)
+        - if [[ "$PLATFORM" == "iOS Simulator" ]]; then slather; fi
         - sleep 5 # https://github.com/travis-ci/travis-ci/issues/4725
       after_failure:
         # install travis artifacts uploader
@@ -84,9 +85,6 @@ jobs:
     - <<: *unittests
       env: SCHEME=OptimizelySwiftSDK-tvOS TEST_SDK=appletvsimulator PLATFORM='tvOS Simulator' OS=12.1 NAME='Apple TV 4K'
       name: PLATFORM='tvOS Simulator' OS=12.1 NAME='Apple TV 4K'
-      after_success:  
-        # do not slather for tvOS
-        - sleep 5 # https://github.com/travis-ci/travis-ci/issues/4725
 
     - stage: 'Prepare for release'
       name: Prepare for release

--- a/.travis.yml
+++ b/.travis.yml
@@ -84,6 +84,9 @@ jobs:
     - <<: *unittests
       env: SCHEME=OptimizelySwiftSDK-tvOS TEST_SDK=appletvsimulator PLATFORM='tvOS Simulator' OS=12.1 NAME='Apple TV 4K'
       name: PLATFORM='tvOS Simulator' OS=12.1 NAME='Apple TV 4K'
+      after_success:  
+        # do not slather for tvOS
+        - sleep 5 # https://github.com/travis-ci/travis-ci/issues/4725
 
     - stage: 'Prepare for release'
       name: Prepare for release

--- a/Sources/Customization/DefaultEventDispatcher.swift
+++ b/Sources/Customization/DefaultEventDispatcher.swift
@@ -24,9 +24,9 @@ open class DefaultEventDispatcher: BackgroundingCallbacks, OPTEventDispatcher {
     
     static let sharedInstance = DefaultEventDispatcher()
     
-    // default timerInterval
+    // timer-interval for batching (0 = no batching, negative = use default)
     var timerInterval: TimeInterval
-    // default batchSize.
+    // batch size (1 = no batching, 0 or negative = use default)
     // attempt to send events in batches with batchSize number of events combined
     var batchSize: Int
     var maxQueueSize: Int
@@ -61,10 +61,12 @@ open class DefaultEventDispatcher: BackgroundingCallbacks, OPTEventDispatcher {
                 timerInterval: TimeInterval = DefaultValues.timeInterval,
                 maxQueueSize: Int = DefaultValues.maxQueueSize) {
         self.batchSize = batchSize > 0 ? batchSize : DefaultValues.batchSize
+        self.timerInterval = timerInterval >= 0 ? timerInterval : DefaultValues.timeInterval
+        self.maxQueueSize = maxQueueSize >= 100 ? maxQueueSize : DefaultValues.maxQueueSize
+        
         self.backingStore = backingStore
         self.backingStoreName = dataStoreName
-        self.timerInterval = timerInterval
-        self.maxQueueSize = maxQueueSize > 100 ? maxQueueSize : DefaultValues.maxQueueSize
+
         
         switch backingStore {
         case .file:

--- a/Sources/Data Model/ProjectConfig.swift
+++ b/Sources/Data Model/ProjectConfig.swift
@@ -157,7 +157,7 @@ extension ProjectConfig {
     }
     
     private func getWhitelistedVariationId(userId: String, experimentId: String) -> String? {
-        if var dic = whitelistUsers[userId] {
+        if let dic = whitelistUsers[userId] {
             return dic[experimentId]
         }
         

--- a/Tests/OptimizelyTests-Common/EventDispatcherTests.swift
+++ b/Tests/OptimizelyTests-Common/EventDispatcherTests.swift
@@ -47,7 +47,7 @@ class EventDispatcherTests: XCTestCase {
     }
 
     func testDefaultDispatcher() {
-        eventDispatcher = DefaultEventDispatcher(timerInterval: 1)
+        eventDispatcher = DefaultEventDispatcher(timerInterval: 10)
         let pEventD: OPTEventDispatcher = eventDispatcher!
 
         pEventD.flushEvents()
@@ -55,9 +55,7 @@ class EventDispatcherTests: XCTestCase {
         eventDispatcher?.dispatcher.sync {
         }
         
-        pEventD.dispatchEvent(event: EventForDispatch(body: Data())) { (_) -> Void in
-            
-        }
+        pEventD.dispatchEvent(event: EventForDispatch(body: Data()), completionHandler: nil)
         
         eventDispatcher?.dispatcher.sync {
         }

--- a/Tests/OptimizelyTests-Common/EventDispatcherTests_Batch.swift
+++ b/Tests/OptimizelyTests-Common/EventDispatcherTests_Batch.swift
@@ -119,12 +119,13 @@ extension EventDispatcherTests_Batch {
         XCTAssert(defaultMaxQueueSize > 100)
 
         // invalid batchSize falls back to default value
-        
-        ep = DefaultEventDispatcher(batchSize: 0, timerInterval: 0, maxQueueSize: 0)
-        XCTAssertEqual(ep.batchSize, defaultBatchSize)
-        XCTAssertEqual(ep.maxQueueSize, defaultMaxQueueSize)
-
+        // (timerInterval = 0 is a valid value, meaning no batch)
         // invalid timeInterval tested in "testEventDispatchedOnTimer_ZeroInterval" below
+
+        ep = DefaultEventDispatcher(batchSize: 0, timerInterval: -1, maxQueueSize: 0)
+        XCTAssertEqual(ep.batchSize, defaultBatchSize)
+        XCTAssertEqual(ep.timerInterval, defaultTimeInterval)
+        XCTAssertEqual(ep.maxQueueSize, defaultMaxQueueSize)
     }
     
 }
@@ -688,7 +689,7 @@ extension EventDispatcherTests_Batch {
         wait(for: [eventDispatcher.exp!], timeout: 3)
         XCTAssertEqual(eventDispatcher.sendRequestedEvents.count, 1, "should flush on batchSize hit")
     }
-
+    
     func testEventsFlushedOnRevisionChange() {
         // this tests timer-based dispatch, available for iOS 10+
         guard #available(iOS 10.0, tvOS 10.0, *) else { return }


### PR DESCRIPTION
* when timerInterval is negative, spec defines to use default interval value (instead of disabling batch).