### PR TITLE
chore: update license header template to 2020

### DIFF
--- a/OptimizelySwiftSDK.xcworkspace/xcshareddata/IDETemplateMacros.plist
+++ b/OptimizelySwiftSDK.xcworkspace/xcshareddata/IDETemplateMacros.plist
@@ -5,7 +5,7 @@
     <key>FILEHEADER</key>
     <string>
 /****************************************************************************
-* Copyright 2019, Optimizely, Inc. and contributors                        *
+* Copyright 2020, Optimizely, Inc. and contributors                        *
 *                                                                          *
 * Licensed under the Apache License, Version 2.0 (the "License");          *
 * you may not use this file except in compliance with the License.         *

--- a/Scripts/change_header/header.template
+++ b/Scripts/change_header/header.template
@@ -1,5 +1,5 @@
 /****************************************************************************
-* Copyright 2019, Optimizely, Inc. and contributors                        *
+* Copyright 2020, Optimizely, Inc. and contributors                        *
 *                                                                          *
 * Licensed under the Apache License, Version 2.0 (the "License");          *
 * you may not use this file except in compliance with the License.         *


### PR DESCRIPTION
Update copyright year to 2020 in license templates for new files.