### PR TITLE
feat: added "enabled" field to decision metadata structure.

### DIFF
--- a/Sources/Data Model/DispatchEvents/BatchEvent.swift
+++ b/Sources/Data Model/DispatchEvents/BatchEvent.swift
@@ -84,12 +84,15 @@ struct DecisionMetadata: Codable, Equatable {
     let ruleKey: String
     let flagKey: String
     let variationKey: String
+    let enabled: Bool
+    
     
     enum CodingKeys: String, CodingKey {
         case ruleType = "rule_type"
         case ruleKey = "rule_key"
         case flagKey = "flag_key"
         case variationKey = "variation_key"
+        case enabled = "enabled"
     }
 }
 

--- a/Sources/Implementation/Events/BatchEventBuilder.swift
+++ b/Sources/Implementation/Events/BatchEventBuilder.swift
@@ -29,13 +29,14 @@ class BatchEventBuilder {
                                       userId: String,
                                       attributes: OptimizelyAttributes?,
                                       flagKey: String,
-                                      ruleType: String) -> Data? {
+                                      ruleType: String,
+                                      enabled: Bool) -> Data? {
         
         if (ruleType == Constants.DecisionSource.rollout.rawValue || variation == nil) && !config.sendFlagDecisions {
             return nil
         }
         
-        let metaData = DecisionMetadata(ruleType: ruleType, ruleKey: experiment?.key ?? "", flagKey: flagKey, variationKey: variation?.key ?? "")
+        let metaData = DecisionMetadata(ruleType: ruleType, ruleKey: experiment?.key ?? "", flagKey: flagKey, variationKey: variation?.key ?? "", enabled: enabled)
         
         let decision = Decision(variationID: variation?.id ?? "",
                                 campaignID: experiment?.layerId ?? "",

--- a/Sources/Optimizely/OptimizelyClient.swift
+++ b/Sources/Optimizely/OptimizelyClient.swift
@@ -260,7 +260,8 @@ open class OptimizelyClient: NSObject {
                             userId: userId,
                             attributes: attributes,
                             flagKey: "",
-                            ruleType: Constants.DecisionSource.experiment.rawValue)
+                            ruleType: Constants.DecisionSource.experiment.rawValue,
+                            enabled: true)
         
         return variation.key
     }
@@ -387,7 +388,7 @@ open class OptimizelyClient: NSObject {
             logger.i(.featureNotEnabledForUser(featureKey, userId))
         }
         
