### PR TITLE
fix: add close() API to OptimizelyClient and EventDispatcher for test support

### DIFF
--- a/DemoSwiftApp/AppDelegate.swift
+++ b/DemoSwiftApp/AppDelegate.swift
@@ -152,7 +152,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             }
         })
         
-        _ = optimizely.notificationCenter.addLogEventNotificationListener(logEventListener: { (url, event) in
+        _ = notificationCenter.addLogEventNotificationListener(logEventListener: { (url, event) in
             print("Received logEvent notification: \(url) \(event)")
         })
     }

--- a/OptimizelySwiftSDK.xcodeproj/project.pbxproj
+++ b/OptimizelySwiftSDK.xcodeproj/project.pbxproj
@@ -2183,6 +2183,7 @@
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
+				Base,
 			);
 			mainGroup = 0B7CB0B821AC5FE2007B77E5;
 			productRefGroup = 0B7CB0C321AC5FE2007B77E5 /* Products */;

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -5,7 +5,7 @@ DEPENDENCIES:
   - SwiftLint
 
 SPEC REPOS:
-  https://github.com/cocoapods/specs.git:
+  https://github.com/CocoaPods/Specs.git:
     - SwiftLint
 
 SPEC CHECKSUMS:
@@ -13,4 +13,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 94877e134bcac3007b5b3e8cdbd17fa6eb0fd375
 
-COCOAPODS: 1.6.1
+COCOAPODS: 1.8.0

