### PR TITLE
fix: sync init flow changed to support dynamic update

### DIFF
--- a/OptimizelySwiftSDK.xcodeproj/project.pbxproj
+++ b/OptimizelySwiftSDK.xcodeproj/project.pbxproj
@@ -327,6 +327,8 @@
 		6E34A647231ED28600BAE302 /* empty_datafile_new_account_id.json in Resources */ = {isa = PBXBuildFile; fileRef = 6E34A63D231ED28600BAE302 /* empty_datafile_new_account_id.json */; };
 		6E34A648231ED28600BAE302 /* empty_datafile_new_account_id.json in Resources */ = {isa = PBXBuildFile; fileRef = 6E34A63D231ED28600BAE302 /* empty_datafile_new_account_id.json */; };
 		6E34A649231ED28600BAE302 /* empty_datafile_new_account_id.json in Resources */ = {isa = PBXBuildFile; fileRef = 6E34A63D231ED28600BAE302 /* empty_datafile_new_account_id.json */; };
+		6E5AB69323F6130D007A82B1 /* OptimizelyClientTests_Init_Sync.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E5AB69123F6130C007A82B1 /* OptimizelyClientTests_Init_Sync.swift */; };
+		6E5AB69423F6130D007A82B1 /* OptimizelyClientTests_Init_Async.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E5AB69223F6130D007A82B1 /* OptimizelyClientTests_Init_Async.swift */; };
 		6E614DD621E3F38A005982A1 /* Optimizely.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6E614DCD21E3F389005982A1 /* Optimizely.framework */; };
 		6E636B912236C91F00AF3CEF /* Optimizely.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6EBAEB6C21E3FEF800D13AA9 /* Optimizely.framework */; };
 		6E636BA02236C96700AF3CEF /* Optimizely.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6EBAEB6C21E3FEF800D13AA9 /* Optimizely.framework */; };
@@ -1268,6 +1270,8 @@
 		6E34A623231ED04900BAE302 /* empty_datafile_new_project_id.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = empty_datafile_new_project_id.json; sourceTree = "<group>"; };
 		6E34A624231ED04900BAE302 /* empty_datafile_new_revision.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = empty_datafile_new_revision.json; sourceTree = "<group>"; };
 		6E34A63D231ED28600BAE302 /* empty_datafile_new_account_id.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = empty_datafile_new_account_id.json; sourceTree = "<group>"; };
+		6E5AB69123F6130C007A82B1 /* OptimizelyClientTests_Init_Sync.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OptimizelyClientTests_Init_Sync.swift; sourceTree = "<group>"; };
+		6E5AB69223F6130D007A82B1 /* OptimizelyClientTests_Init_Async.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OptimizelyClientTests_Init_Async.swift; sourceTree = "<group>"; };
 		6E614DCD21E3F389005982A1 /* Optimizely.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Optimizely.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6E614DD521E3F38A005982A1 /* OptimizelyTests-tvOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "OptimizelyTests-tvOS.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		6E636B8C2236C91F00AF3CEF /* OptimizelyTests-APIs-iOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "OptimizelyTests-APIs-iOS.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1911,6 +1915,8 @@
 		6E7519B922C5211100B2B157 /* OptimizelyTests-APIs */ = {
 			isa = PBXGroup;
 			children = (
+				6E5AB69223F6130D007A82B1 /* OptimizelyClientTests_Init_Async.swift */,
+				6E5AB69123F6130C007A82B1 /* OptimizelyClientTests_Init_Sync.swift */,
 				6E7519BA22C5211100B2B157 /* OptimizelyClientTests_Evaluation.swift */,
 				6E7519BB22C5211100B2B157 /* OptimizelyClientTests_DatafileHandler.swift */,
 				6E7519BC22C5211100B2B157 /* OptimizelyErrorTests.swift */,
@@ -2848,9 +2854,11 @@
 				6E7517F022C520D400B2B157 /* DataStoreMemory.swift in Sources */,
 				6E9B11D922C548A200C22D81 /* OptimizelyClientTests_Invalid.swift in Sources */,
 				6E9B11D522C548A200C22D81 /* OptimizelyClientTests_Evaluation.swift in Sources */,
+				6E5AB69423F6130D007A82B1 /* OptimizelyClientTests_Init_Async.swift in Sources */,
 				6E9B11DA22C548A200C22D81 /* OptimizelyClientTests_ObjcAPIs.m in Sources */,
 				6E75179A22C520D400B2B157 /* DataStoreQueueStackImpl+Extension.swift in Sources */,
 				6E75182022C520D400B2B157 /* BatchEventBuilder.swift in Sources */,
+				6E5AB69323F6130D007A82B1 /* OptimizelyClientTests_Init_Sync.swift in Sources */,
 				6E75184422C520D400B2B157 /* Event.swift in Sources */,
 				6E75194022C520D500B2B157 /* OPTDecisionService.swift in Sources */,
 				6E7518E022C520D400B2B157 /* ConditionLeaf.swift in Sources */,

--- a/Sources/Implementation/DefaultDatafileHandler.swift
+++ b/Sources/Implementation/DefaultDatafileHandler.swift
@@ -1,18 +1,18 @@
 /****************************************************************************
-* Copyright 2019, Optimizely, Inc. and contributors                        *
-*                                                                          *
-* Licensed under the Apache License, Version 2.0 (the "License");          *
-* you may not use this file except in compliance with the License.         *
-* You may obtain a copy of the License at                                  *
-*                                                                          *
-*    http://www.apache.org/licenses/LICENSE-2.0                            *
-*                                                                          *
-* Unless required by applicable law or agreed to in writing, software      *
-* distributed under the License is distributed on an "AS IS" BASIS,        *
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *
-* See the License for the specific language governing permissions and      *
-* limitations under the License.                                           *
-***************************************************************************/
+ * Copyright 2019-2020, Optimizely, Inc. and contributors                   *
+ *                                                                          *
+ * Licensed under the Apache License, Version 2.0 (the "License");          *
+ * you may not use this file except in compliance with the License.         *
+ * You may obtain a copy of the License at                                  *
+ *                                                                          *
+ *    http://www.apache.org/licenses/LICENSE-2.0                            *
+ *                                                                          *
+ * Unless required by applicable law or agreed to in writing, software      *
+ * distributed under the License is distributed on an "AS IS" BASIS,        *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *
+ * See the License for the specific language governing permissions and      *
+ * limitations under the License.                                           *
+ ***************************************************************************/
 
 import Foundation
 
@@ -84,7 +84,6 @@ class DefaultDatafileHandler: OPTDatafileHandler {
         }
         
         return request
-
     }
     
     open func getResponseData(sdkKey: String, response: HTTPURLResponse, url: URL?) -> Data? {
@@ -101,7 +100,8 @@ class DefaultDatafileHandler: OPTDatafileHandler {
     }
     
     open func downloadDatafile(sdkKey: String,
-                               resourceTimeoutInterval: Double? = nil,
+                               returnCacheIfNoChange: Bool,
+                               resourceTimeoutInterval: Double?,
                                completionHandler: @escaping DatafileDownloadCompletionHandler) {
         
         downloadQueue.async {
@@ -121,7 +121,16 @@ class DefaultDatafileHandler: OPTDatafileHandler {
                         result = .success(data)
                     } else if response.statusCode == 304 {
                         self.logger.d("The datafile was not modified and won't be downloaded again")
-                        result = .success(nil)
+                        
+                        if returnCacheIfNoChange {
+                            if let data = self.loadSavedDatafile(sdkKey: sdkKey) {
+                                result = .success(data)
+                            } else {
+                                result = .failure(.datafileLoadingFailed(sdkKey))
+                            }
+                        } else {
+                            result = .success(nil)
+                        }
                     }
                 }
                 
@@ -169,7 +178,6 @@ class DefaultDatafileHandler: OPTDatafileHandler {
             self.performPerodicDownload(sdkKey: sdkKey, startTime: startDate, updateInterval: updateInterval, datafileChangeNotification: datafileChangeNotification)
         }
         timer.invalidate()
-
     }
     
     func hasPeriodUpdates(sdkKey: String) -> Bool {
@@ -220,7 +228,6 @@ class DefaultDatafileHandler: OPTDatafileHandler {
                 timer.timer?.invalidate()
                 timers.removeValue(forKey: sdkKey)
             }
-
         }
     }
     
@@ -293,7 +300,6 @@ class DefaultDatafileHandler: OPTDatafileHandler {
                 try? FileManager.default.removeItem(at: fileURL)
             }
         }
