### PR TITLE
fix: Targeting rollout should move to fallback rule when bucketing fails.

### DIFF
--- a/Sources/Implementation/DefaultDecisionService.swift
+++ b/Sources/Implementation/DefaultDecisionService.swift
@@ -1,5 +1,5 @@
 /****************************************************************************
-* Copyright 2019, Optimizely, Inc. and contributors                        *
+* Copyright 2019-2020, Optimizely, Inc. and contributors                   *
 *                                                                          *
 * Licensed under the Apache License, Version 2.0 (the "License");          *
 * you may not use this file except in compliance with the License.         *

--- a/Sources/Implementation/DefaultDecisionService.swift
+++ b/Sources/Implementation/DefaultDecisionService.swift
@@ -200,9 +200,9 @@ class DefaultDecisionService: OPTDecisionService {
                     logger.d(.userBucketedIntoTargetingRule(userId, index + 1))
                     
                     return variation
-                } else {
-                    logger.d(.userNotBucketedIntoTargetingRule(userId, index + 1))
                 }
+                logger.d(.userNotBucketedIntoTargetingRule(userId, index + 1))
+                break
             } else {
                 logger.d(.userDoesntMeetConditionsForTargetingRule(userId, index + 1))
             }

--- a/Tests/OptimizelyTests-Common/DecisionServiceTests_Features.swift
+++ b/Tests/OptimizelyTests-Common/DecisionServiceTests_Features.swift
@@ -1,5 +1,5 @@
 /****************************************************************************
-* Copyright 2019, Optimizely, Inc. and contributors                        *
+* Copyright 2019-2020, Optimizely, Inc. and contributors                   *
 *                                                                          *
 * Licensed under the Apache License, Version 2.0 (the "License");          *
 * you may not use this file except in compliance with the License.         *


### PR DESCRIPTION
## Summary
- fixes target-rollout error continuing other rules when a rule hits but bucketing fails.

## Test Plan
- FSC should pass.
- Updated unit tests accordingly.

## Issues
- https://optimizely.atlassian.net/browse/OASIS-6334