--- a/Sources/Customization/DefaultEventDispatcher.swift
+++ b/Sources/Customization/DefaultEventDispatcher.swift
@@ -276,7 +276,7 @@ extension DefaultEventDispatcher {
     
     // MARK: - Tests
 
-    func close() {
+    open func close() {
         self.flushEvents()
         self.dispatcher.sync {}
     }

--- a/Sources/Customization/DefaultEventDispatcher.swift
+++ b/Sources/Customization/DefaultEventDispatcher.swift
@@ -54,7 +54,6 @@ open class DefaultEventDispatcher: BackgroundingCallbacks, OPTEventDispatcher {
     var observerProjectId: NSObjectProtocol?
     var observerRevision: NSObjectProtocol?
     
-
     public init(batchSize: Int = DefaultValues.batchSize,
                 backingStore: DataStoreType = .file,
                 dataStoreName: String = "OPTEventQueue",
@@ -67,7 +66,6 @@ open class DefaultEventDispatcher: BackgroundingCallbacks, OPTEventDispatcher {
         self.backingStore = backingStore
         self.backingStoreName = dataStoreName
 
-        
         switch backingStore {
         case .file:
             self.dataStore = DataStoreQueueStackImpl<EventForDispatch>(queueStackName: "OPTEventQueue",
@@ -256,12 +254,12 @@ open class DefaultEventDispatcher: BackgroundingCallbacks, OPTEventDispatcher {
 extension DefaultEventDispatcher {
     
     func addProjectChangeNotificationObservers() {
-        observerProjectId = NotificationCenter.default.addObserver(forName: .didReceiveOptimizelyProjectIdChange, object: nil, queue: nil) { [weak self] (notif) in
+        observerProjectId = NotificationCenter.default.addObserver(forName: .didReceiveOptimizelyProjectIdChange, object: nil, queue: nil) { [weak self] (_) in
             self?.logger.d("Event flush triggered by datafile projectId change")
             self?.flushEvents()
         }
         
-        observerRevision = NotificationCenter.default.addObserver(forName: .didReceiveOptimizelyRevisionChange, object: nil, queue: nil) { [weak self] (notif) in
+        observerRevision = NotificationCenter.default.addObserver(forName: .didReceiveOptimizelyRevisionChange, object: nil, queue: nil) { [weak self] (_) in
             self?.logger.d("Event flush triggered by datafile revision change")
             self?.flushEvents()
         }
@@ -274,6 +272,13 @@ extension DefaultEventDispatcher {
         if let observer = observerRevision {
             NotificationCenter.default.removeObserver(observer, name: .didReceiveOptimizelyRevisionChange, object: nil)
         }
+    }
+    
+    // MARK: - Tests
+
+    func close() {
+        self.flushEvents()
+        self.dispatcher.sync {}
     }
     
 }

--- a/Sources/Customization/Protocols/OPTEventDispatcher.swift
+++ b/Sources/Customization/Protocols/OPTEventDispatcher.swift
@@ -36,7 +36,7 @@ public protocol OPTEventDispatcher {
     func close()
 }
 
-extension OPTEventDispatcher {
+public extension OPTEventDispatcher {
     // override this for testing support only
     func close() {}
 }

--- a/Sources/Customization/Protocols/OPTEventDispatcher.swift
+++ b/Sources/Customization/Protocols/OPTEventDispatcher.swift
@@ -32,3 +32,9 @@ public protocol OPTEventDispatcher {
     /// Attempts to flush the event queue if there are any events to process.
     func flushEvents()
 }
+
+// MARK: - Tests
+
+extension OPTEventDispatcher {
+    func close() {}
+}

--- a/Sources/Customization/Protocols/OPTEventDispatcher.swift
+++ b/Sources/Customization/Protocols/OPTEventDispatcher.swift
@@ -31,10 +31,12 @@ public protocol OPTEventDispatcher {
     
     /// Attempts to flush the event queue if there are any events to process.
     func flushEvents()
+    
+    /// flush events in queue synchrnonous (optional for testing support)
+    func close()
 }
 
-// MARK: - Tests
-
 extension OPTEventDispatcher {
+    // override this for testing support only
     func close() {}
 }

--- a/Sources/Optimizely/OptimizelyClient.swift
+++ b/Sources/Optimizely/OptimizelyClient.swift
@@ -631,11 +631,15 @@ extension OptimizelyClient {
             let event = EventForDispatch(body: body)
             self.sendEventToDispatcher(event: event, completionHandler: nil)
             
+            // send notification in sync mode (functionally same as async here since it's already in background thread),
+            // but this will make testing simpler (timing control)
+
             self.sendActivateNotification(experiment: experiment,
                                           variation: variation,
                                           userId: userId,
                                           attributes: attributes,
-                                          event: event)
+                                          event: event,
+                                          async: false)
         }
 
     }
@@ -661,11 +665,15 @@ extension OptimizelyClient {
             let event = EventForDispatch(body: body)
             self.sendEventToDispatcher(event: event, completionHandler: nil)
             
+            // send notification in sync mode (functionally same as async here since it's already in background thread),
+            // but this will make testing simpler (timing control)
+
             self.sendTrackNotification(eventKey: eventKey,
                                        userId: userId,
                                        attributes: attributes,
                                        eventTags: eventTags,
-                                       event: event)
+                                       event: event,
+                                       async: false)
         }
     }
     
@@ -686,25 +694,31 @@ extension OptimizelyClient {
                                   variation: Variation,
                                   userId: String,
                                   attributes: OptimizelyAttributes?,
-                                  event: EventForDispatch) {
+                                  event: EventForDispatch,
+                                  async: Bool = true) {
         
-        self.sendNotification(type: .activate, args: [experiment,
-                                                      userId,
-                                                      attributes,
-                                                      variation,
-                                                      ["url": event.url as Any, "body": event.body as Any]])
+        self.sendNotification(type: .activate,
+                              args: [experiment,
+                                     userId,
+                                     attributes,
+                                     variation,
+                                     ["url": event.url as Any, "body": event.body as Any]],
+                              async: async)
     }
     
     func sendTrackNotification(eventKey: String,
                                userId: String,
                                attributes: OptimizelyAttributes?,
                                eventTags: OptimizelyEventTags?,
-                               event: EventForDispatch) {
-        self.sendNotification(type: .track, args: [eventKey,
-                                                   userId,
-                                                   attributes,
-                                                   eventTags,
-                                                   ["url": event.url as Any, "body": event.body as Any]])
+                               event: EventForDispatch,
+                               async: Bool = true) {
+        self.sendNotification(type: .track,
+                              args: [eventKey,
+                                     userId,
+                                     attributes,
+                                     eventTags,
+                                     ["url": event.url as Any, "body": event.body as Any]],
+                              async: async)
     }
     
     func sendDecisionNotification(decisionType: Constants.DecisionType,
@@ -716,22 +730,25 @@ extension OptimizelyClient {
                                   featureEnabled: Bool? = nil,
                                   variableKey: String? = nil,
                                   variableType: String? = nil,
-                                  variableValue: Any? = nil) {
-        self.sendNotification(type: .decision, args: [decisionType.rawValue,
-                                                      userId,
-                                                      attributes ?? OptimizelyAttributes(),
-                                                      self.makeDecisionInfo(decisionType: decisionType,
-                                                                            experiment: experiment,
-                                                                            variation: variation,
-                                                                            feature: feature,
-                                                                            featureEnabled: featureEnabled,
-                                                                            variableKey: variableKey,
-                                                                            variableType: variableType,
-                                                                            variableValue: variableValue)])
+                                  variableValue: Any? = nil,
+                                  async: Bool = true) {
+        self.sendNotification(type: .decision,
+                              args: [decisionType.rawValue,
+                                     userId,
+                                     attributes ?? OptimizelyAttributes(),
+                                     self.makeDecisionInfo(decisionType: decisionType,
+                                                           experiment: experiment,
+                                                           variation: variation,
+                                                           feature: feature,
+                                                           featureEnabled: featureEnabled,
+                                                           variableKey: variableKey,
+                                                           variableType: variableType,
+                                                           variableValue: variableValue)],
+                              async: async)
     }
     
-    func sendDatafileChangeNotification(data: Data) {
-        self.sendNotification(type: .datafileChange, args: [data])
+    func sendDatafileChangeNotification(data: Data, async: Bool = true) {
+        self.sendNotification(type: .datafileChange, args: [data], async: async)
     }
     
     func makeDecisionInfo(decisionType: Constants.DecisionType,
@@ -784,12 +801,31 @@ extension OptimizelyClient {
         return decisionInfo
     }
     
-    func sendNotification(type: NotificationType, args: [Any?]) {
-        // callback in background thread
-        eventLock.async {
+    func sendNotification(type: NotificationType, args: [Any?], async: Bool = true) {
+        let notify = {
             // make sure that notificationCenter is not-nil (still registered when async notification is called)
             self.notificationCenter?.sendNotifications(type: type.rawValue, args: args)
         }
+        
+        if async {
+            eventLock.async {
+                notify()
+            }
+        } else {
+            notify()
+        }
     }
 
+}
+
+// MARK: - For test support
+
+extension OptimizelyClient {
+    
+    public func close() {
+        datafileHandler.stopUpdates(sdkKey: sdkKey)
+        eventLock.sync {}
+        eventDispatcher?.close()
+    }
+    
 }

--- a/Sources/Utils/Constants.swift
+++ b/Sources/Utils/Constants.swift
@@ -50,5 +50,4 @@ struct Constants {
         static let variation = "variationKey"
     }
     
-
 }

--- a/Tests/OptimizelyTests-Common/EventDispatcherTests_Batch.swift
+++ b/Tests/OptimizelyTests-Common/EventDispatcherTests_Batch.swift
@@ -316,8 +316,7 @@ extension EventDispatcherTests_Batch {
 
         // flush
         
-        eventDispatcher.flushEvents()
-        eventDispatcher.dispatcher.sync {}
+        eventDispatcher.close()
 
         XCTAssertEqual(eventDispatcher.sendRequestedEvents.count, 1, "all events should be batched together")
         let batch = eventDispatcher.sendRequestedEvents[0]
@@ -345,9 +344,8 @@ extension EventDispatcherTests_Batch {
                                 (kUrlA, batchEventB),
                                 (kUrlA, batchEventA)])
 
-        eventDispatcher.flushEvents()
-        eventDispatcher.dispatcher.sync {}
-        
+        eventDispatcher.close()
+
         XCTAssertEqual(eventDispatcher.sendRequestedEvents.count, 1)
         let batch = eventDispatcher.sendRequestedEvents[0]
         let batchedEvents = try! JSONDecoder().decode(BatchEvent.self, from: batch.body)
@@ -379,9 +377,8 @@ extension EventDispatcherTests_Batch {
                                 (kUrlA, batchEventA),
                                 (kUrlB, batchEventB)])
             
-        eventDispatcher.flushEvents()
-        eventDispatcher.dispatcher.sync {}
-        
+        eventDispatcher.close()
+
         XCTAssertEqual(eventDispatcher.sendRequestedEvents.count, 2, "different urls should not be batched")
         
         // first 2 events batched together
@@ -428,9 +425,8 @@ extension EventDispatcherTests_Batch {
         eventDispatcher.dispatchEvent(event: makeInvalidEventForDispatchWithWrongData(), completionHandler: nil)
         eventDispatcher.dispatchEvent(event: makeEventForDispatch(url: kUrlA, event: batchEventA), completionHandler: nil)
 
-        eventDispatcher.flushEvents()
-        eventDispatcher.dispatcher.sync {}
-        
+        eventDispatcher.close()
+
         XCTAssertEqual(eventDispatcher.sendRequestedEvents.count, 2, "different urls should not be batched")
         
         // first 2 events batched together
@@ -480,9 +476,8 @@ extension EventDispatcherTests_Batch {
         dispatchMultipleEvents([(kUrlA, batchEventA),
                                 (kUrlA, batchEventA)])
 
-        eventDispatcher.flushEvents()
-        eventDispatcher.dispatcher.sync {}
-        
+        eventDispatcher.close()
+
         let maxFailureCount = 3 + 1   // DefaultEventDispatcher.maxFailureCount + 1
         
         XCTAssertEqual(eventDispatcher.sendRequestedEvents.count, maxFailureCount, "repeated the same request several times before giveup")
@@ -506,8 +501,7 @@ extension EventDispatcherTests_Batch {
         eventDispatcher.forceError = false
         
         // assume flushEvents called again on next timer fire
-        eventDispatcher.flushEvents()
-        eventDispatcher.dispatcher.sync {}
+        eventDispatcher.close()
 
         XCTAssertEqual(eventDispatcher.sendRequestedEvents.count, maxFailureCount + 1, "only one more since succeeded")
         XCTAssertEqual(eventDispatcher.sendRequestedEvents[3], eventDispatcher.sendRequestedEvents[0])


### PR DESCRIPTION
- async event dispatch and notification makes testing complicated (timing control)
- add an extra API call: close() for testing support only
- it stops datafile polling and flush all events synchronously