### PR TITLE
fix: make notificationCenter thread-safe

### DIFF
--- a/Sources/Implementation/DefaultNotificationCenter.swift
+++ b/Sources/Implementation/DefaultNotificationCenter.swift
@@ -18,8 +18,18 @@ import Foundation
 
 public class DefaultNotificationCenter: OPTNotificationCenter {
     public var notificationId: Int = 1
-    var notificationListeners = [Int: (Int, GenericListener)]()
     
+    typealias NotificationListeners = [Int: (Int, GenericListener)]
+    private var atomicNotificationListeners = AtomicProperty(property: NotificationListeners())
+    var notificationListeners: NotificationListeners {
+        get {
+            return atomicNotificationListeners.property!
+        }
+        set {
+            atomicNotificationListeners.property = newValue
+        }
+    }    
+        
     var observerLogEvent: NSObjectProtocol?
 
     required public init() {

--- a/Sources/Implementation/DefaultNotificationCenter.swift
+++ b/Sources/Implementation/DefaultNotificationCenter.swift
@@ -21,10 +21,10 @@ public class DefaultNotificationCenter: OPTNotificationCenter {
     
     public var notificationId: Int {
         get {
-            return notificationListeners.notificationId
+            return notificationListeners.getNotificationId()
         }
         set {
-            notificationListeners.notificationId = newValue
+            notificationListeners.setNotificationId(newValue)
         }
     }
         
@@ -184,22 +184,28 @@ class NotificationListeners {
     var listeners = [Int: (Int, GenericListener)]()
     let lock = DispatchQueue(label: "notification")
     
-    private var id = AtomicProperty(property: 1)
-    var notificationId: Int {
-        get {
-            return id.property!
+    private var notificationId = 1
+    
+    func getNotificationId() -> Int {
+        var returnId = 0
+        lock.sync {
+            returnId = self.notificationId
         }
-        set {
-            id.property = newValue
+        return returnId
+    }
+        
+    func setNotificationId(_ value: Int) {
+        lock.async {
+            self.notificationId = value
         }
     }
     
     func add(type: NotificationType, listener: @escaping GenericListener) -> Int? {
         var returnId = 0
         lock.sync {
-            listeners[notificationId] = (type.rawValue, listener)
-            returnId = notificationId
-            notificationId = returnId + 1
+            returnId = self.notificationId
+            listeners[returnId] = (type.rawValue, listener)
+            self.notificationId = returnId + 1
         }
         return returnId
     }

--- a/Sources/Protocols/OPTNotificationCenter.swift
+++ b/Sources/Protocols/OPTNotificationCenter.swift
@@ -18,7 +18,8 @@ import Foundation
 
 /// Enum representing notification types.
 @objc public enum NotificationType: Int {
-    case activate = 1
+    case generic = 0
+    case activate
     case track
     case datafileChange
     case decision

--- a/Tests/OptimizelyTests-Common/NotificationCenterTests.swift
+++ b/Tests/OptimizelyTests-Common/NotificationCenterTests.swift
@@ -18,7 +18,7 @@ import XCTest
 
 class NotificationCenterTests: XCTestCase {
     
-    let notificationCenter: DefaultNotificationCenter = DefaultNotificationCenter()
+    var notificationCenter: DefaultNotificationCenter!
     var experiment: Experiment?
     var variation: Variation?
     var called = false
@@ -38,7 +38,7 @@ class NotificationCenterTests: XCTestCase {
                                             "forcedVariations": ["12345": "1234567890"]]
 
     override func setUp() {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
+         super.setUp()
         
         let data: [String: Any] = NotificationCenterTests.sampleExperiment
         
@@ -46,12 +46,14 @@ class NotificationCenterTests: XCTestCase {
         
         variation = experiment!.variations[0]
 
+        notificationCenter = DefaultNotificationCenter()
         notificationCenter.clearAllNotificationListeners()
     }
 
     override func tearDown() {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
         notificationCenter.clearAllNotificationListeners()
+        notificationCenter = nil  // deinit immediately after each test
+        super.tearDown()
     }
     
     func sendActivate() {
@@ -271,7 +273,7 @@ class NotificationCenterTests: XCTestCase {
             exp.fulfill()
         }
 
-        wait(for: [exp], timeout: 30.0)
+        wait(for: [exp], timeout: 10.0)
         XCTAssertEqual(notificationCenter.notificationId - 1, numConcurrency)
     }
     
@@ -312,7 +314,7 @@ class NotificationCenterTests: XCTestCase {
             exp.fulfill()
         }
 
-        wait(for: [exp], timeout: 30.0)
+        wait(for: [exp], timeout: 10.0)
         
         self.called = false
         
@@ -353,7 +355,7 @@ class NotificationCenterTests: XCTestCase {
             exp.fulfill()
         }
 
-        wait(for: [exp], timeout: 30.0)
+        wait(for: [exp], timeout: 10.0)
 
         self.called = false
         

--- a/Tests/OptimizelyTests-Common/NotificationCenterTests.swift
+++ b/Tests/OptimizelyTests-Common/NotificationCenterTests.swift
@@ -271,7 +271,7 @@ class NotificationCenterTests: XCTestCase {
             exp.fulfill()
         }
 
-        wait(for: [exp], timeout: 10.0)
+        wait(for: [exp], timeout: 30.0)
         XCTAssertEqual(notificationCenter.notificationId - 1, numConcurrency)
     }
     
@@ -312,7 +312,7 @@ class NotificationCenterTests: XCTestCase {
             exp.fulfill()
         }
 
-        wait(for: [exp], timeout: 10.0)
+        wait(for: [exp], timeout: 30.0)
         
         self.called = false
         
@@ -353,7 +353,7 @@ class NotificationCenterTests: XCTestCase {
             exp.fulfill()
         }
 
-        wait(for: [exp], timeout: 10.0)
+        wait(for: [exp], timeout: 30.0)
 
         self.called = false
         

--- a/Tests/OptimizelyTests-Common/NotificationCenterTests.swift
+++ b/Tests/OptimizelyTests-Common/NotificationCenterTests.swift
@@ -241,13 +241,27 @@ class NotificationCenterTests: XCTestCase {
         XCTAssertTrue(called)
     }
     
+    func testNotificationCenterThreadSafe() {
+        let exp = expectation(description: "x")
+        exp.expectedFulfillmentCount = 3
 
-
-    func testPerformanceExample() {
-        // This is an example of a performance test case.
-        self.measure {
-            // Put the code you want to measure the time of here.
+        DispatchQueue.global().asyncAfter(deadline: .now() + .microseconds(0)) {
+            _ = self.addActivateListener()
+            for _ in 0..<100000 { self.sendActivate() }
+            exp.fulfill()
         }
+        DispatchQueue.global().asyncAfter(deadline: .now() + .microseconds(100)) {
+            _ = self.addTrackListener()
+            for _ in 0..<100000 { self.sendTrack() }
+            exp.fulfill()
+        }
+        DispatchQueue.global().asyncAfter(deadline: .now() + .microseconds(200)) {
+            _ = self.addDecisionListener()
+            for _ in 0..<100000 { self.sendDecision() }
+            exp.fulfill()
+        }
+        
+        wait(for: [exp], timeout: 3.0)
+        XCTAssert(true)
     }
-
 }


### PR DESCRIPTION
* App can crash when notification addition and calling conflicts with multi-threads.
* This fix adds thread-safety for notificationCenter.