### PR TITLE
fix: add check to see that all dot notated areas are numbers.

### DIFF
--- a/Sources/Data Model/Audience/SemanticVersion.swift
+++ b/Sources/Data Model/Audience/SemanticVersion.swift
@@ -88,7 +88,7 @@ extension SemanticVersion {
             throw OptimizelyError.attributeFormatInvalid
         }
         var targetedVersionParts = targetPrefix.split(separator: ".")
-        guard targetedVersionParts.count == dotCount + 1 else {
+        guard targetedVersionParts.count == dotCount + 1 && targetedVersionParts.filter({$0.isNumber}).count == targetedVersionParts.count else {
             throw OptimizelyError.attributeFormatInvalid
         }
         if let targetSuffix = targetSuffix {

--- a/Tests/OptimizelyTests-DataModel/SemanticVersionTests.swift
+++ b/Tests/OptimizelyTests-DataModel/SemanticVersionTests.swift
@@ -165,7 +165,8 @@ class SemanticVersionTests: XCTestCase {
     
     func testInvalidAttributes() {
         let target = "2.1.0"
-        let versions = ["-", ".", "..", "+", "+test", " ", "2 .3. 0", "2.", ".2.2", "3.7.2.2"]
+        let versions = ["-", ".", "..", "+", "+test", " ", "2 .3. 0", "2.", ".2.2", "3.7.2.2", "3.x",
+        ",", "+build-prerelese"]
         for (_, version) in versions.enumerated() {
             XCTAssert(((try? (version.compareVersion(targetedVersion: target)) < 0) == nil))
         }


### PR DESCRIPTION
## Summary
- Add a check to make sure that the dot notated prefix is a number.  