### PR TITLE
chore: upgrade travis xcode to 11.3 and simulators to OS13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ jobs:
     - stage: 'SourceClear and Lint'
       language: swift
       os: osx
-      osx_image: xcode10.2
+      osx_image: xcode11.3
       install:
         - gem install cocoapods -v '1.8.0'
       script:
@@ -60,12 +60,12 @@ jobs:
       stage: 'Unit Tests'
       language: swift
       os: osx
-      osx_image: xcode10.2
+      osx_image: xcode11.3
       branches:
         only:
           - master
       env: SCHEME=OptimizelySwiftSDK-iOS TEST_SDK=iphonesimulator PLATFORM='iOS Simulator' OS=12.1 NAME='iPhone 7'
-      name: PLATFORM='iOS Simulator' OS=12.1 NAME='iPhone 7'
+      name: PLATFORM='iOS Simulator' OS=13.2 NAME='iPhone X'
       install:
         - gem install slather --no-document --quiet
         - gem install cocoapods -v '1.8.0'
@@ -102,7 +102,7 @@ jobs:
       name: Prepare for release
       language: swift
       os: osx
-      osx_image: xcode10.2
+      osx_image: xcode11.3
       env:
         - VERSION=3.1.0
       install:
@@ -119,7 +119,7 @@ jobs:
       name: Push to cocoapods.org
       language: minimal
       os: osx
-      osx_image: xcode10.2
+      osx_image: xcode11.3
       env:
         - VERSION=3.1.0
       install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -90,8 +90,8 @@ jobs:
       env: SCHEME=OptimizelySwiftSDK-iOS TEST_SDK=iphonesimulator PLATFORM='iOS Simulator' OS=11.4 NAME='iPhone 7 Plus'
       name: PLATFORM='iOS Simulator' OS=11.4 NAME='iPhone 7 Plus'
     - <<: *unittests
-      env: SCHEME=OptimizelySwiftSDK-iOS TEST_SDK=iphonesimulator PLATFORM='iOS Simulator' OS=10.3 NAME='iPad Air'
-      name: PLATFORM='iOS Simulator' OS=10.3 NAME='iPad Air'
+      env: SCHEME=OptimizelySwiftSDK-iOS TEST_SDK=iphonesimulator PLATFORM='iOS Simulator' OS=10.3.1 NAME='iPad Air'
+      name: PLATFORM='iOS Simulator' OS=10.3.1 NAME='iPad Air'
     - <<: *unittests
       env: SCHEME=OptimizelySwiftSDK-tvOS TEST_SDK=appletvsimulator PLATFORM='tvOS Simulator' OS=12.1 NAME='Apple TV 4K'
       name: PLATFORM='tvOS Simulator' OS=12.1 NAME='Apple TV 4K'

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,8 +71,6 @@ jobs:
         - gem install cocoapods -v '1.8.0'
         - pod repo update
         - pod install
-        # fix simulator known issue (https://developer.apple.com/documentation/xcode_release_notes/xcode_10_2_1_release_notes)
-        - sudo mkdir '/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS 9.3.simruntime/Contents/Resources/RuntimeRoot/usr/lib/swift'
         # install jq without cleaning up
         - HOMEBREW_NO_INSTALL_CLEANUP=true brew install jq
         # preload simulator
@@ -92,8 +90,8 @@ jobs:
       env: SCHEME=OptimizelySwiftSDK-iOS TEST_SDK=iphonesimulator PLATFORM='iOS Simulator' OS=11.4 NAME='iPhone 7 Plus'
       name: PLATFORM='iOS Simulator' OS=11.4 NAME='iPhone 7 Plus'
     - <<: *unittests
-      env: SCHEME=OptimizelySwiftSDK-iOS TEST_SDK=iphonesimulator PLATFORM='iOS Simulator' OS=9.3 NAME='iPad Air'
-      name: PLATFORM='iOS Simulator' OS=9.3 NAME='iPad Air'
+      env: SCHEME=OptimizelySwiftSDK-iOS TEST_SDK=iphonesimulator PLATFORM='iOS Simulator' OS=10.3 NAME='iPad Air'
+      name: PLATFORM='iOS Simulator' OS=10.3 NAME='iPad Air'
     - <<: *unittests
       env: SCHEME=OptimizelySwiftSDK-tvOS TEST_SDK=appletvsimulator PLATFORM='tvOS Simulator' OS=12.1 NAME='Apple TV 4K'
       name: PLATFORM='tvOS Simulator' OS=12.1 NAME='Apple TV 4K'

--- a/.travis.yml
+++ b/.travis.yml
@@ -90,8 +90,8 @@ jobs:
       env: SCHEME=OptimizelySwiftSDK-iOS TEST_SDK=iphonesimulator PLATFORM='iOS Simulator' OS=11.4 NAME='iPhone 7 Plus'
       name: PLATFORM='iOS Simulator' OS=11.4 NAME='iPhone 7 Plus'
     - <<: *unittests
-      env: SCHEME=OptimizelySwiftSDK-iOS TEST_SDK=iphonesimulator PLATFORM='iOS Simulator' OS=10.3.1 NAME='iPad Air'
-      name: PLATFORM='iOS Simulator' OS=10.3.1 NAME='iPad Air'
+      env: SCHEME=OptimizelySwiftSDK-iOS TEST_SDK=iphonesimulator PLATFORM='iOS Simulator' OS=11.1 NAME='iPad Air'
+      name: PLATFORM='iOS Simulator' OS=11.1 NAME='iPad Air'
     - <<: *unittests
       env: SCHEME=OptimizelySwiftSDK-tvOS TEST_SDK=appletvsimulator PLATFORM='tvOS Simulator' OS=12.1 NAME='Apple TV 4K'
       name: PLATFORM='tvOS Simulator' OS=12.1 NAME='Apple TV 4K'


### PR DESCRIPTION
Upgrade travis xcode to 11.3 to include iOS13 devices in testing
- With this upgrade, travis drops iOS9 and 10. Upgrade them to iOS11+