### PR TITLE
fix(OptimizelyJSON): Send map instead of OptimizelyJSON object in decision notification.

### DIFF
--- a/Sources/Optimizely/OptimizelyClient.swift
+++ b/Sources/Optimizely/OptimizelyClient.swift
@@ -549,23 +549,30 @@ open class OptimizelyClient: NSObject {
         
         var type: Constants.VariableValueType?
         var valueParsed: T?
+        var notificationValue: Any? = featureValue
         
         switch T.self {
         case is String.Type:
             type = .string
             valueParsed = featureValue as? T
+            notificationValue = valueParsed
         case is Int.Type:
             type = .integer
             valueParsed = Int(featureValue) as? T
+            notificationValue = valueParsed
         case is Double.Type:
             type = .double
             valueParsed = Double(featureValue) as? T
+            notificationValue = valueParsed
         case is Bool.Type:
             type = .boolean
             valueParsed = Bool(featureValue) as? T
+            notificationValue = valueParsed
         case is OptimizelyJSON.Type:
             type = .json
-            valueParsed = OptimizelyJSON(payload: featureValue) as? T
+            let jsonValue = OptimizelyJSON(payload: featureValue)
+            valueParsed = jsonValue as? T
+            notificationValue = jsonValue?.toMap()
         default:
             break
         }
@@ -590,7 +597,7 @@ open class OptimizelyClient: NSObject {
                                  featureEnabled: featureEnabled,
                                  variableKey: variableKey,
                                  variableType: variable.type,
-                                 variableValue: value)
+                                 variableValue: notificationValue)
         
         return value
     }

