### PR TITLE
ci: Run source clear before linting and tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,11 @@ os: linux
 
 # Integration tests need to run first to reset the PR build status to pending
 stages:
+  - name: 'Source Clear'
   - name: 'Lint markdown files'
   - name: 'Trigger Integration Tests'
     if: env(RUN_COMPAT_SUITE) = true
   - name: 'Lint'
-  - name: 'Source Clear'
   - name: 'Unit Tests'
   - name: 'Prepare for release'
     if: env(PREP) = true and type = api


### PR DESCRIPTION
Summary
-------
Stages run sequentially on Travis. If a stage fails, all the following stages are not executed. We execute source clear only on cron, and if due to any reason unit or integration tests fail, the source clear is not executed. Hence, moving source clear stage before tests. 


Test plan
---------
All unit tests must be passed. 
FSC must be passed.