### PR TITLE
refact: clean up SDK init methods with polling control

### DIFF
--- a/DemoObjCApp/AppDelegate.m
+++ b/DemoObjCApp/AppDelegate.m
@@ -1,5 +1,5 @@
 /****************************************************************************
-* Copyright 2019, Optimizely, Inc. and contributors                        *
+* Copyright 2019-2020, Optimizely, Inc. and contributors                   *
 *                                                                          *
 * Licensed under the Apache License, Version 2.0 (the "License");          *
 * you may not use this file except in compliance with the License.         *

--- a/DemoObjCApp/AppDelegate.m
+++ b/DemoObjCApp/AppDelegate.m
@@ -55,11 +55,9 @@ static NSString * const kOptimizelyEventKey = @"sample_conversion";
 // MARK: - Initialization Examples
 
 -(void)initializeOptimizelySDKAsynchronous {
-    DefaultEventDispatcher *eventDispacher = [[DefaultEventDispatcher alloc] initWithBatchSize:10 timerInterval:1 maxQueueSize:1000];
-    
     self.optimizely = [[OptimizelyClient alloc] initWithSdkKey:kOptimizelySdkKey
                                                         logger:nil
-                                               eventDispatcher:eventDispacher
+                                               eventDispatcher:nil
                                             userProfileService:nil
                                       periodicDownloadInterval:@(5)
                                                defaultLogLevel:OptimizelyLogLevelDebug];
@@ -104,18 +102,42 @@ static NSString * const kOptimizelyEventKey = @"sample_conversion";
 -(void)initializeOptimizelySDKWithCustomization {
     // customization example (optional)
     
-    CustomLogger *customLogger = [[CustomLogger alloc] init];
-    // 30 sec interval may be too frequent. This is for demo purpose.
-    // This should be should be much larger (default = 10 mins).
-    NSNumber *customDownloadIntervalInSecs = @(30);
+    // You can enable background datafile polling by setting periodicDownloadInterval (polling is disabled by default)
+    // 60 sec interval may be too frequent. This is for demo purpose. (You can set this to nil to use the recommended value of 600 secs).
+    NSNumber *downloadIntervalInSecs = @(60);
     
+    // You can turn off event batching with 0 timerInterval (this means that events are sent out immediately to the server instead of saving in the local queue for batching)
+    DefaultEventDispatcher *eventDispatcher = [[DefaultEventDispatcher alloc] initWithBatchSize:10
+                                                                                  timerInterval:0
+                                                                                   maxQueueSize:1000];
+    
+    // customize logger
+    CustomLogger *customLogger = [[CustomLogger alloc] init];
+
     self.optimizely = [[OptimizelyClient alloc] initWithSdkKey:kOptimizelySdkKey
                                                          logger:customLogger
-                                                eventDispatcher:nil
+                                                eventDispatcher:eventDispatcher
                                              userProfileService:nil
-                                       periodicDownloadInterval:customDownloadIntervalInSecs
+                                       periodicDownloadInterval:downloadIntervalInSecs
                                                 defaultLogLevel:OptimizelyLogLevelDebug];
     
+    [self addNotificationListeners];
+    
+    [self.optimizely startWithCompletion:^(NSData *data, NSError *error) {
+        if (error == nil) {
+            NSLog(@"Optimizely SDK initialized successfully!");
+        } else {
+            NSLog(@"Optimizely SDK initiliazation failed: %@", error.localizedDescription);
+        }
+        
+        [self startWithRootViewController];
+        
+        // For sample codes for APIs, see "Samples/SamplesForAPI.swift"
+        //[SamplesForAPI checkOptimizelyConfig:self.optimizely];
+    }];
+}
+
+-(void)addNotificationListeners {
     NSNumber *notifId;
     notifId = [self.optimizely.notificationCenter addDecisionNotificationListenerWithDecisionListener:^(NSString *type,
                                                                                               NSString *userId,
@@ -135,20 +157,8 @@ static NSString * const kOptimizelyEventKey = @"sample_conversion";
                                                                                                         NSDictionary<NSString *,id> *event) {
         NSLog(@"Received logEvent notification: %@ %@", url, event);
     }];
-    
-    [self.optimizely startWithCompletion:^(NSData *data, NSError *error) {
-        if (error == nil) {
-            NSLog(@"Optimizely SDK initialized successfully!");
-        } else {
-            NSLog(@"Optimizely SDK initiliazation failed: %@", error.localizedDescription);
-        }
-        
-        [self startWithRootViewController];
-        
-        // For sample codes for APIs, see "Samples/SamplesForAPI.swift"
-        //[SamplesForAPI checkOptimizelyConfig:self.optimizely];
-    }];
 }
+
 
 // MARK: - ViewControl
 

--- a/DemoObjCApp/DemoObjcApp.xcodeproj/xcshareddata/xcschemes/DemoObjciOS.xcscheme
+++ b/DemoObjCApp/DemoObjcApp.xcodeproj/xcshareddata/xcschemes/DemoObjciOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1010"
+   LastUpgradeVersion = "1130"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -27,8 +27,6 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
-      <Testables>
-      </Testables>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -38,8 +36,8 @@
             ReferencedContainer = "container:DemoObjcApp.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
+      <Testables>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -61,8 +59,6 @@
             ReferencedContainer = "container:DemoObjcApp.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/DemoObjCApp/DemoObjcApp.xcodeproj/xcshareddata/xcschemes/DemoObjctvOS.xcscheme
+++ b/DemoObjCApp/DemoObjcApp.xcodeproj/xcshareddata/xcschemes/DemoObjctvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1010"
+   LastUpgradeVersion = "1130"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -27,8 +27,6 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
-      <Testables>
-      </Testables>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -38,8 +36,8 @@
             ReferencedContainer = "container:DemoObjcApp.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
+      <Testables>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -61,8 +59,6 @@
             ReferencedContainer = "container:DemoObjcApp.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/DemoSwiftApp/AppDelegate.swift
+++ b/DemoSwiftApp/AppDelegate.swift
@@ -57,7 +57,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func initializeOptimizelySDKAsynchronous() {
         optimizely = OptimizelyClient(sdkKey: sdkKey, defaultLogLevel: logLevel)
 
-        addListeners()
+        addNotificationListeners()
 
         optimizely.start { result in
             switch result {
@@ -78,7 +78,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         optimizely = OptimizelyClient(sdkKey: sdkKey, defaultLogLevel: logLevel)
         
-        addListeners()
+        addNotificationListeners()
 
         do {
             let datafileJSON = try String(contentsOfFile: localDatafilePath, encoding: .utf8)
@@ -95,17 +95,23 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func initializeOptimizelySDKWithCustomization() {
         // customization example (optional)
 
-        let customLogger = CustomLogger()
-        // 60 sec interval may be too frequent. This is for demo purpose.
-        // This should be should be much larger (default = 10 mins).
-        let customDownloadIntervalInSecs = 60
+        // You can enable background datafile polling by setting periodicDownloadInterval (polling is disabled by default)
+        // 60 sec interval may be too frequent. This is for demo purpose. (You can set this to nil to use the recommended value of 600 secs).
+        let downloadIntervalInSecs: Int? = 60
 
+        // You can turn off event batching with 0 timerInterval (this means that events are sent out immediately to the server instead of saving in the local queue for batching)
+        let eventDispatcher = DefaultEventDispatcher(timerInterval: 0)
+
+        // customize logger
+        let customLogger = CustomLogger()
+        
         optimizely = OptimizelyClient(sdkKey: sdkKey,
                                        logger: customLogger,
-                                       periodicDownloadInterval: customDownloadIntervalInSecs,
+                                       eventDispatcher: eventDispatcher,
+                                       periodicDownloadInterval: downloadIntervalInSecs,
                                        defaultLogLevel: logLevel)
     
-        addListeners()
+        addNotificationListeners()
         
         // initialize SDK
         optimizely!.start { result in
@@ -122,7 +128,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         }
     }
     
-    func addListeners() {
+    func addNotificationListeners() {
         // notification listeners
         let notificationCenter = optimizely.notificationCenter!
             

--- a/DemoSwiftApp/AppDelegate.swift
+++ b/DemoSwiftApp/AppDelegate.swift
@@ -1,5 +1,5 @@
 /****************************************************************************
-* Copyright 2019, Optimizely, Inc. and contributors                        *
+* Copyright 2019-2020, Optimizely, Inc. and contributors                   *
 *                                                                          *
 * Licensed under the Apache License, Version 2.0 (the "License");          *
 * you may not use this file except in compliance with the License.         *

--- a/DemoSwiftApp/DemoSwiftApp.xcodeproj/project.pbxproj
+++ b/DemoSwiftApp/DemoSwiftApp.xcodeproj/project.pbxproj
@@ -393,7 +393,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 1010;
-				LastUpgradeCheck = 0940;
+				LastUpgradeCheck = 1130;
 				ORGANIZATIONNAME = Optimizely;
 				TargetAttributes = {
 					252D7DEC21C8800800134A7A = {
@@ -418,10 +418,9 @@
 			};
 			buildConfigurationList = EA5246B81DC7186800AF6685 /* Build configuration list for PBXProject "DemoSwiftApp" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
-				English,
 				en,
 				Base,
 			);
@@ -807,6 +806,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
@@ -874,6 +874,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";

--- a/DemoSwiftApp/DemoSwiftApp.xcodeproj/xcshareddata/xcschemes/DemoSwiftiOS.xcscheme
+++ b/DemoSwiftApp/DemoSwiftApp.xcodeproj/xcshareddata/xcschemes/DemoSwiftiOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1010"
+   LastUpgradeVersion = "1130"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -27,6 +27,15 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "252D7DEC21C8800800134A7A"
+            BuildableName = "DemoSwiftiOS.app"
+            BlueprintName = "DemoSwiftiOS"
+            ReferencedContainer = "container:DemoSwiftApp.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -39,17 +48,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "252D7DEC21C8800800134A7A"
-            BuildableName = "DemoSwiftiOS.app"
-            BlueprintName = "DemoSwiftiOS"
-            ReferencedContainer = "container:DemoSwiftApp.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -71,8 +69,6 @@
             ReferencedContainer = "container:DemoSwiftApp.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/DemoSwiftApp/DemoSwiftApp.xcodeproj/xcshareddata/xcschemes/DemoSwifttvOS.xcscheme
+++ b/DemoSwiftApp/DemoSwiftApp.xcodeproj/xcshareddata/xcschemes/DemoSwifttvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1010"
+   LastUpgradeVersion = "1130"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -27,6 +27,15 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "252D7E1021C8804E00134A7A"
+            BuildableName = "DemoSwifttvOS.app"
+            BlueprintName = "DemoSwifttvOS"
+            ReferencedContainer = "container:DemoSwiftApp.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -39,17 +48,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "252D7E1021C8804E00134A7A"
-            BuildableName = "DemoSwifttvOS.app"
-            BlueprintName = "DemoSwifttvOS"
-            ReferencedContainer = "container:DemoSwiftApp.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -71,8 +69,6 @@
             ReferencedContainer = "container:DemoSwiftApp.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/DemoSwiftApp/Samples/SamplesForAPI.swift
+++ b/DemoSwiftApp/Samples/SamplesForAPI.swift
@@ -164,7 +164,7 @@ class SamplesForAPI {
                 
                 variationKeys.forEach { varKey in
                     let variation = variationsMap[varKey]!
-                    print("[OptimizelyConfig]       -- variation = { key: \(varKey), id: \(variation.id), featureEnabled: \(variation.featureEnabled)")
+                    print("[OptimizelyConfig]       -- variation = { key: \(varKey), id: \(variation.id), featureEnabled: \(String(describing: variation.featureEnabled))")
                     
                     let variablesMap = variationsMap[varKey]!.variablesMap
                     let variableKeys = variablesMap.keys

--- a/DemoSwiftApp/Samples/SamplesForAPI.swift
+++ b/DemoSwiftApp/Samples/SamplesForAPI.swift
@@ -1,6 +1,6 @@
 //
 /****************************************************************************
- * Copyright 2019, Optimizely, Inc. and contributors                        *
+ * Copyright 2019-2020, Optimizely, Inc. and contributors                   *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *

--- a/OptimizelySwiftSDK.xcodeproj/xcshareddata/xcschemes/OptimizelySwiftSDK-Commons.xcscheme
+++ b/OptimizelySwiftSDK.xcodeproj/xcshareddata/xcschemes/OptimizelySwiftSDK-Commons.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1010"
+   LastUpgradeVersion = "1130"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -24,8 +24,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -37,8 +35,6 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/OptimizelySwiftSDK.xcodeproj/xcshareddata/xcschemes/OptimizelySwiftSDK-DataModels.xcscheme
+++ b/OptimizelySwiftSDK.xcodeproj/xcshareddata/xcschemes/OptimizelySwiftSDK-DataModels.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1010"
+   LastUpgradeVersion = "1130"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -24,8 +24,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -37,8 +35,6 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/OptimizelySwiftSDK.xcodeproj/xcshareddata/xcschemes/OptimizelySwiftSDK-iOS.xcscheme
+++ b/OptimizelySwiftSDK.xcodeproj/xcshareddata/xcschemes/OptimizelySwiftSDK-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1010"
+   LastUpgradeVersion = "1130"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -26,8 +26,17 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      codeCoverageEnabled = "YES"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "6EBAEB6B21E3FEF800D13AA9"
+            BuildableName = "Optimizely.framework"
+            BlueprintName = "OptimizelySwiftSDK-iOS"
+            ReferencedContainer = "container:OptimizelySwiftSDK.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <CodeCoverageTargets>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -131,17 +140,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "6EBAEB6B21E3FEF800D13AA9"
-            BuildableName = "Optimizely.framework"
-            BlueprintName = "OptimizelySwiftSDK-iOS"
-            ReferencedContainer = "container:OptimizelySwiftSDK.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -162,8 +160,6 @@
             ReferencedContainer = "container:OptimizelySwiftSDK.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/OptimizelySwiftSDK.xcodeproj/xcshareddata/xcschemes/OptimizelySwiftSDK-tvOS.xcscheme
+++ b/OptimizelySwiftSDK.xcodeproj/xcshareddata/xcschemes/OptimizelySwiftSDK-tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1010"
+   LastUpgradeVersion = "1130"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -27,6 +27,15 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "6E614DCC21E3F389005982A1"
+            BuildableName = "Optimizely.framework"
+            BlueprintName = "OptimizelySwiftSDK-tvOS"
+            ReferencedContainer = "container:OptimizelySwiftSDK.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -69,17 +78,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "6E614DCC21E3F389005982A1"
-            BuildableName = "Optimizely.framework"
-            BlueprintName = "OptimizelySwiftSDK-tvOS"
-            ReferencedContainer = "container:OptimizelySwiftSDK.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -100,8 +98,6 @@
             ReferencedContainer = "container:OptimizelySwiftSDK.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/OptimizelySwiftSDK.xcodeproj/xcshareddata/xcschemes/OptimizelySwiftSDKTests-Common-tvOS.xcscheme
+++ b/OptimizelySwiftSDK.xcodeproj/xcshareddata/xcschemes/OptimizelySwiftSDKTests-Common-tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1010"
+   LastUpgradeVersion = "1130"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -24,8 +24,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -37,8 +35,6 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/OptimizelySwiftSDK.xcodeproj/xcshareddata/xcschemes/OptimizelyTests-Commons-iOS.xcscheme
+++ b/OptimizelySwiftSDK.xcodeproj/xcshareddata/xcschemes/OptimizelyTests-Commons-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1010"
+   LastUpgradeVersion = "1130"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -28,8 +28,6 @@
             </LocationScenarioReference>
          </TestableReference>
       </Testables>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -41,8 +39,6 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/OptimizelySwiftSDK.xcodeproj/xcshareddata/xcschemes/OptimizelyTests-DataModel-tvOS.xcscheme
+++ b/OptimizelySwiftSDK.xcodeproj/xcshareddata/xcschemes/OptimizelyTests-DataModel-tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1010"
+   LastUpgradeVersion = "1130"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -24,8 +24,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -37,8 +35,6 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/OptimizelySwiftSDK.xcodeproj/xcshareddata/xcschemes/OptimizelyTests-DataModels-iOS.xcscheme
+++ b/OptimizelySwiftSDK.xcodeproj/xcshareddata/xcschemes/OptimizelyTests-DataModels-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1010"
+   LastUpgradeVersion = "1130"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -24,8 +24,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -37,8 +35,6 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/OptimizelySwiftSDK.xcodeproj/xcshareddata/xcschemes/OptimizelyTests-Others-iOS.xcscheme
+++ b/OptimizelySwiftSDK.xcodeproj/xcshareddata/xcschemes/OptimizelyTests-Others-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1010"
+   LastUpgradeVersion = "1130"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -24,8 +24,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -37,8 +35,6 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/OptimizelySwiftSDK.xcodeproj/xcshareddata/xcschemes/OptimizelyTests-Others-tvOS.xcscheme
+++ b/OptimizelySwiftSDK.xcodeproj/xcshareddata/xcschemes/OptimizelyTests-Others-tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1010"
+   LastUpgradeVersion = "1130"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -24,8 +24,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -37,8 +35,6 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Sources/Extensions/OptimizelyClient+Extension.swift
+++ b/Sources/Extensions/OptimizelyClient+Extension.swift
@@ -44,30 +44,5 @@ extension OptimizelyClient {
         // sdk keys without having to be created for every key.
         HandlerRegistryService.shared.registerBinding(binder: Binder<OPTDatafileHandler>(service: OPTDatafileHandler.self).singetlon().reInitializeStrategy(strategy: .reUse).to(factory: type(of: datafileHandler).init).using(instance: datafileHandler).sdkKey(key: sdkKey))
     }
-    
-    /// Optimizely Manager
-    ///
-    /// - Parameters:
-    ///   - sdkKey: sdk key
-    ///   - logger: custom Logger
-    ///   - eventDispatcher: custom EventDispatcher (optional)
-    ///   - userProfileService: custom UserProfileService (optional)
-    ///   - periodicDownloadInterval: custom interval for periodic background datafile download (optional. default = 10 * 60 secs)
-    ///   - defaultLogLevel: default log level (optional. default = .info)
-    public convenience init(sdkKey: String,
-                            logger: OPTLogger? = nil,
-                            eventDispatcher: OPTEventDispatcher? = nil,
-                            userProfileService: OPTUserProfileService? = nil,
-                            periodicDownloadInterval: Int? = nil,
-                            defaultLogLevel: OptimizelyLogLevel? = nil) {
-        let interval = periodicDownloadInterval ?? 10 * 60
-        
-        self.init(sdkKey: sdkKey, logger: logger, eventDispatcher: eventDispatcher, userProfileService: userProfileService, defaultLogLevel: defaultLogLevel)
-        
-        if let handler = datafileHandler as? DefaultDatafileHandler, interval > 0 {
-            handler.setTimer(sdkKey: sdkKey, interval: interval)
-        }
-        
-    }
 
 }

--- a/Sources/Extensions/OptimizelyClient+Extension.swift
+++ b/Sources/Extensions/OptimizelyClient+Extension.swift
@@ -44,5 +44,32 @@ extension OptimizelyClient {
         // sdk keys without having to be created for every key.
         HandlerRegistryService.shared.registerBinding(binder: Binder<OPTDatafileHandler>(service: OPTDatafileHandler.self).singetlon().reInitializeStrategy(strategy: .reUse).to(factory: type(of: datafileHandler).init).using(instance: datafileHandler).sdkKey(key: sdkKey))
     }
+    
+    /// OptimizelyClient init
+    ///
+    /// - Parameters:
+    ///   - sdkKey: sdk key
+    ///   - logger: custom Logger
+    ///   - eventDispatcher: custom EventDispatcher (optional)
+    ///   - userProfileService: custom UserProfileService (optional)
+    ///   - periodicDownloadInterval: custom interval for periodic background datafile download.
+    ///         The recommended value is 10 * 60 secs (you can also set this to nil to use the recommended value).
+    ///         Set this to 0 to disable periodic downloading.
+    ///   - defaultLogLevel: default log level (optional. default = .info)
+    public convenience init(sdkKey: String,
+                            logger: OPTLogger? = nil,
+                            eventDispatcher: OPTEventDispatcher? = nil,
+                            userProfileService: OPTUserProfileService? = nil,
+                            periodicDownloadInterval: Int?,
+                            defaultLogLevel: OptimizelyLogLevel? = nil) {
+        let interval = periodicDownloadInterval ?? 10 * 60
+        
+        self.init(sdkKey: sdkKey, logger: logger, eventDispatcher: eventDispatcher, userProfileService: userProfileService, defaultLogLevel: defaultLogLevel)
+        
+        if let handler = datafileHandler as? DefaultDatafileHandler, interval > 0 {
+            handler.setTimer(sdkKey: sdkKey, interval: interval)
+        }
+        
+    }
 
 }

--- a/Sources/Extensions/OptimizelyClient+Extension.swift
+++ b/Sources/Extensions/OptimizelyClient+Extension.swift
@@ -1,5 +1,5 @@
 /****************************************************************************
-* Copyright 2019, Optimizely, Inc. and contributors                        *
+* Copyright 2019-2020, Optimizely, Inc. and contributors                   *
 *                                                                          *
 * Licensed under the Apache License, Version 2.0 (the "License");          *
 * you may not use this file except in compliance with the License.         *

--- a/Sources/Optimizely/OptimizelyClient+ObjC.swift
+++ b/Sources/Optimizely/OptimizelyClient+ObjC.swift
@@ -19,7 +19,7 @@ import Foundation
 extension OptimizelyClient {
     
     @available(swift, obsoleted: 1.0)
-    /// Optimizely Manager
+    /// OptimizelyClient init
     ///
     /// - Parameters:
     ///   - sdkKey: sdk key
@@ -32,7 +32,8 @@ extension OptimizelyClient {
                   defaultLogLevel: .info)
     }
     
-    /// Optimizely Manager
+    @available(swift, obsoleted: 1.0)
+    /// OptimizelyClient init
     ///
     /// - Parameters:
     ///   - sdkKey: sdk key

--- a/Sources/Optimizely/OptimizelyClient+ObjC.swift
+++ b/Sources/Optimizely/OptimizelyClient+ObjC.swift
@@ -28,7 +28,7 @@ extension OptimizelyClient {
                   logger: nil,
                   eventDispatcher: nil,
                   userProfileService: nil,
-                  periodicDownloadInterval: nil as NSNumber?,
+                  periodicDownloadInterval: 0,   // polling disabled
                   defaultLogLevel: .info)
     }
     
@@ -39,7 +39,7 @@ extension OptimizelyClient {
     ///   - logger: custom Logger
     ///   - eventDispatcher: custom EventDispatcher (optional)
     ///   - userProfileService: custom UserProfileService (optional)
-    ///   - periodicDownloadInterval: custom interval for periodic background datafile download (optional. default = 10 * 60 secs)
+    ///   - periodicDownloadInterval: custom interval for periodic background datafile download (optional). Set this to 0 to disable polling. When polling is needed, the recommended value is 10 * 60 secs (you can also set this to nil to use the recommended value)
     ///   - defaultLogLevel: default log level (optional. default = .info)
     @objc public convenience init(sdkKey: String,
                                   logger: OPTLogger?,

--- a/Sources/Optimizely/OptimizelyClient+ObjC.swift
+++ b/Sources/Optimizely/OptimizelyClient+ObjC.swift
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2019, Optimizely, Inc. and contributors                        *
+ * Copyright 2019-2020, Optimizely, Inc. and contributors                   *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *

--- a/Sources/Optimizely/OptimizelyClient.swift
+++ b/Sources/Optimizely/OptimizelyClient.swift
@@ -94,15 +94,16 @@ open class OptimizelyClient: NSObject {
                               datafileHandler: DefaultDatafileHandler(),
                               decisionService: DefaultDecisionService(userProfileService: userProfileService),
                               notificationCenter: DefaultNotificationCenter())
-        
-        logger.d("SDK Version: \(version)")
 
-        // set up datafile polling interval (disable when interval is 0)
+        // set up datafile polling interval (polling disabled when interval is 0)
+        // this setup should be done after registerServices() to support injecting test DatafileHandlers
         
         let interval = periodicDownloadInterval ?? 10 * 60
         if interval > 0, let handler = datafileHandler as? DefaultDatafileHandler {
             handler.setTimer(sdkKey: sdkKey, interval: interval)
         }
+        
+        logger.d("SDK Version: \(version)")
     }
     
     /// Start Optimizely SDK (Asynchronous)

--- a/Sources/Optimizely/OptimizelyClient.swift
+++ b/Sources/Optimizely/OptimizelyClient.swift
@@ -1,5 +1,5 @@
 /****************************************************************************
-* Copyright 2019, Optimizely, Inc. and contributors                        *
+* Copyright 2019-2020, Optimizely, Inc. and contributors                   *
 *                                                                          *
 * Licensed under the Apache License, Version 2.0 (the "License");          *
 * you may not use this file except in compliance with the License.         *

--- a/Sources/Optimizely/OptimizelyClient.swift
+++ b/Sources/Optimizely/OptimizelyClient.swift
@@ -71,12 +71,13 @@ open class OptimizelyClient: NSObject {
     ///   - logger: custom Logger
     ///   - eventDispatcher: custom EventDispatcher (optional)
     ///   - userProfileService: custom UserProfileService (optional)
-    ///   - periodicDownloadInterval: custom interval for periodic background datafile download (optional. default = 10 * 60 secs)
+    ///   - periodicDownloadInterval: custom interval for periodic background datafile download (optional). Default = 0 (polling disabled). The recommended value is 10 * 60 secs (you can also set this to nil to use the recommended value)
     ///   - defaultLogLevel: default log level (optional. default = .info)
     public init(sdkKey: String,
                 logger: OPTLogger? = nil,
                 eventDispatcher: OPTEventDispatcher? = nil,
                 userProfileService: OPTUserProfileService? = nil,
+                periodicDownloadInterval: Int? = 0,
                 defaultLogLevel: OptimizelyLogLevel? = nil) {
         
         self.sdkKey = sdkKey
@@ -95,6 +96,13 @@ open class OptimizelyClient: NSObject {
                               notificationCenter: DefaultNotificationCenter())
         
         logger.d("SDK Version: \(version)")
+
+        // set up datafile polling interval (disable when interval is 0)
+        
+        let interval = periodicDownloadInterval ?? 10 * 60
+        if interval > 0, let handler = datafileHandler as? DefaultDatafileHandler {
+            handler.setTimer(sdkKey: sdkKey, interval: interval)
+        }
     }
     
     /// Start Optimizely SDK (Asynchronous)

--- a/Sources/Optimizely/OptimizelyClient.swift
+++ b/Sources/Optimizely/OptimizelyClient.swift
@@ -71,13 +71,11 @@ open class OptimizelyClient: NSObject {
     ///   - logger: custom Logger
     ///   - eventDispatcher: custom EventDispatcher (optional)
     ///   - userProfileService: custom UserProfileService (optional)
-    ///   - periodicDownloadInterval: custom interval for periodic background datafile download (optional). Default = 0 (polling disabled). The recommended value is 10 * 60 secs (you can also set this to nil to use the recommended value)
     ///   - defaultLogLevel: default log level (optional. default = .info)
     public init(sdkKey: String,
                 logger: OPTLogger? = nil,
                 eventDispatcher: OPTEventDispatcher? = nil,
                 userProfileService: OPTUserProfileService? = nil,
-                periodicDownloadInterval: Int? = 0,
                 defaultLogLevel: OptimizelyLogLevel? = nil) {
         
         self.sdkKey = sdkKey
@@ -94,14 +92,6 @@ open class OptimizelyClient: NSObject {
                               datafileHandler: DefaultDatafileHandler(),
                               decisionService: DefaultDecisionService(userProfileService: userProfileService),
                               notificationCenter: DefaultNotificationCenter())
-
-        // set up datafile polling interval (polling disabled when interval is 0)
-        // this setup should be done after registerServices() to support injecting test DatafileHandlers
-        
-        let interval = periodicDownloadInterval ?? 10 * 60
-        if interval > 0, let handler = datafileHandler as? DefaultDatafileHandler {
-            handler.setTimer(sdkKey: sdkKey, interval: interval)
-        }
         
         logger.d("SDK Version: \(version)")
     }

--- a/Sources/Optimizely/OptimizelyClient.swift
+++ b/Sources/Optimizely/OptimizelyClient.swift
@@ -64,7 +64,7 @@ open class OptimizelyClient: NSObject {
 
     // MARK: - Public interfaces
     
-    /// Optimizely Manager
+    /// OptimizelyClient init
     ///
     /// - Parameters:
     ///   - sdkKey: sdk key

--- a/Sources/Optimizely/OptimizelyConfig+ObjC.swift
+++ b/Sources/Optimizely/OptimizelyConfig+ObjC.swift
@@ -16,7 +16,6 @@
 
 import Foundation
 
-
 /// Objective-C interface for OptimizelyConfig
 
 @objc(OptimizelyConfig)

--- a/Sources/Optimizely/OptimizelyConfig+ObjC.swift
+++ b/Sources/Optimizely/OptimizelyConfig+ObjC.swift
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2019, Optimizely, Inc. and contributors                        *
+ * Copyright 2020, Optimizely, Inc. and contributors                        *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *

--- a/Sources/Optimizely/OptimizelyConfig.swift
+++ b/Sources/Optimizely/OptimizelyConfig.swift
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2019, Optimizely, Inc. and contributors                        *
+ * Copyright 2020, Optimizely, Inc. and contributors                        *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *
@@ -142,4 +142,3 @@ extension OptimizelyConfigImp {
     }
     
 }
-

--- a/Tests/OptimizelyTests-Common/DecisionListenerTests.swift
+++ b/Tests/OptimizelyTests-Common/DecisionListenerTests.swift
@@ -1,5 +1,5 @@
 /****************************************************************************
-* Copyright 2019, Optimizely, Inc. and contributors                        *
+* Copyright 2019-2020, Optimizely, Inc. and contributors                   *
 *                                                                          *
 * Licensed under the Apache License, Version 2.0 (the "License");          *
 * you may not use this file except in compliance with the License.         *

--- a/Tests/OptimizelyTests-Common/DecisionListenerTests.swift
+++ b/Tests/OptimizelyTests-Common/DecisionListenerTests.swift
@@ -592,7 +592,6 @@ class FakeManager: OptimizelyClient {
                   logger: OPTLogger? = nil,
                   eventDispatcher: OPTEventDispatcher? = nil,
                   userProfileService: OPTUserProfileService? = nil,
-                  periodicDownloadInterval: Int? = 0,
                   defaultLogLevel: OptimizelyLogLevel? = nil) {
         
         super.init(sdkKey: sdkKey, logger: logger, eventDispatcher: eventDispatcher, userProfileService: userProfileService, defaultLogLevel: defaultLogLevel)

--- a/Tests/OptimizelyTests-Common/DecisionListenerTests.swift
+++ b/Tests/OptimizelyTests-Common/DecisionListenerTests.swift
@@ -588,7 +588,12 @@ class FakeManager: OptimizelyClient {
         }
     }
     
-    override init(sdkKey: String, logger: OPTLogger? = nil, eventDispatcher: OPTEventDispatcher? = nil, userProfileService: OPTUserProfileService? = nil, defaultLogLevel: OptimizelyLogLevel? = nil) {
+    override init(sdkKey: String,
+                  logger: OPTLogger? = nil,
+                  eventDispatcher: OPTEventDispatcher? = nil,
+                  userProfileService: OPTUserProfileService? = nil,
+                  periodicDownloadInterval: Int? = 0,
+                  defaultLogLevel: OptimizelyLogLevel? = nil) {
         
         super.init(sdkKey: sdkKey, logger: logger, eventDispatcher: eventDispatcher, userProfileService: userProfileService, defaultLogLevel: defaultLogLevel)
         HandlerRegistryService.shared.removeAll()


### PR DESCRIPTION
* SDK init with and without polling are controlled with separate init methods, which conflict with each other. Cleaned up.
* Improved SDK initialization samples