### PR TITLE
chore: fix a simulator name error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,8 +68,8 @@ jobs:
       branches:
         only:
           - master
-      env: SCHEME=OptimizelySwiftSDK-iOS TEST_SDK=iphonesimulator PLATFORM='iOS Simulator' OS=13.2 NAME='iPhone 11'
-      name: PLATFORM='iOS Simulator' OS=13.2 NAME='iPhone 11'
+      env: SCHEME=OptimizelySwiftSDK-iOS TEST_SDK=iphonesimulator PLATFORM='iOS Simulator' OS=13.3 NAME='iPhone 11'
+      name: PLATFORM='iOS Simulator' OS=13.3 NAME='iPhone 11'
       install:
         - gem install slather --no-document --quiet
         - gem install cocoapods -v '1.8.0'

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,7 @@ jobs:
       branches:
         only:
           - master
-      env: SCHEME=OptimizelySwiftSDK-iOS TEST_SDK=iphonesimulator PLATFORM='iOS Simulator' OS=12.1 NAME='iPhone 7'
+      env: SCHEME=OptimizelySwiftSDK-iOS TEST_SDK=iphonesimulator PLATFORM='iOS Simulator' OS=13.2 NAME='iPhone X'
       name: PLATFORM='iOS Simulator' OS=13.2 NAME='iPhone X'
       install:
         - gem install slather --no-document --quiet

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,8 +68,8 @@ jobs:
       branches:
         only:
           - master
-      env: SCHEME=OptimizelySwiftSDK-iOS TEST_SDK=iphonesimulator PLATFORM='iOS Simulator' OS=13.2 NAME='iPhone X'
-      name: PLATFORM='iOS Simulator' OS=13.2 NAME='iPhone X'
+      env: SCHEME=OptimizelySwiftSDK-iOS TEST_SDK=iphonesimulator PLATFORM='iOS Simulator' OS=13.2 NAME='iPhone 11'
+      name: PLATFORM='iOS Simulator' OS=13.2 NAME='iPhone 11'
       install:
         - gem install slather --no-document --quiet
         - gem install cocoapods -v '1.8.0'

--- a/Scripts/start_simulator.sh
+++ b/Scripts/start_simulator.sh
@@ -9,5 +9,12 @@ set -eou pipefail
 # prep jq arg because it doesnt allow parameter expansion within its single quotes
 echo ".devices.\"com.apple.CoreSimulator.SimRuntime.${PLATFORM/ Simulator/}-${OS/./-}\"" > /tmp/jq_file
 
-xcrun simctl boot $( xcrun simctl list --json devices | jq -f /tmp/jq_file | jq -r '.[] | select(.name==env.NAME) | .udid' ) && sleep 30
+simulator=$( xcrun simctl list --json devices | jq -f /tmp/jq_file | jq -r '.[] | select(.name==env.NAME) | .udid' )
+if [ -z $simulator ]; then
+    echo "The requested simulator ($PLATFORM $OS $NAME) cannot be found."
+    xcrun instruments -s device
+    exit 1
+fi
+
+xcrun simctl boot $simulator && sleep 30
 xcrun simctl list | grep Booted


### PR DESCRIPTION
- Fix an error in travis.yml (unit test simulator is not synced with its name)
- Add a command for dump available simulators when failed to launch the simulator