--- a/Tests/OptimizelyTests-Common/DecisionListenerTests.swift
+++ b/Tests/OptimizelyTests-Common/DecisionListenerTests.swift
@@ -33,7 +33,6 @@ class DecisionListenerTests: XCTestCase {
     let kVariableValueInt = 42
     let kVariableValueDouble = 4.2
     let kVariableValueBool = true
-    let kVariableValueJSON = "{\"value\":1}"
     
     // MARK: - Properties
     
@@ -159,7 +158,7 @@ class DecisionListenerTests: XCTestCase {
         _ = notificationCenter.addDecisionNotificationListener { (_, _, _, decisionInfo) in
             XCTAssertEqual(decisionInfo[Constants.DecisionInfoKeys.featureEnabled] as! Bool, false)
             XCTAssertEqual(decisionInfo[Constants.DecisionInfoKeys.source] as! String, Constants.DecisionSource.rollout.rawValue)
-            XCTAssertEqual((decisionInfo[Constants.DecisionInfoKeys.variableValue] as! OptimizelyJSON).toString(), self.kVariableValueJSON)
+            XCTAssertEqual((decisionInfo[Constants.DecisionInfoKeys.variableValue] as! [String: Any])["value"] as! Int, 1)
             XCTAssertEqual(decisionInfo[Constants.DecisionInfoKeys.variableType] as! String, Constants.VariableValueType.json.rawValue)
             XCTAssertNil(decisionInfo[Constants.ExperimentDecisionInfoKeys.experiment])
             XCTAssertNil(decisionInfo[Constants.ExperimentDecisionInfoKeys.variation])
@@ -359,7 +358,7 @@ class DecisionListenerTests: XCTestCase {
         _ = notificationCenter.addDecisionNotificationListener { (_, _, _, decisionInfo) in
             XCTAssertEqual(decisionInfo[Constants.DecisionInfoKeys.featureEnabled] as! Bool, true)
             XCTAssertEqual(decisionInfo[Constants.DecisionInfoKeys.source] as! String, Constants.DecisionSource.rollout.rawValue)
-            XCTAssertEqual((decisionInfo[Constants.DecisionInfoKeys.variableValue] as! OptimizelyJSON).toString(), "{\"value\":2}")
+            XCTAssertEqual((decisionInfo[Constants.DecisionInfoKeys.variableValue] as! [String: Any])["value"] as! Int, 2)
             XCTAssertEqual(decisionInfo[Constants.DecisionInfoKeys.variableType] as! String, Constants.VariableValueType.json.rawValue)
             XCTAssertNil(decisionInfo[Constants.ExperimentDecisionInfoKeys.experiment])
             XCTAssertNil(decisionInfo[Constants.ExperimentDecisionInfoKeys.variation])
@@ -376,7 +375,7 @@ class DecisionListenerTests: XCTestCase {
         _ = notificationCenter.addDecisionNotificationListener { (_, _, _, decisionInfo) in
             XCTAssertEqual(decisionInfo[Constants.DecisionInfoKeys.featureEnabled] as! Bool, false)
             XCTAssertEqual(decisionInfo[Constants.DecisionInfoKeys.source] as! String, Constants.DecisionSource.rollout.rawValue)
-            XCTAssertEqual((decisionInfo[Constants.DecisionInfoKeys.variableValue] as! OptimizelyJSON).toString(), self.kVariableValueJSON)
+            XCTAssertEqual((decisionInfo[Constants.DecisionInfoKeys.variableValue] as! [String: Any])["value"] as! Int, 1)
             XCTAssertEqual(decisionInfo[Constants.DecisionInfoKeys.variableType] as! String, Constants.VariableValueType.json.rawValue)
             XCTAssertNil(decisionInfo[Constants.ExperimentDecisionInfoKeys.experiment])
             XCTAssertNil(decisionInfo[Constants.ExperimentDecisionInfoKeys.variation])
@@ -652,7 +651,7 @@ class DecisionListenerTests: XCTestCase {
         _ = notificationCenter.addDecisionNotificationListener { (_, _, _, decisionInfo) in
             XCTAssertEqual(decisionInfo[Constants.DecisionInfoKeys.featureEnabled] as! Bool, true)
             XCTAssertEqual(decisionInfo[Constants.DecisionInfoKeys.source] as! String, Constants.DecisionSource.featureTest.rawValue)
-            XCTAssertEqual((decisionInfo[Constants.DecisionInfoKeys.variableValue] as! OptimizelyJSON).toString(), "{\"value\":2}")
+            XCTAssertEqual((decisionInfo[Constants.DecisionInfoKeys.variableValue] as! [String: Any])["value"] as! Int, 2)
             XCTAssertEqual(decisionInfo[Constants.DecisionInfoKeys.variableType] as! String, Constants.VariableValueType.json.rawValue)
             let sourceInfo: [String: Any] = decisionInfo[Constants.DecisionInfoKeys.sourceInfo]! as! [String: Any]
             XCTAssertNotNil(sourceInfo)
@@ -671,7 +670,7 @@ class DecisionListenerTests: XCTestCase {
         _ = notificationCenter.addDecisionNotificationListener { (_, _, _, decisionInfo) in
             XCTAssertEqual(decisionInfo[Constants.DecisionInfoKeys.featureEnabled] as! Bool, false)
             XCTAssertEqual(decisionInfo[Constants.DecisionInfoKeys.source] as! String, Constants.DecisionSource.featureTest.rawValue)
-            XCTAssertEqual((decisionInfo[Constants.DecisionInfoKeys.variableValue] as! OptimizelyJSON).toString(), self.kVariableValueJSON)
+            XCTAssertEqual((decisionInfo[Constants.DecisionInfoKeys.variableValue] as! [String: Any])["value"] as! Int, 1)
             XCTAssertEqual(decisionInfo[Constants.DecisionInfoKeys.variableType] as! String, Constants.VariableValueType.json.rawValue)
             let sourceInfo: [String: Any] = decisionInfo[Constants.DecisionInfoKeys.sourceInfo]! as! [String: Any]
             XCTAssertNotNil(sourceInfo)


### PR DESCRIPTION
## Summary
- Fixed an issue with decision notification where `OptimizelyJSON` object was being sent as variable value instead of a map.

## Test Plan
- FSC should pass with FEATURE_JSON tag.
- Updated unit tests accordingly.

## Issues
https://optimizely.atlassian.net/browse/OASIS-6427