-        sendImpressionEvent(experiment: pair?.experiment, variation: pair?.variation, userId: userId, attributes: attributes, flagKey: featureKey, ruleType: source)
+        sendImpressionEvent(experiment: pair?.experiment, variation: pair?.variation, userId: userId, attributes: attributes, flagKey: featureKey, ruleType: source, enabled: featureEnabled)
         
         sendDecisionNotification(decisionType: .feature,
                                  userId: userId,
@@ -745,7 +746,8 @@ extension OptimizelyClient {
                              userId: String,
                              attributes: OptimizelyAttributes? = nil,
                              flagKey: String,
-                             ruleType: String) {
+                             ruleType: String,
+                             enabled: Bool) {
         
         // non-blocking (event data serialization takes time)
         eventLock.async {
@@ -757,7 +759,8 @@ extension OptimizelyClient {
                                                                      userId: userId,
                                                                      attributes: attributes,
                                                                      flagKey: flagKey,
-                                                                     ruleType: ruleType) else {
+                                                                     ruleType: ruleType,
+                                                                     enabled: enabled) else {
                 self.logger.e(OptimizelyError.eventBuildFailure(DispatchEvent.activateEventKey))
                 return
             }

--- a/Tests/OptimizelyTests-APIs/OptimizelyClientTests_Others.swift
+++ b/Tests/OptimizelyTests-APIs/OptimizelyClientTests_Others.swift
@@ -290,7 +290,7 @@ class OptimizelyClientTests_Others: XCTestCase {
         // set invalid (infinity) to attribute values, which will cause JSONEncoder.encode exception
         let attributes = ["testvar": Double.infinity]
         
-        optimizely.sendImpressionEvent(experiment: experiment, variation: variation, userId: kUserId, attributes: attributes, flagKey: "", ruleType: Constants.DecisionSource.rollout.rawValue)
+        optimizely.sendImpressionEvent(experiment: experiment, variation: variation, userId: kUserId, attributes: attributes, flagKey: "", ruleType: Constants.DecisionSource.rollout.rawValue, enabled: true)
         XCTAssert(eventDispatcher.events.count == 0)
     }
     
@@ -322,7 +322,7 @@ class OptimizelyClientTests_Others: XCTestCase {
         // force condition for sdk-not-ready
         optimizely.config = nil
         
-        optimizely.sendImpressionEvent(experiment: experiment, variation: variation, userId: kUserId, flagKey: experiment.key, ruleType: Constants.DecisionSource.rollout.rawValue)
+        optimizely.sendImpressionEvent(experiment: experiment, variation: variation, userId: kUserId, flagKey: experiment.key, ruleType: Constants.DecisionSource.rollout.rawValue, enabled: true)
         XCTAssert(eventDispatcher.events.isEmpty, "event should not be sent out sdk is not configured properly")
 
         optimizely.sendConversionEvent(eventKey: kEventKey, userId: kUserId)

--- a/Tests/OptimizelyTests-Common/BatchEventBuilderTests_Events.swift
+++ b/Tests/OptimizelyTests-Common/BatchEventBuilderTests_Events.swift
@@ -82,6 +82,7 @@ class BatchEventBuilderTests_Events: XCTestCase {
         XCTAssertEqual(metaData["rule_key"] as! String, "ab_running_exp_audience_combo_exact_foo_or_true__and__42_or_4_2")
         XCTAssertEqual(metaData["flag_key"] as! String, "")
         XCTAssertEqual(metaData["variation_key"] as! String, "all_traffic_variation")
+        XCTAssertTrue(metaData["enabled"] as! Bool)
         
         let de = (snapshot["events"]  as! Array<Dictionary<String, Any>>)[0]
         
@@ -115,20 +116,20 @@ class BatchEventBuilderTests_Events: XCTestCase {
         let variation = experiment?.getVariation(id: "10416523162")
         
         for scenario in scenarios {
-            let event = BatchEventBuilder.createImpressionEvent(config: optimizely.config!, experiment: experiment!, variation: variation, userId: userId, attributes: attributes, flagKey: experiment!.key, ruleType: scenario.key)
+            let event = BatchEventBuilder.createImpressionEvent(config: optimizely.config!, experiment: experiment!, variation: variation, userId: userId, attributes: attributes, flagKey: experiment!.key, ruleType: scenario.key, enabled: true)
             scenario.value ? XCTAssertNotNil(event): XCTAssertNil(event)
         }
         
         // nil variation should always return nil
         for scenario in scenarios {
-            let event = BatchEventBuilder.createImpressionEvent(config: optimizely.config!, experiment: experiment!, variation: nil, userId: userId, attributes: attributes, flagKey: experiment!.key, ruleType: scenario.key)
+            let event = BatchEventBuilder.createImpressionEvent(config: optimizely.config!, experiment: experiment!, variation: nil, userId: userId, attributes: attributes, flagKey: experiment!.key, ruleType: scenario.key, enabled: true)
             XCTAssertNil(event)
         }
         
         // should always return a event if sendFlagDecisions is set
         optimizely.config?.project.sendFlagDecisions = true
         for scenario in scenarios {
-            let event = BatchEventBuilder.createImpressionEvent(config: optimizely.config!, experiment: experiment!, variation: nil, userId: userId, attributes: attributes, flagKey: experiment!.key, ruleType: scenario.key)
+            let event = BatchEventBuilder.createImpressionEvent(config: optimizely.config!, experiment: experiment!, variation: nil, userId: userId, attributes: attributes, flagKey: experiment!.key, ruleType: scenario.key, enabled: true)
             XCTAssertNotNil(event)
         }
         optimizely.config?.project.sendFlagDecisions = nil
@@ -144,7 +145,7 @@ class BatchEventBuilderTests_Events: XCTestCase {
         let experiment = optimizely.config?.getExperiment(id: "10390977714")
         
         optimizely.config?.project.sendFlagDecisions = true
-        let event = BatchEventBuilder.createImpressionEvent(config: optimizely.config!, experiment: experiment!, variation: nil, userId: userId, attributes: attributes, flagKey: experiment!.key, ruleType: Constants.DecisionSource.featureTest.rawValue)
+        let event = BatchEventBuilder.createImpressionEvent(config: optimizely.config!, experiment: experiment!, variation: nil, userId: userId, attributes: attributes, flagKey: experiment!.key, ruleType: Constants.DecisionSource.featureTest.rawValue, enabled: false)
         XCTAssertNotNil(event)
         
         let visitor = (getEventJSON(data: event!)!["visitors"] as! Array<Dictionary<String, Any>>)[0]
@@ -156,13 +157,14 @@ class BatchEventBuilderTests_Events: XCTestCase {
         XCTAssertEqual(metaData["rule_key"] as! String, "ab_running_exp_audience_combo_exact_foo_or_true__and__42_or_4_2")
         XCTAssertEqual(metaData["flag_key"] as! String, "ab_running_exp_audience_combo_exact_foo_or_true__and__42_or_4_2")
         XCTAssertEqual(metaData["variation_key"] as! String, "")
+        XCTAssertFalse(metaData["enabled"] as! Bool)
         optimizely.config?.project.sendFlagDecisions = nil
     }
     
     func testCreateImpressionEventWithoutExperimentAndVariation() {
         
         optimizely.config?.project.sendFlagDecisions = true
-        let event = BatchEventBuilder.createImpressionEvent(config: optimizely.config!, experiment: nil, variation: nil, userId: userId, attributes: [String: Any](), flagKey: "feature_1", ruleType: Constants.DecisionSource.rollout.rawValue)
+        let event = BatchEventBuilder.createImpressionEvent(config: optimizely.config!, experiment: nil, variation: nil, userId: userId, attributes: [String: Any](), flagKey: "feature_1", ruleType: Constants.DecisionSource.rollout.rawValue, enabled: true)
         XCTAssertNotNil(event)
         
         let visitor = (getEventJSON(data: event!)!["visitors"] as! Array<Dictionary<String, Any>>)[0]
@@ -174,6 +176,7 @@ class BatchEventBuilderTests_Events: XCTestCase {
         XCTAssertEqual(metaData["rule_key"] as! String, "")
         XCTAssertEqual(metaData["flag_key"] as! String, "feature_1")
         XCTAssertEqual(metaData["variation_key"] as! String, "")
+        XCTAssertTrue(metaData["enabled"] as! Bool)
         optimizely.config?.project.sendFlagDecisions = nil
     }
     
@@ -277,6 +280,7 @@ extension BatchEventBuilderTests_Events {
             XCTAssertEqual(metaData["rule_key"] as! String, "")
             XCTAssertEqual(metaData["flag_key"] as! String, "feature_1")
             XCTAssertEqual(metaData["variation_key"] as! String, "")
+            XCTAssertFalse(metaData["enabled"] as! Bool)
         } else {
             XCTFail("No event found")
         }
@@ -310,6 +314,7 @@ extension BatchEventBuilderTests_Events {
             XCTAssertEqual(metaData["rule_key"] as! String, "exp_with_audience")
             XCTAssertEqual(metaData["flag_key"] as! String, "feature_1")
             XCTAssertEqual(metaData["variation_key"] as! String, "a")
+            XCTAssertTrue(metaData["enabled"] as! Bool)
         } else {
             XCTFail("No event found")
         }
@@ -344,6 +349,7 @@ extension BatchEventBuilderTests_Events {
             XCTAssertEqual(metaData["rule_key"] as! String, "exp_with_audience")
             XCTAssertEqual(metaData["flag_key"] as! String, "feature_1")
             XCTAssertEqual(metaData["variation_key"] as! String, "a")
+            XCTAssertTrue(metaData["enabled"] as! Bool)
         } else {
             XCTFail("No event found")
         }


### PR DESCRIPTION
## Summary
- added "enabled" field to decision metadata structure
- setting "enabled" to true for activate() since we check for non nil variation. 