-
     }
 }
 
@@ -313,11 +319,10 @@ extension URLRequest {
             addValue(lastModified, forHTTPHeaderField: "If-Modified-Since")
         }
     }
-
+    
     func getLastModified() -> String? {
         return value(forHTTPHeaderField: "If-Modified-Since")
     }
-
 }
 
 extension HTTPURLResponse {

--- a/Sources/Optimizely/OptimizelyClient+ObjC.swift
+++ b/Sources/Optimizely/OptimizelyClient+ObjC.swift
@@ -99,8 +99,28 @@ extension OptimizelyClient {
     ///   - doFetchDatafileBackground: This is for debugging purposes when
     ///             you don't want to download the datafile.  In practice, you should allow the
     ///             background thread to update the cache copy (optional)
-    public func objcStart(datafile: Data, doFetchDatafileBackground: Bool = true) throws {
+    public func objcStart(datafile: Data, doFetchDatafileBackground: Bool) throws {
         try self.start(datafile: datafile, doFetchDatafileBackground: doFetchDatafileBackground)
+    }
+    
+    @available(swift, obsoleted: 1.0)
+    @objc(startWithDatafile:doUpdateConfigOnNewDatafile:doFetchDatafileBackground:error:)
+    /// Start Optimizely SDK (Synchronous)
+    ///
+    /// - Parameters:
+    ///   - datafile: This datafile will be used when cached copy is not available (fresh start)
+    ///             A cached copy from previous download is used if it's available.
+    ///             The datafile will be updated from the server in the background thread.
+    ///   - doUpdateConfigOnNewDatafile: When a new datafile is fetched from the server in the background thread,
+    ///             the SDK will be updated with the new datafile immediately if this value is set to true.
+    ///             When it's set to false (default), the new datafile is cached and will be used when the SDK is started again.
+    ///   - doFetchDatafileBackground: This is for debugging purposes when
+    ///             you don't want to download the datafile.  In practice, you should allow the
+    ///             background thread to update the cache copy (optional)
+    public func objcStart(datafile: Data, doUpdateConfigOnNewDatafile: Bool, doFetchDatafileBackground: Bool) throws {
+        try self.start(datafile: datafile,
+                       doUpdateConfigOnNewDatafile: doUpdateConfigOnNewDatafile,
+                       doFetchDatafileBackground: doFetchDatafileBackground)
     }
     
     @available(swift, obsoleted: 1.0)

--- a/Sources/Optimizely/OptimizelyClient.swift
+++ b/Sources/Optimizely/OptimizelyClient.swift
@@ -24,6 +24,8 @@ open class OptimizelyClient: NSObject {
     // MARK: - Properties
     
     var sdkKey: String
+    var periodicDownloadInterval = 0
+    
     private var atomicConfig: AtomicProperty<ProjectConfig> = AtomicProperty<ProjectConfig>()
     var config: ProjectConfig? {
         get {
@@ -80,6 +82,7 @@ open class OptimizelyClient: NSObject {
                 defaultLogLevel: OptimizelyLogLevel? = nil) {
         
         self.sdkKey = sdkKey
+        self.periodicDownloadInterval = 0  // this will be updated with the new API change
         
         super.init()
         
@@ -162,8 +165,7 @@ open class OptimizelyClient: NSObject {
         datafileHandler.downloadDatafile(sdkKey: sdkKey, returnCacheIfNoChange: false) { result in
             // override to update always if periodic datafile polling is enabled
             // this is necessary for the case that the first cache download gets the updated datafile
-            guard doUpdateConfigOnNewDatafile ||
-                self.datafileHandler.hasPeriodUpdates(sdkKey: self.sdkKey) else { return }
+            guard doUpdateConfigOnNewDatafile || (self.periodicDownloadInterval > 0) else { return }
             
             if case .success(let data) = result, let datafile = data {
                 // new datafile came in

--- a/Sources/Optimizely/OptimizelyClient.swift
+++ b/Sources/Optimizely/OptimizelyClient.swift
@@ -106,18 +106,22 @@ open class OptimizelyClient: NSObject {
     ///   - resourceTimeout: timeout for datafile download (optional)
     ///   - completion: callback when initialization is completed
     public func start(resourceTimeout: Double? = nil, completion: ((OptimizelyResult<Data>) -> Void)? = nil) {
-        fetchDatafileBackground(resourceTimeout: resourceTimeout) { result in
+        datafileHandler.downloadDatafile(sdkKey: sdkKey, returnCacheIfNoChange: true) { result in
             switch result {
-            case .failure:
-                completion?(result)
             case .success(let datafile):
+                guard let datafile = datafile else {
+                    completion?(.failure(.datafileLoadingFailed(self.sdkKey)))
+                    return
+                }
+                
                 do {
                     try self.configSDK(datafile: datafile)
-                    
-                    completion?(result)
+                    completion?(.success(datafile))
                 } catch {
                     completion?(.failure(error as! OptimizelyError))
                 }
+            case .failure(let error):
+                completion?(.failure(error))
             }
         }
     }
@@ -139,80 +143,75 @@ open class OptimizelyClient: NSObject {
     ///   - datafile: This datafile will be used when cached copy is not available (fresh start)
     ///             A cached copy from previous download is used if it's available.
     ///             The datafile will be updated from the server in the background thread.
+    ///   - doUpdateConfigOnNewDatafile: When a new datafile is fetched from the server in the background thread, the SDK will be updated with the new datafile immediately if this value is set to true. When it's set to false (default), the new datafile is cached and will be used when the SDK is started again.
     ///   - doFetchDatafileBackground: This is for debugging purposes when
     ///             you don't want to download the datafile.  In practice, you should allow the
     ///             background thread to update the cache copy (optional)
-    public func start(datafile: Data, doFetchDatafileBackground: Bool = true) throws {
+    public func start(datafile: Data,
+                      doUpdateConfigOnNewDatafile: Bool = false,
+                      doFetchDatafileBackground: Bool = true) throws {
         let cachedDatafile = self.datafileHandler.loadSavedDatafile(sdkKey: self.sdkKey)
         let selectedDatafile = cachedDatafile ?? datafile
         
         try configSDK(datafile: selectedDatafile)
         
         // continue to fetch updated datafile from the server in background and cache it for next sessions
-        if doFetchDatafileBackground { fetchDatafileBackground() }
+        
+        if !doFetchDatafileBackground { return }
+        
+        datafileHandler.downloadDatafile(sdkKey: sdkKey, returnCacheIfNoChange: false) { result in
+            // override to update always if periodic datafile polling is enabled
+            // this is necessary for the case that the first cache download gets the updated datafile
+            guard doUpdateConfigOnNewDatafile ||
+                self.datafileHandler.hasPeriodUpdates(sdkKey: self.sdkKey) else { return }
+            
+            if case .success(let data) = result, let datafile = data {
+                // new datafile came in
+                self.updateConfigFromBackgroundFetch(data: datafile)
+            }
+        }
     }
     
     func configSDK(datafile: Data) throws {
         do {
             self.config = try ProjectConfig(datafile: datafile)
-                        
+
             datafileHandler.startUpdates(sdkKey: self.sdkKey) { data in
-                // new datafile came in...
-                if let config = try? ProjectConfig(datafile: data) {
-                    do {
-                        if let users = self.config?.whitelistUsers {
-                            config.whitelistUsers = users
-                        }
-                        
-                        self.config = config
-                        
-                        // call reinit on the services we know we are reinitializing.
-                        
-                        for component in HandlerRegistryService.shared.lookupComponents(sdkKey: self.sdkKey) ?? [] {
-                            HandlerRegistryService.shared.reInitializeComponent(service: component, sdkKey: self.sdkKey)
-                        }
-                        
-                    }
-                    
-                    self.sendDatafileChangeNotification(data: data)
-                }
+                // new datafile came in
+                self.updateConfigFromBackgroundFetch(data: data)
             }
-        } catch {
+        } catch let error as OptimizelyError {
             // .datafileInvalid
             // .datafaileVersionInvalid
             // .datafaileLoadingFailed
+            self.logger.e(error)
+            throw error
+        } catch {
+            self.logger.e(error.localizedDescription)
             throw error
         }
     }
     
-    func fetchDatafileBackground(resourceTimeout: Double? = nil, completion: ((OptimizelyResult<Data>) -> Void)? = nil) {
-        
-        datafileHandler.downloadDatafile(sdkKey: self.sdkKey, resourceTimeoutInterval: resourceTimeout) { result in
-            var fetchResult: OptimizelyResult<Data>
-            
-            switch result {
-            case .failure(let error):
-                fetchResult = .failure(error)
-            case .success(let datafile):
-                // we got a new datafile.
-                if let datafile = datafile {
-                    fetchResult = .success(datafile)
-                }
-                // we got a success but no datafile 304. So, load the saved datafile.
-                else if let data = self.datafileHandler.loadSavedDatafile(sdkKey: self.sdkKey) {
-                    fetchResult = .success(data)
-                }
-                // if that fails, we have a problem.
-                else {
-                    fetchResult = .failure(.datafileLoadingFailed(self.sdkKey))
-                }
-                
-            }
-            
-            completion?(fetchResult)
+    func updateConfigFromBackgroundFetch(data: Data) {
+        guard let config = try? ProjectConfig(datafile: data) else {
+            return
         }
+        
+        if let users = self.config?.whitelistUsers {
+            config.whitelistUsers = users
+        }
+        
+        self.config = config
+        
+        // call reinit on the services we know we are reinitializing.
+        
+        for component in HandlerRegistryService.shared.lookupComponents(sdkKey: self.sdkKey) ?? [] {
+            HandlerRegistryService.shared.reInitializeComponent(service: component, sdkKey: self.sdkKey)
+        }
+
+        self.sendDatafileChangeNotification(data: data)
     }
-    
+        
     /**
      * Use the activate method to start an experiment.
      *

--- a/Sources/Optimizely/OptimizelyClient.swift
+++ b/Sources/Optimizely/OptimizelyClient.swift
@@ -24,7 +24,6 @@ open class OptimizelyClient: NSObject {
     // MARK: - Properties
     
     var sdkKey: String
-    var periodicDownloadInterval = 0
     
     private var atomicConfig: AtomicProperty<ProjectConfig> = AtomicProperty<ProjectConfig>()
     var config: ProjectConfig? {
@@ -41,6 +40,11 @@ open class OptimizelyClient: NSObject {
     }
     
     let eventLock = DispatchQueue(label: "com.optimizely.client")
+    
+    private var periodicDownloadInterval = 0
+    private var isPeriodicPollingEnabled: Bool {
+        return periodicDownloadInterval > 0
+    }
 
     // MARK: - Customizable Services
     
@@ -82,7 +86,6 @@ open class OptimizelyClient: NSObject {
                 defaultLogLevel: OptimizelyLogLevel? = nil) {
         
         self.sdkKey = sdkKey
-        self.periodicDownloadInterval = 0  // this will be updated with the new API change
         
         super.init()
         
@@ -165,7 +168,7 @@ open class OptimizelyClient: NSObject {
         datafileHandler.downloadDatafile(sdkKey: sdkKey, returnCacheIfNoChange: false) { result in
             // override to update always if periodic datafile polling is enabled
             // this is necessary for the case that the first cache download gets the updated datafile
-            guard doUpdateConfigOnNewDatafile || (self.periodicDownloadInterval > 0) else { return }
+            guard doUpdateConfigOnNewDatafile || self.isPeriodicPollingEnabled else { return }
             
             if case .success(let data) = result, let datafile = data {
                 // new datafile came in

--- a/Sources/Protocols/OPTDatafileHandler.swift
+++ b/Sources/Protocols/OPTDatafileHandler.swift
@@ -1,5 +1,5 @@
 /****************************************************************************
-* Copyright 2019, Optimizely, Inc. and contributors                        *
+* Copyright 2019-2020, Optimizely, Inc. and contributors                   *
 *                                                                          *
 * Licensed under the Apache License, Version 2.0 (the "License");          *
 * you may not use this file except in compliance with the License.         *
@@ -41,6 +41,7 @@ public protocol OPTDatafileHandler {
      - Parameter completionHhandler:  listener to call when datafile download complete
      */
     func downloadDatafile(sdkKey: String,
+                          returnCacheIfNoChange: Bool,
                           resourceTimeoutInterval: Double?,
                           completionHandler:@escaping DatafileDownloadCompletionHandler)
     
@@ -62,6 +63,11 @@ public protocol OPTDatafileHandler {
      Stop all periodic updates. This should be called when the app goes to background
      */
     func stopAllUpdates()
+
+    /**
+     Check if periodic datafile update has been set for the given sdkKey
+     */
+    func hasPeriodUpdates(sdkKey: String) -> Bool
 
     /**
      Save the datafile to cache.
@@ -88,5 +94,20 @@ public protocol OPTDatafileHandler {
      - Parameter sdkKey: sdkKey
      */
     func removeSavedDatafile(sdkKey: String)
+
+}
+
+extension OPTDatafileHandler {
+    
+    // default values support
+    func downloadDatafile(sdkKey: String,
+                          returnCacheIfNoChange: Bool = false,
+                          resourceTimeoutInterval: Double? = nil,
+                          completionHandler:@escaping DatafileDownloadCompletionHandler) {
+        downloadDatafile(sdkKey: sdkKey,
+                         returnCacheIfNoChange: returnCacheIfNoChange,
+                         resourceTimeoutInterval: resourceTimeoutInterval,
+                         completionHandler: completionHandler)
+    }
 
 }

--- a/Sources/Protocols/OPTDatafileHandler.swift
+++ b/Sources/Protocols/OPTDatafileHandler.swift
@@ -65,11 +65,6 @@ public protocol OPTDatafileHandler {
     func stopAllUpdates()
 
     /**
-     Check if periodic datafile update has been set for the given sdkKey
-     */
-    func hasPeriodUpdates(sdkKey: String) -> Bool
-
-    /**
      Save the datafile to cache.
      - Parameter sdkKey: sdkKey
      - Parameter datafile: JSON string of datafile.

--- a/Tests/OptimizelyTests-APIs/OptimizelyClientTests_DatafileHandler.swift
+++ b/Tests/OptimizelyTests-APIs/OptimizelyClientTests_DatafileHandler.swift
@@ -74,7 +74,7 @@ class OptimizelyClientTests_DatafileHandler: XCTestCase {
         
         try? FileManager.default.removeItem(at: fileUrl!)
         
-        client.datafileHandler.stopAllUpdates()
+        client.datafileHandler?.stopAllUpdates()
         
         HandlerRegistryService.shared.binders.property?.removeAll()
 

--- a/Tests/OptimizelyTests-APIs/OptimizelyClientTests_Init_Async.swift
+++ b/Tests/OptimizelyTests-APIs/OptimizelyClientTests_Init_Async.swift
@@ -1,0 +1,183 @@
+/****************************************************************************
+* Copyright 2020, Optimizely, Inc. and contributors                        *
+*                                                                          *
+* Licensed under the Apache License, Version 2.0 (the "License");          *
+* you may not use this file except in compliance with the License.         *
+* You may obtain a copy of the License at                                  *
+*                                                                          *
+*    http://www.apache.org/licenses/LICENSE-2.0                            *
+*                                                                          *
+* Unless required by applicable law or agreed to in writing, software      *
+* distributed under the License is distributed on an "AS IS" BASIS,        *
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *
+* See the License for the specific language governing permissions and      *
+* limitations under the License.                                           *
+***************************************************************************/
+    
+
+import XCTest
+
+class OptimizelyClientTests_Init_Async: XCTestCase {
+
+    // MARK: - Constants
+
+    static let JSONfilename = "api_datafile"
+    let kRevision = "241"
+    let kExperimentKey = "exp_with_audience"
+    
+    let kVariationKey = "a"
+    let kVariationOtherKey = "b"
+    
+    let kFeatureKey = "feature_1"
+    let kFeatureOtherKey = "feature_2"
+    
+    let kVariableKeyString = "s_foo"
+    let kVariableKeyInt = "i_42"
+    let kVariableKeyDouble = "d_4_2"
+    let kVariableKeyBool = "b_true"
+    
+    let kVariableValueString = "foo"
+    let kVariableValueInt = 42
+    let kVariableValueDouble = 4.2
+    let kVariableValueBool = true
+    
+    let kEventKey = "event1"
+    
+    let kUserId = "11111"
+    let kSDKKey = "anyKey"
+    
+    static let JSONfilenameUpdated = "feature_variables"
+    let kRevisionUpdated = "34"
+
+    override func setUp() {
+    }
+    
+    func testInitAsync() {
+        let testSdkKey = OTUtils.randomSdkKey  // unique but consistent with registry + start
+        
+        let handler = FakeDatafileHandler(mode: .successWithData)
+        HandlerRegistryService.shared.registerBinding(binder: Binder(service: OPTDatafileHandler.self).sdkKey(key: testSdkKey).using(instance: handler).to(factory: FakeDatafileHandler.init).reInitializeStrategy(strategy: .reUse).singetlon())
+        
+        let optimizely = OptimizelyClient(sdkKey: testSdkKey)
+
+        let exp = expectation(description: "x")
+        optimizely.start { result in
+            let variationKey: String = try! optimizely.activate(experimentKey: self.kExperimentKey, userId: self.kUserId)
+            XCTAssert(variationKey == self.kVariationKey)
+            exp.fulfill()
+        }
+        
+        wait(for: [exp], timeout: 10)
+    }
+    
+    func testInitAsync_fetchError() {
+        let testSdkKey = OTUtils.randomSdkKey  // unique but consistent with registry + start
+        
+        let handler = FakeDatafileHandler(mode: .failure)
+        HandlerRegistryService.shared.registerBinding(binder: Binder(service: OPTDatafileHandler.self).sdkKey(key: testSdkKey).using(instance: handler).to(factory: FakeDatafileHandler.init).reInitializeStrategy(strategy: .reUse).singetlon())
+        
+        let optimizely = OptimizelyClient(sdkKey: testSdkKey)
+
+        let exp = expectation(description: "x")
+        optimizely.start { result in
+            if case .failure = result {
+                XCTAssert(true)
+            } else {
+                XCTAssert(false)
+            }
+            exp.fulfill()
+        }
+        
+        wait(for: [exp], timeout: 10)
+    }
+    
+    func testInitAsync_fetchNil_whenCacheLoadFailed() {
+        let testSdkKey = OTUtils.randomSdkKey  // unique but consistent with registry + start
+        
+        let handler = FakeDatafileHandler(mode: .failedToLoadFromCache)
+        HandlerRegistryService.shared.registerBinding(binder: Binder(service: OPTDatafileHandler.self).sdkKey(key: testSdkKey).using(instance: handler).to(factory: FakeDatafileHandler.init).reInitializeStrategy(strategy: .reUse).singetlon())
+        
+        let optimizely = OptimizelyClient(sdkKey: testSdkKey)
+
+        let exp = expectation(description: "x")
+        optimizely.start { result in
+            if case .failure = result {
+                XCTAssert(true)
+            } else {
+                XCTAssert(false)
+            }
+            exp.fulfill()
+        }
+        
+        wait(for: [exp], timeout: 10)
+    }
+
+    func testInitAsync_enablePeriodicPolling() {
+        let testSdkKey = OTUtils.randomSdkKey  // unique but consistent with registry + start
+        
+        let handler = FakeDatafileHandler(mode: .successWithData)
+        HandlerRegistryService.shared.registerBinding(binder: Binder(service: OPTDatafileHandler.self).sdkKey(key: testSdkKey).using(instance: handler).to(factory: FakeDatafileHandler.init).reInitializeStrategy(strategy: .reUse).singetlon())
+        
+        let optimizely = OptimizelyClient(sdkKey: testSdkKey,
+                                          periodicDownloadInterval: 1)
+        
+        let exp = expectation(description: "x")
+
+        let notifId = optimizely.notificationCenter!.addDatafileChangeNotificationListener { _ in
+            let optConfig = try! optimizely.getOptimizelyConfig()
+            XCTAssertEqual(optConfig.revision, self.kRevisionUpdated)
+            exp.fulfill()
+        }
+
+        optimizely.start { result in
+            let optConfig = try! optimizely.getOptimizelyConfig()
+            XCTAssertEqual(optConfig.revision, self.kRevision)
+        }
+        
+        wait(for: [exp], timeout: 10)
+        
+        // disconnect the listener so exp not fulfilled redundantly
+        optimizely.notificationCenter!.removeNotificationListener(notificationId: notifId!)
+    }
+}
+
+extension OptimizelyClientTests_Init_Async {
+    
+    enum DataFileResponse {
+        case successWithData
+        case failedToLoadFromCache
+        case failure
+    }
+    
+    class FakeDatafileHandler: DefaultDatafileHandler {
+        var mode: DataFileResponse
+        var fileFlag: Bool = true
+                
+        init(mode: DataFileResponse) {
+            self.mode = mode
+        }
+        
+        required init() {
+            fatalError("init() has not been implemented")
+        }
+        
+        override func downloadDatafile(sdkKey: String,
+                                       returnCacheIfNoChange: Bool,
+                                       resourceTimeoutInterval: Double?,
+                                       completionHandler: @escaping DatafileDownloadCompletionHandler) {
+            
+            switch mode {
+            case .successWithData:
+                let filename = fileFlag ? OptimizelyClientTests_Init_Async.JSONfilename : OptimizelyClientTests_Init_Async.JSONfilenameUpdated
+                fileFlag.toggle()
+                
+                let data = OTUtils.loadJSONDatafile(filename)
+                completionHandler(.success(data))
+            case .failedToLoadFromCache:
+                completionHandler(.success(nil))
+            case .failure:
+                completionHandler(.failure(.dataFileInvalid))
+            }
+        }
+    }
+}

--- a/Tests/OptimizelyTests-APIs/OptimizelyClientTests_Init_Sync.swift
+++ b/Tests/OptimizelyTests-APIs/OptimizelyClientTests_Init_Sync.swift
@@ -1,0 +1,199 @@
+/****************************************************************************
+* Copyright 2020, Optimizely, Inc. and contributors                        *
+*                                                                          *
+* Licensed under the Apache License, Version 2.0 (the "License");          *
+* you may not use this file except in compliance with the License.         *
+* You may obtain a copy of the License at                                  *
+*                                                                          *
+*    http://www.apache.org/licenses/LICENSE-2.0                            *
+*                                                                          *
+* Unless required by applicable law or agreed to in writing, software      *
+* distributed under the License is distributed on an "AS IS" BASIS,        *
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *
+* See the License for the specific language governing permissions and      *
+* limitations under the License.                                           *
+***************************************************************************/
+    
+
+import XCTest
+
+class OptimizelyClientTests_Init_Sync: XCTestCase {
+
+    // MARK: - Constants
+
+    let kJSONfilename = "api_datafile"
+    let kRevision = "241"
+    let kExperimentKey = "exp_with_audience"
+    
+    let kVariationKey = "a"
+    let kVariationOtherKey = "b"
+    
+    let kFeatureKey = "feature_1"
+    let kFeatureOtherKey = "feature_2"
+    
+    let kVariableKeyString = "s_foo"
+    let kVariableKeyInt = "i_42"
+    let kVariableKeyDouble = "d_4_2"
+    let kVariableKeyBool = "b_true"
+    
+    let kVariableValueString = "foo"
+    let kVariableValueInt = 42
+    let kVariableValueDouble = 4.2
+    let kVariableValueBool = true
+    
+    let kEventKey = "event1"
+    
+    let kUserId = "11111"
+    let kSDKKey = "anyKey"
+    
+    let kRevisionUpdated = "34"
+    static let JSONfilenameUpdated = "feature_variables"
+
+    // MARK: - Properties
+
+    var datafile: Data!
+
+    override func setUp() {
+        self.datafile = OTUtils.loadJSONDatafile(kJSONfilename)
+    }
+    
+    func testInitSync() {
+        let optimizely = OptimizelyClient(sdkKey: OTUtils.randomSdkKey)
+
+        try! optimizely.start(datafile: datafile)
+        
+        let variationKey: String = try! optimizely.activate(experimentKey: kExperimentKey, userId: kUserId)
+        XCTAssert(variationKey == kVariationKey)
+    }
+    
+    func testInitSync_doBackgroundFetch_update() {
+        let testSdkKey = OTUtils.randomSdkKey  // unique but consistent with registry + start
+        
+        let handler = FakeDatafileHandler(mode: .successWithData)
+        HandlerRegistryService.shared.registerBinding(binder: Binder(service: OPTDatafileHandler.self).sdkKey(key: testSdkKey).using(instance: handler).to(factory: FakeDatafileHandler.init).reInitializeStrategy(strategy: .reUse).singetlon())
+        
+        let optimizely = OptimizelyClient(sdkKey: testSdkKey)
+
+        try! optimizely.start(datafile: datafile,
+                              doUpdateConfigOnNewDatafile: true)
+        
+        let optConfig = try! optimizely.getOptimizelyConfig()
+        XCTAssertEqual(optConfig.revision, kRevisionUpdated)
+    }
+    
+    func testInitSync_doBackgroundFetch_updateButNilReturned() {
+        let testSdkKey = OTUtils.randomSdkKey  // unique but consistent with registry + start
+        
+        let handler = FakeDatafileHandler(mode: .successWithNil)
+        HandlerRegistryService.shared.registerBinding(binder: Binder(service: OPTDatafileHandler.self).sdkKey(key: testSdkKey).using(instance: handler).to(factory: FakeDatafileHandler.init).reInitializeStrategy(strategy: .reUse).singetlon())
+        
+        let optimizely = OptimizelyClient(sdkKey: testSdkKey)
+
+        try! optimizely.start(datafile: datafile,
+                              doUpdateConfigOnNewDatafile: true)
+        
+        let optConfig = try! optimizely.getOptimizelyConfig()
+        XCTAssertEqual(optConfig.revision, kRevision)
+    }
+
+    func testInitSync_doBackgroundFetch_updateButErrorReturned() {
+        let testSdkKey = OTUtils.randomSdkKey  // unique but consistent with registry + start
+        
+        let handler = FakeDatafileHandler(mode: .failure)
+        HandlerRegistryService.shared.registerBinding(binder: Binder(service: OPTDatafileHandler.self).sdkKey(key: testSdkKey).using(instance: handler).to(factory: FakeDatafileHandler.init).reInitializeStrategy(strategy: .reUse).singetlon())
+        
+        let optimizely = OptimizelyClient(sdkKey: testSdkKey)
+
+        try! optimizely.start(datafile: datafile,
+                              doUpdateConfigOnNewDatafile: true)
+        
+        let optConfig = try! optimizely.getOptimizelyConfig()
+        XCTAssertEqual(optConfig.revision, kRevision)
+    }
+    
+    func testInitSync_doBackgroundFetch_noUpdate() {
+        let testSdkKey = OTUtils.randomSdkKey  // unique but consistent with registry + start
+        
+        let handler = FakeDatafileHandler(mode: .successWithData)
+        HandlerRegistryService.shared.registerBinding(binder: Binder(service: OPTDatafileHandler.self).sdkKey(key: testSdkKey).using(instance: handler).to(factory: FakeDatafileHandler.init).reInitializeStrategy(strategy: .reUse).singetlon())
+        
+        let optimizely = OptimizelyClient(sdkKey: testSdkKey)
+
+        try! optimizely.start(datafile: datafile,
+                              doUpdateConfigOnNewDatafile: false)
+        
+        let optConfig = try! optimizely.getOptimizelyConfig()
+        XCTAssertEqual(optConfig.revision, kRevision)
+    }
+    
+    func testInitSync_doNotBackgroundFetch() {
+        let testSdkKey = OTUtils.randomSdkKey  // unique but consistent with registry + start
+        
+        let handler = FakeDatafileHandler(mode: .successWithData)
+        HandlerRegistryService.shared.registerBinding(binder: Binder(service: OPTDatafileHandler.self).sdkKey(key: testSdkKey).using(instance: handler).to(factory: FakeDatafileHandler.init).reInitializeStrategy(strategy: .reUse).singetlon())
+        
+        let optimizely = OptimizelyClient(sdkKey: testSdkKey)
+
+        try! optimizely.start(datafile: datafile,
+                              doUpdateConfigOnNewDatafile: true,
+                              doFetchDatafileBackground: true)
+        
+        let optConfig = try! optimizely.getOptimizelyConfig()
+        XCTAssertEqual(optConfig.revision, kRevisionUpdated)
+    }
+
+    
+    func testInitSync_doBackgroundFetch_noUpdate_overridenByPolling() {
+        let testSdkKey = OTUtils.randomSdkKey  // unique but consistent with registry + start
+        
+        let handler = FakeDatafileHandler(mode: .successWithData)
+        HandlerRegistryService.shared.registerBinding(binder: Binder(service: OPTDatafileHandler.self).sdkKey(key: testSdkKey).using(instance: handler).to(factory: FakeDatafileHandler.init).reInitializeStrategy(strategy: .reUse).singetlon())
+        
+        let optimizely = OptimizelyClient(sdkKey: testSdkKey,
+                                          periodicDownloadInterval: 10)
+
+        try! optimizely.start(datafile: datafile,
+                              doUpdateConfigOnNewDatafile: false)
+        
+        let optConfig = try! optimizely.getOptimizelyConfig()
+        XCTAssertEqual(optConfig.revision, kRevisionUpdated)
+    }
+}
+
+extension OptimizelyClientTests_Init_Sync {
+    
+    enum DataFileResponse {
+        case successWithData
+        case successWithNil
+        case failure
+    }
+    
+    class FakeDatafileHandler: DefaultDatafileHandler {
+        var mode: DataFileResponse
+                
+        init(mode: DataFileResponse) {
+            self.mode = mode
+        }
+        
+        required init() {
+            fatalError("init() has not been implemented")
+        }
+        
+        override func downloadDatafile(sdkKey: String,
+                                       returnCacheIfNoChange: Bool,
+                                       resourceTimeoutInterval: Double?,
+                                       completionHandler: @escaping DatafileDownloadCompletionHandler) {
+            
+            switch mode {
+            case .successWithData:
+                let data = OTUtils.loadJSONDatafile(OptimizelyClientTests_Init_Sync.JSONfilenameUpdated)
+                completionHandler(.success(data))
+            case .successWithNil:
+                completionHandler(.success(nil))
+            case .failure:
+                completionHandler(.failure(.dataFileInvalid))
+            }
+        }
+    }
+}
+

--- a/Tests/OptimizelyTests-APIs/OptimizelyClientTests_ObjcAPIs.m
+++ b/Tests/OptimizelyTests-APIs/OptimizelyClientTests_ObjcAPIs.m
@@ -241,6 +241,8 @@ static enum OptimizelyLogLevel logLevel = OptimizelyLogLevelInfo;
     [self.optimizely startWithDatafile:datafile error:nil];
     
     [self.optimizely startWithDatafile:datafileData doFetchDatafileBackground:false error:nil];
+    [self.optimizely startWithDatafile:datafileData doUpdateConfigOnNewDatafile:true doFetchDatafileBackground:true error:nil];
+    [self.optimizely startWithDatafile:datafileData doUpdateConfigOnNewDatafile:false doFetchDatafileBackground:true error:nil];
 }
 
 @end

--- a/Tests/OptimizelyTests-APIs/OptimizelyClientTests_OptimizelyConfig.swift
+++ b/Tests/OptimizelyTests-APIs/OptimizelyClientTests_OptimizelyConfig.swift
@@ -63,7 +63,10 @@ class OptimizelyClientTests_OptimizelyConfig: XCTestCase {
     func testGetOptimizelyConfig_AfterDatafileUpdate() {
         class FakeDatafileHandler: DefaultDatafileHandler {
             let datafile = OTUtils.loadJSONDatafile("optimizely_config_datafile")
-            override func downloadDatafile(sdkKey: String, resourceTimeoutInterval: Double?, completionHandler: @escaping DatafileDownloadCompletionHandler) {
+            override func downloadDatafile(sdkKey: String,
+                                           returnCacheIfNoChange: Bool,
+                                           resourceTimeoutInterval: Double?,
+                                           completionHandler: @escaping DatafileDownloadCompletionHandler) {
                 completionHandler(.success(datafile))
             }
         }

--- a/Tests/OptimizelyTests-APIs/OptimizelyClientTests_OptimizelyConfig.swift
+++ b/Tests/OptimizelyTests-APIs/OptimizelyClientTests_OptimizelyConfig.swift
@@ -84,14 +84,13 @@ class OptimizelyClientTests_OptimizelyConfig: XCTestCase {
         let optimizely = OptimizelyClient(sdkKey: badUniqueSdkKey, periodicDownloadInterval: 1)
         
         var exp: XCTestExpectation? = expectation(description: "datafile update event")
-        _ = optimizely.notificationCenter!.addDatafileChangeNotificationListener { (_) in
+        _ = optimizely.notificationCenter!.addDatafileChangeNotificationListener { _ in
             optimizelyConfig = try! optimizely.getOptimizelyConfig()
             exp?.fulfill()
-            exp = nil // disregard following update notification
         }
         
         let datafile = OTUtils.loadJSONDatafile("empty_datafile")!
-        try! optimizely.start(datafile: datafile)
+        try! optimizely.start(datafile: datafile, doFetchDatafileBackground: false)
         
         // before datafile remote updated ("empty_datafile")
         
@@ -99,7 +98,8 @@ class OptimizelyClientTests_OptimizelyConfig: XCTestCase {
         XCTAssert(optimizelyConfig!.revision == "100")
         
         wait(for: [exp!], timeout: 10)
-        
+        exp = nil // disregard following update notification
+
         // after datafile remote updated ("optimizely_config_datafile")
         XCTAssert(optimizelyConfig!.revision == "9")
     }

--- a/Tests/OptimizelyTests-APIs/OptimizelyClientTests_Others.swift
+++ b/Tests/OptimizelyTests-APIs/OptimizelyClientTests_Others.swift
@@ -212,6 +212,7 @@ class OptimizelyClientTests_Others: XCTestCase {
         
         class FakeDatafileHandler: DefaultDatafileHandler {
             override func downloadDatafile(sdkKey: String,
+                                           returnCacheIfNoChange: Bool,
                                            resourceTimeoutInterval: Double? = nil,
                                            completionHandler: @escaping DatafileDownloadCompletionHandler) {
                 let invalidDatafile = OTUtils.loadJSONDatafile("unsupported_datafile")!

--- a/Tests/OptimizelyTests-Common/DatafileHandlerTests.swift
+++ b/Tests/OptimizelyTests-Common/DatafileHandlerTests.swift
@@ -168,7 +168,10 @@ class DatafileHandlerTests: XCTestCase {
     func testPeriodicDownload() {
         class FakeDatafileHandler: DefaultDatafileHandler {
             let data = Data()
-            override func downloadDatafile(sdkKey: String, resourceTimeoutInterval: Double?, completionHandler: @escaping DatafileDownloadCompletionHandler) {
+            override func downloadDatafile(sdkKey: String,
+                                           returnCacheIfNoChange: Bool,
+                                           resourceTimeoutInterval: Double?,
+                                           completionHandler: @escaping DatafileDownloadCompletionHandler) {
                 completionHandler(.success(data))
             }
         }
@@ -196,7 +199,10 @@ class DatafileHandlerTests: XCTestCase {
     func testPeriodicDownloadWithOptimizlyClient() {
         class FakeDatafileHandler: DefaultDatafileHandler {
             let data = OTUtils.loadJSONDatafile("typed_audience_datafile")
-            override func downloadDatafile(sdkKey: String, resourceTimeoutInterval: Double?, completionHandler: @escaping DatafileDownloadCompletionHandler) {
+            override func downloadDatafile(sdkKey: String,
+                                           returnCacheIfNoChange: Bool,
+                                           resourceTimeoutInterval: Double?,
+                                           completionHandler: @escaping DatafileDownloadCompletionHandler) {
                 completionHandler(.success(data))
             }
         }

--- a/Tests/OptimizelyTests-Common/DatafileHandlerTests.swift
+++ b/Tests/OptimizelyTests-Common/DatafileHandlerTests.swift
@@ -218,7 +218,7 @@ class DatafileHandlerTests: XCTestCase {
         _ = optimizely.notificationCenter!.addDatafileChangeNotificationListener { (_) in
             count += 1
             if count == 9 {
-                optimizely.datafileHandler.stopAllUpdates()
+                optimizely.datafileHandler?.stopAllUpdates()
                 expection.fulfill()
             }
         }

--- a/Tests/OptimizelyTests-Common/EventDispatcherTests_Batch.swift
+++ b/Tests/OptimizelyTests-Common/EventDispatcherTests_Batch.swift
@@ -971,16 +971,13 @@ extension EventDispatcherTests_Batch {
 
 extension EventDispatcherTests_Batch {
     
-    func testRandomEvents_10() {
+    func testRandomEvents() {
         runRandomEventsTest(numEvents: 9, eventDispatcher: eventDispatcher, tc: self)
     }
     
-    func testRandomEvents_100() {
-        runRandomEventsTest(numEvents: 111, eventDispatcher: eventDispatcher, tc: self, numInvalidEvents: 0)
-    }
-    
-    func testRandomEventsWithInvalid_100() {
-        runRandomEventsTest(numEvents: 111, eventDispatcher: eventDispatcher, tc: self, numInvalidEvents: 10)
+    func testRandomEventsWithInvalid() {
+        let numEvents = 21
+        runRandomEventsTest(numEvents: numEvents, eventDispatcher: eventDispatcher, tc: self, numInvalidEvents: Int(Float(numEvents) * 0.1))
     }
 
     // Utils


### PR DESCRIPTION
* Add an option to dynamically update ProjectConfig on datafile cache update for sync init flow (this feature is disabled by default to be compatible with the old versions).
* When periodic polling is enabled, the sync cache change always update ProjectConfig dynamically regardless of the setting above.