### PR TITLE
feat(decide): clone user-context before calling optimizely decide

### DIFF
--- a/Sources/Optimizely+Decide/OptimizelyDecision.swift
+++ b/Sources/Optimizely+Decide/OptimizelyDecision.swift
@@ -34,7 +34,7 @@ public struct OptimizelyDecision {
     /// The flag key for which the decision has been made for.
     public let flagKey: String
     
-    /// The user context for which the decision has been made for.
+    /// A copy of the user context for which the decision has been made for.
     public let userContext: OptimizelyUserContext
     
     /// An array of error/info/debug messages describing why the decision has been made.

--- a/Sources/Optimizely+Decide/OptimizelyDecision.swift
+++ b/Sources/Optimizely+Decide/OptimizelyDecision.swift
@@ -25,7 +25,7 @@ public struct OptimizelyDecision {
     /// The boolean value indicating if the flag is enabled or not.
     public let enabled: Bool
     
-    /// The collection of variables assocaited with the decision.
+    /// The collection of variables associated with the decision.
     public let variables: OptimizelyJSON
     
     /// The rule key of the decision.
@@ -37,7 +37,7 @@ public struct OptimizelyDecision {
     /// A copy of the user context for which the decision has been made for.
     public let userContext: OptimizelyUserContext
     
-    /// An array of error/info/debug messages describing why the decision has been made.
+    /// An array of error/info messages describing why the decision has been made.
     public let reasons: [String]
 }
 

--- a/Sources/Optimizely+Decide/OptimizelyDecision.swift
+++ b/Sources/Optimizely+Decide/OptimizelyDecision.swift
@@ -1,5 +1,5 @@
 /****************************************************************************
-* Copyright 2020, Optimizely, Inc. and contributors                        *
+* Copyright 2020-2021, Optimizely, Inc. and contributors                   *
 *                                                                          *
 * Licensed under the Apache License, Version 2.0 (the "License");          *
 * you may not use this file except in compliance with the License.         *

--- a/Sources/Optimizely+Decide/OptimizelyUserContext.swift
+++ b/Sources/Optimizely+Decide/OptimizelyUserContext.swift
@@ -26,6 +26,11 @@ public class OptimizelyUserContext {
         return atomicAttributes.property ?? [:]
     }
     
+    var clone: OptimizelyUserContext? {
+        guard let optimizely = self.optimizely else { return nil }
+        return OptimizelyUserContext(optimizely: optimizely, userId: userId, attributes: attributes)
+    }
+    
     lazy var logger = OPTLoggerFactory.getLogger()
     
     /// OptimizelyUserContext init
@@ -64,11 +69,11 @@ public class OptimizelyUserContext {
     public func decide(key: String,
                        options: [OptimizelyDecideOption]? = nil) -> OptimizelyDecision {
         
-        guard let optimizely = self.optimizely else {
+        guard let optimizely = self.optimizely, let clone = self.clone else {
             return OptimizelyDecision.errorDecision(key: key, user: self, error: .sdkNotReady)
         }
         
-        return optimizely.decide(user: self, key: key, options: options)
+        return optimizely.decide(user: clone, key: key, options: options)
     }
 
     /// Returns a key-map of decision results for multiple flag keys and a user context.
@@ -83,12 +88,12 @@ public class OptimizelyUserContext {
     public func decide(keys: [String],
                        options: [OptimizelyDecideOption]? = nil) -> [String: OptimizelyDecision] {
 
-        guard let optimizely = self.optimizely else {
+        guard let optimizely = self.optimizely, let clone = self.clone else {
             logger.e(OptimizelyError.sdkNotReady)
             return [:]
         }
         
-        return optimizely.decide(user: self, keys: keys, options: options)
+        return optimizely.decide(user: clone, keys: keys, options: options)
     }
     
     /// Returns a key-map of decision results for all active flag keys.
@@ -97,12 +102,12 @@ public class OptimizelyUserContext {
     ///   - options: An array of options for decision-making.
     /// - Returns: A dictionary of all decision results, mapped by flag keys.
     public func decideAll(options: [OptimizelyDecideOption]? = nil) -> [String: OptimizelyDecision] {
-        guard let optimizely = self.optimizely else {
+        guard let optimizely = self.optimizely, let clone = self.clone else {
             logger.e(OptimizelyError.sdkNotReady)
             return [:]
         }
 
-        return optimizely.decideAll(user: self, options: options)
+        return optimizely.decideAll(user: clone, options: options)
     }
 
     /// Track an event.

--- a/Sources/Optimizely+Decide/OptimizelyUserContext.swift
+++ b/Sources/Optimizely+Decide/OptimizelyUserContext.swift
@@ -1,5 +1,5 @@
 /****************************************************************************
-* Copyright 2020, Optimizely, Inc. and contributors                        *
+* Copyright 2020-2021, Optimizely, Inc. and contributors                   *
 *                                                                          *
 * Licensed under the Apache License, Version 2.0 (the "License");          *
 * you may not use this file except in compliance with the License.         *


### PR DESCRIPTION
Clone the current user-context and pass it to optimizely.decide()
- user context can be changed while processing the decide request.
- with this fix, decide can return the copy of the original user-context as a part of the decision