### PR TITLE
Forward resourceTimeout to datafileHandler

### DIFF
--- a/Sources/Optimizely/OptimizelyClient.swift
+++ b/Sources/Optimizely/OptimizelyClient.swift
@@ -114,7 +114,7 @@ open class OptimizelyClient: NSObject {
     ///   - resourceTimeout: timeout for datafile download (optional)
     ///   - completion: callback when initialization is completed
     public func start(resourceTimeout: Double? = nil, completion: ((OptimizelyResult<Data>) -> Void)? = nil) {
-        datafileHandler?.downloadDatafile(sdkKey: sdkKey, returnCacheIfNoChange: true) { result in
+        datafileHandler?.downloadDatafile(sdkKey: sdkKey, returnCacheIfNoChange: true, resourceTimeoutInterval: resourceTimeout) { result in
             switch result {
             case .success(let datafile):
                 guard let datafile = datafile else {


### PR DESCRIPTION
During evaluations of which `start` method we should use in our project, we discovered that in the async initialization, the `resourceTimeout` is not forwarded to the `datafileHandler`. This will be fixed with this PR.