### PR TITLE
Allow supplying data file handler.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,9 +42,9 @@ jobs:
     - stage: 'Lint'
       language: swift
       os: osx
-      osx_image: xcode11.3
+      osx_image: xcode11.6
       install:
-        - gem install cocoapods -v '1.8.0'
+        - gem install cocoapods -v '1.9.3'
       script:
         - pod spec lint --quick
       after_script:
@@ -64,7 +64,7 @@ jobs:
       stage: 'Unit Tests'
       language: swift
       os: osx
-      osx_image: xcode11.3
+      osx_image: xcode11.6
       branches:
         only:
           - master
@@ -72,7 +72,7 @@ jobs:
       name: PLATFORM='iOS Simulator' OS=13.3 NAME='iPhone 11'
       install:
         - gem install slather --no-document --quiet
-        - gem install cocoapods -v '1.8.0'
+        - gem install cocoapods -v '1.9.3'
         - pod repo update
         - pod install
         # install jq without cleaning up
@@ -104,14 +104,14 @@ jobs:
       name: Prepare for release
       language: swift
       os: osx
-      osx_image: xcode11.3
+      osx_image: xcode11.6
       env:
         - VERSION=3.7.0
       install:
         # install hub
         - wget https://github.com/github/hub/releases/download/v2.11.2/hub-darwin-amd64-2.11.2.tgz -O /tmp/hub-darwin-amd64-2.11.2.tgz && tar -xvf /tmp/hub-darwin-amd64-2.11.2.tgz -C /usr/local/opt && ln -s /usr/local/opt/hub-darwin-amd64-2.11.2/bin/hub /usr/local/bin/hub
         # upgrade cocoapods
-        - gem install cocoapods -v '1.8.0'
+        - gem install cocoapods -v '1.9.3'
       script:
         - Scripts/run_prep.sh
       after_failure:
@@ -121,13 +121,13 @@ jobs:
       name: Push to cocoapods.org
       language: minimal
       os: osx
-      osx_image: xcode11.3
+      osx_image: xcode11.6
       env:
         - VERSION=3.7.0
       install:
         # install hub
         - wget https://github.com/github/hub/releases/download/v2.11.2/hub-darwin-amd64-2.11.2.tgz -O /tmp/hub-darwin-amd64-2.11.2.tgz && tar -xvf /tmp/hub-darwin-amd64-2.11.2.tgz -C /usr/local/opt && ln -s /usr/local/opt/hub-darwin-amd64-2.11.2/bin/hub /usr/local/bin/hub
         # upgrade cocoapods
-        - gem install cocoapods -v '1.8.0'
+        - gem install cocoapods -v '1.9.3'
       script:
         - Scripts/run_release.sh

--- a/OptimizelySwiftSDK.xcodeproj/project.pbxproj
+++ b/OptimizelySwiftSDK.xcodeproj/project.pbxproj
@@ -2012,6 +2012,7 @@
 				6E75165F22C520D400B2B157 /* DefaultLogger.swift */,
 				6E75166022C520D400B2B157 /* DefaultUserProfileService.swift */,
 				6E75166122C520D400B2B157 /* DefaultEventDispatcher.swift */,
+				6E75167D22C520D400B2B157 /* DefaultDatafileHandler.swift */,
 				6E75166222C520D400B2B157 /* Protocols */,
 			);
 			path = Customization;
@@ -2023,6 +2024,7 @@
 				6E75166322C520D400B2B157 /* OPTLogger.swift */,
 				6E75166422C520D400B2B157 /* OPTUserProfileService.swift */,
 				6E75166522C520D400B2B157 /* OPTEventDispatcher.swift */,
+				6E7516A422C520D400B2B157 /* OPTDatafileHandler.swift */,
 			);
 			path = Protocols;
 			sourceTree = "<group>";
@@ -2081,7 +2083,6 @@
 		6E75167C22C520D400B2B157 /* Implementation */ = {
 			isa = PBXGroup;
 			children = (
-				6E75167D22C520D400B2B157 /* DefaultDatafileHandler.swift */,
 				6E623F01253F9045000617D0 /* DecisionInfo.swift */,
 				6E75167E22C520D400B2B157 /* DefaultBucketer.swift */,
 				6E75167F22C520D400B2B157 /* DefaultNotificationCenter.swift */,
@@ -2164,7 +2165,6 @@
 				6E7516A122C520D400B2B157 /* DataStoreQueueStack.swift */,
 				6E7516A222C520D400B2B157 /* OPTDataStore.swift */,
 				6E7516A322C520D400B2B157 /* OPTDecisionService.swift */,
-				6E7516A422C520D400B2B157 /* OPTDatafileHandler.swift */,
 				6E7516A522C520D400B2B157 /* OPTBucketer.swift */,
 			);
 			path = Protocols;

--- a/Sources/Customization/Protocols/OPTDatafileHandler.swift
+++ b/Sources/Customization/Protocols/OPTDatafileHandler.swift
@@ -1,5 +1,5 @@
 /****************************************************************************
-* Copyright 2019-2020, Optimizely, Inc. and contributors                   *
+* Copyright 2019-2021, Optimizely, Inc. and contributors                   *
 *                                                                          *
 * Licensed under the Apache License, Version 2.0 (the "License");          *
 * you may not use this file except in compliance with the License.         *
@@ -25,11 +25,27 @@ public protocol OPTDatafileHandler {
     init()
     
     var endPointStringFormat: String { get set }
+    
+    /**
+     Save an interval for periodic polling
+     
+     - Parameter sdkKey: sdk key of the datafile to download
+     - Parameter interval: interval in secs (> 0)
+     */
+    func setPeriodicInterval(sdkKey: String, interval: Int)
+    
+    /**
+     Check if periodic polling has been set
+     
+     - Parameter sdkKey: sdk key of the datafile to download
+     - Returns: true if set
+     */
+    func hasPeriodicInterval(sdkKey: String) -> Bool
+    
     /**
     Synchronous call to download the datafile.
 
     - Parameter sdkKey: sdk key of the datafile to download
-    - Parameter datafileConfig: DatafileConfig for the datafile
     - Returns: a valid datafile or null
      */
     func downloadDatafile(sdkKey: String) -> Data?
@@ -37,6 +53,7 @@ public protocol OPTDatafileHandler {
     /**
      Asynchronous download data file.
      - Parameter sdkKey: application context for download
+     - Parameter returnCacheIfNoChange: include a cached datafile in result when datafile not changed.
      - Parameter resourceTimeoutInterval: timeout in seconds to wait for resource.
      - Parameter completionHhandler:  listener to call when datafile download complete
      */

--- a/Sources/Customization/Protocols/OPTDatafileHandler.swift
+++ b/Sources/Customization/Protocols/OPTDatafileHandler.swift
@@ -55,7 +55,7 @@ public protocol OPTDatafileHandler {
      - Parameter sdkKey: application context for download
      - Parameter returnCacheIfNoChange: include a cached datafile in result when datafile not changed.
      - Parameter resourceTimeoutInterval: timeout in seconds to wait for resource.
-     - Parameter completionHhandler:  listener to call when datafile download complete
+     - Parameter completionHandler:  listener to call when datafile download is completed.
      */
     func downloadDatafile(sdkKey: String,
                           returnCacheIfNoChange: Bool,

--- a/Sources/Extensions/OptimizelyClient+Extension.swift
+++ b/Sources/Extensions/OptimizelyClient+Extension.swift
@@ -57,13 +57,15 @@ extension OptimizelyClient {
     ///         Set this to 0 to disable periodic downloading.
     ///   - defaultLogLevel: default log level (optional. default = .info)
     ///   - defaultDecisionOptions: default decision optiopns (optional)
+    ///   - defaultDatafileHandler: default data file handler (optional)
     public convenience init(sdkKey: String,
                             logger: OPTLogger? = nil,
                             eventDispatcher: OPTEventDispatcher? = nil,
                             userProfileService: OPTUserProfileService? = nil,
                             periodicDownloadInterval: Int?,
                             defaultLogLevel: OptimizelyLogLevel? = nil,
-                            defaultDecideOptions: [OptimizelyDecideOption]? = nil) {
+                            defaultDecideOptions: [OptimizelyDecideOption]? = nil,
+                            defaultDatafileHandler: OPTDatafileHandler? = nil) {
         let interval = periodicDownloadInterval ?? 10 * 60
         
         self.init(sdkKey: sdkKey,
@@ -71,12 +73,13 @@ extension OptimizelyClient {
                   eventDispatcher: eventDispatcher,
                   userProfileService: userProfileService,
                   defaultLogLevel: defaultLogLevel,
-                  defaultDecideOptions: defaultDecideOptions)
+                  defaultDecideOptions: defaultDecideOptions,
+                  defaultDatafileHandler: defaultDatafileHandler)
         
         if let handler = datafileHandler as? DefaultDatafileHandler, interval > 0 {
             handler.setTimer(sdkKey: sdkKey, interval: interval)
         }
-        
+
     }
 
 }

--- a/Sources/Extensions/OptimizelyClient+Extension.swift
+++ b/Sources/Extensions/OptimizelyClient+Extension.swift
@@ -51,35 +51,34 @@ extension OptimizelyClient {
     ///   - sdkKey: sdk key
     ///   - logger: custom Logger
     ///   - eventDispatcher: custom EventDispatcher (optional)
+    ///   - datafileHandler: custom datafile handler (optional)
     ///   - userProfileService: custom UserProfileService (optional)
-    ///   - periodicDownloadInterval: custom interval for periodic background datafile download.
+    ///   - periodicDownloadInterval: interval in secs for periodic background datafile download.
     ///         The recommended value is 10 * 60 secs (you can also set this to nil to use the recommended value).
     ///         Set this to 0 to disable periodic downloading.
     ///   - defaultLogLevel: default log level (optional. default = .info)
     ///   - defaultDecisionOptions: default decision optiopns (optional)
-    ///   - defaultDatafileHandler: default data file handler (optional)
     public convenience init(sdkKey: String,
                             logger: OPTLogger? = nil,
                             eventDispatcher: OPTEventDispatcher? = nil,
+                            datafileHandler: OPTDatafileHandler? = nil,
                             userProfileService: OPTUserProfileService? = nil,
                             periodicDownloadInterval: Int?,
                             defaultLogLevel: OptimizelyLogLevel? = nil,
-                            defaultDecideOptions: [OptimizelyDecideOption]? = nil,
-                            defaultDatafileHandler: OPTDatafileHandler? = nil) {
-        let interval = periodicDownloadInterval ?? 10 * 60
+                            defaultDecideOptions: [OptimizelyDecideOption]? = nil) {
         
         self.init(sdkKey: sdkKey,
                   logger: logger,
                   eventDispatcher: eventDispatcher,
+                  datafileHandler: datafileHandler,
                   userProfileService: userProfileService,
                   defaultLogLevel: defaultLogLevel,
-                  defaultDecideOptions: defaultDecideOptions,
-                  defaultDatafileHandler: defaultDatafileHandler)
+                  defaultDecideOptions: defaultDecideOptions)
         
-        if let handler = datafileHandler as? DefaultDatafileHandler, interval > 0 {
-            handler.setTimer(sdkKey: sdkKey, interval: interval)
+        let interval = periodicDownloadInterval ?? 10 * 60
+        if interval > 0 {
+            self.currentDatafileHandler?.setPeriodicInterval(sdkKey: sdkKey, interval: interval)
         }
-
     }
 
 }

--- a/Sources/Implementation/Datastore/DataStoreFile.swift
+++ b/Sources/Implementation/Datastore/DataStoreFile.swift
@@ -1,5 +1,5 @@
 /****************************************************************************
-* Copyright 2019-2020, Optimizely, Inc. and contributors                   *
+* Copyright 2019-2021, Optimizely, Inc. and contributors                   *
 *                                                                          *
 * Licensed under the Apache License, Version 2.0 (the "License");          *
 * you may not use this file except in compliance with the License.         *

--- a/Sources/Implementation/Datastore/DataStoreFile.swift
+++ b/Sources/Implementation/Datastore/DataStoreFile.swift
@@ -18,14 +18,14 @@ import Foundation
 
 /// Implementation of OPTDataStore as a generic for per type storeage in a flat file.
 /// This class should be used as a singleton per storeName and type (T)
-public class DataStoreFile<T>: OPTDataStore where T: Codable {
+open class DataStoreFile<T>: OPTDataStore where T: Codable {
     let dataStoreName: String
     let lock: DispatchQueue
     let async: Bool
     public let url: URL
     lazy var logger: OPTLogger? = OPTLoggerFactory.getLogger()
     
-    init(storeName: String, async: Bool = true) {
+    public init(storeName: String, async: Bool = true) {
         self.async = async
         dataStoreName = storeName
         lock = DispatchQueue(label: storeName)
@@ -56,7 +56,7 @@ public class DataStoreFile<T>: OPTDataStore where T: Codable {
                     return
                 }
                 
-                let contents = try Data(contentsOf: self.url)
+                let contents = try self.readData()
 
                 if type(of: T.self) == type(of: Data.self) {
                     returnItem = contents as? T
@@ -107,7 +107,7 @@ public class DataStoreFile<T>: OPTDataStore where T: Codable {
                     }
                     
                     if let data = data {
-                        try data.write(to: self.url, options: .atomic)
+                        try self.writeData(data)
                     }
                 }
             } catch let e {
@@ -125,5 +125,15 @@ public class DataStoreFile<T>: OPTDataStore where T: Codable {
             }
         }
 
+    }
+
+    // Read Data contents from the URL
+    open func readData() throws -> Data {
+        return try Data(contentsOf: self.url)
+    }
+
+    // Write Data to the URL
+    open func writeData(_ data: Data) throws {
+        try data.write(to: self.url, options: .atomic)
     }
 }

--- a/Sources/Implementation/DefaultDatafileHandler.swift
+++ b/Sources/Implementation/DefaultDatafileHandler.swift
@@ -15,7 +15,7 @@
  ***************************************************************************/
 import Foundation
 
-class DefaultDatafileHandler: OPTDatafileHandler {
+open class DefaultDatafileHandler: OPTDatafileHandler {
     // endpoint used to get the datafile.  This is settable after you create a OptimizelyClient instance.
     public var endPointStringFormat = "https://cdn.optimizely.com/datafiles/%@.json"
     
@@ -29,9 +29,10 @@ class DefaultDatafileHandler: OPTDatafileHandler {
     var datafileCache = [String: OPTDataStore]()
     // and our download queue to speed things up.
     let downloadQueue = DispatchQueue(label: "DefaultDatafileHandlerQueue")
+
     
-    required init() {
-        
+    public required init() {
+
     }
     
     func setTimer(sdkKey: String, interval: Int) {
@@ -43,7 +44,7 @@ class DefaultDatafileHandler: OPTDatafileHandler {
         }
     }
     
-    func downloadDatafile(sdkKey: String) -> Data? {
+    public func downloadDatafile(sdkKey: String) -> Data? {
         
         var datafile: Data?
         let group = DispatchGroup()
@@ -152,6 +153,10 @@ class DefaultDatafileHandler: OPTDatafileHandler {
         }
     }
     
+    open func createDataStore(sdkKey: String) -> OPTDataStore {
+        return DataStoreFile<Data>(storeName: sdkKey)
+    }
+
     func startPeriodicUpdates(sdkKey: String, updateInterval: Int, datafileChangeNotification: ((Data) -> Void)?) {
         
         let now = Date()
@@ -242,17 +247,17 @@ class DefaultDatafileHandler: OPTDatafileHandler {
         
     }
     
-    func startUpdates(sdkKey: String, datafileChangeNotification: ((Data) -> Void)?) {
+    public func startUpdates(sdkKey: String, datafileChangeNotification: ((Data) -> Void)?) {
         if let value = timers.property?[sdkKey], !(value.timer?.isValid ?? false) {
             startPeriodicUpdates(sdkKey: sdkKey, updateInterval: value.interval, datafileChangeNotification: datafileChangeNotification)
         }
     }
     
-    func stopUpdates(sdkKey: String) {
+    public func stopUpdates(sdkKey: String) {
         stopPeriodicUpdates(sdkKey: sdkKey)
     }
     
-    func stopAllUpdates() {
+    public func stopAllUpdates() {
         stopPeriodicUpdates()
     }
     
@@ -260,27 +265,28 @@ class DefaultDatafileHandler: OPTDatafileHandler {
         if let cache = datafileCache[sdkKey] {
             return cache
         } else {
-            let store = DataStoreFile<Data>(storeName: sdkKey)
+            let store = createDataStore(sdkKey: sdkKey)
             datafileCache[sdkKey] = store
             return store
         }
     }
     
-    func saveDatafile(sdkKey: String, dataFile: Data) {
+    public func saveDatafile(sdkKey: String, dataFile: Data) {
         getDatafileCache(sdkKey: sdkKey).saveItem(forKey: sdkKey, value: dataFile)
     }
     
-    func loadSavedDatafile(sdkKey: String) -> Data? {
+    public func loadSavedDatafile(sdkKey: String) -> Data? {
         return getDatafileCache(sdkKey: sdkKey).getItem(forKey: sdkKey) as? Data
     }
     
-    func isDatafileSaved(sdkKey: String) -> Bool {
+    public func isDatafileSaved(sdkKey: String) -> Bool {
         return getDatafileCache(sdkKey: sdkKey).getItem(forKey: sdkKey) as? Data != nil
     }
     
-    func removeSavedDatafile(sdkKey: String) {
+    public func removeSavedDatafile(sdkKey: String) {
         getDatafileCache(sdkKey: sdkKey).removeItem(forKey: sdkKey)
     }
+
 }
 
 extension DataStoreUserDefaults {

--- a/Sources/Optimizely/OptimizelyClient.swift
+++ b/Sources/Optimizely/OptimizelyClient.swift
@@ -84,12 +84,14 @@ open class OptimizelyClient: NSObject {
     ///   - userProfileService: custom UserProfileService (optional)
     ///   - defaultLogLevel: default log level (optional. default = .info)
     ///   - defaultDecisionOptions: default decision optiopns (optional)
+    ///   - defaultDatafileHandler: default data file handler (optional)
     public init(sdkKey: String,
                 logger: OPTLogger? = nil,
                 eventDispatcher: OPTEventDispatcher? = nil,
                 userProfileService: OPTUserProfileService? = nil,
                 defaultLogLevel: OptimizelyLogLevel? = nil,
-                defaultDecideOptions: [OptimizelyDecideOption]? = nil) {
+                defaultDecideOptions: [OptimizelyDecideOption]? = nil,
+                defaultDatafileHandler: OPTDatafileHandler? = nil) {
         
         self.sdkKey = sdkKey
         self.defaultDecideOptions = defaultDecideOptions ?? []
@@ -103,7 +105,7 @@ open class OptimizelyClient: NSObject {
         self.registerServices(sdkKey: sdkKey,
                               logger: logger,
                               eventDispatcher: eventDispatcher ?? DefaultEventDispatcher.sharedInstance,
-                              datafileHandler: DefaultDatafileHandler(),
+                              datafileHandler: defaultDatafileHandler ?? DefaultDatafileHandler(),
                               decisionService: DefaultDecisionService(userProfileService: userProfileService),
                               notificationCenter: DefaultNotificationCenter())
         

--- a/Sources/Optimizely/OptimizelyClient.swift
+++ b/Sources/Optimizely/OptimizelyClient.swift
@@ -43,14 +43,6 @@ open class OptimizelyClient: NSObject {
     
     let eventLock = DispatchQueue(label: "com.optimizely.client")
     
-    private var isPeriodicPollingEnabled: Bool {
-        if let handler = datafileHandler as? DefaultDatafileHandler {
-            return handler.hasPeriodUpdates(sdkKey: sdkKey)
-        } else {
-            return false
-        }
-    }
-    
     // MARK: - Customizable Services
     
     lazy var logger = OPTLoggerFactory.getLogger()
@@ -68,6 +60,7 @@ open class OptimizelyClient: NSObject {
     public var datafileHandler: OPTDatafileHandler? {
         return HandlerRegistryService.shared.injectDatafileHandler(sdkKey: self.sdkKey)
     }
+    lazy var currentDatafileHandler = datafileHandler
     
     public var notificationCenter: OPTNotificationCenter? {
         return HandlerRegistryService.shared.injectNotificationCenter(sdkKey: self.sdkKey)
@@ -81,17 +74,17 @@ open class OptimizelyClient: NSObject {
     ///   - sdkKey: sdk key
     ///   - logger: custom Logger
     ///   - eventDispatcher: custom EventDispatcher (optional)
+    ///   - datafileHandler: custom datafile handler (optional)
     ///   - userProfileService: custom UserProfileService (optional)
     ///   - defaultLogLevel: default log level (optional. default = .info)
     ///   - defaultDecisionOptions: default decision optiopns (optional)
-    ///   - defaultDatafileHandler: default data file handler (optional)
     public init(sdkKey: String,
                 logger: OPTLogger? = nil,
                 eventDispatcher: OPTEventDispatcher? = nil,
+                datafileHandler: OPTDatafileHandler? = nil,
                 userProfileService: OPTUserProfileService? = nil,
                 defaultLogLevel: OptimizelyLogLevel? = nil,
-                defaultDecideOptions: [OptimizelyDecideOption]? = nil,
-                defaultDatafileHandler: OPTDatafileHandler? = nil) {
+                defaultDecideOptions: [OptimizelyDecideOption]? = nil) {
         
         self.sdkKey = sdkKey
         self.defaultDecideOptions = defaultDecideOptions ?? []
@@ -105,7 +98,7 @@ open class OptimizelyClient: NSObject {
         self.registerServices(sdkKey: sdkKey,
                               logger: logger,
                               eventDispatcher: eventDispatcher ?? DefaultEventDispatcher.sharedInstance,
-                              datafileHandler: defaultDatafileHandler ?? DefaultDatafileHandler(),
+                              datafileHandler: datafileHandler ?? DefaultDatafileHandler(),
                               decisionService: DefaultDecisionService(userProfileService: userProfileService),
                               notificationCenter: DefaultNotificationCenter())
         
@@ -183,12 +176,14 @@ open class OptimizelyClient: NSObject {
         
         if !doFetchDatafileBackground { return }
         
-        datafileHandler?.downloadDatafile(sdkKey: sdkKey, returnCacheIfNoChange: false) { [weak self] result in
+        guard let datafileHandler = datafileHandler else { return }
+        
+        datafileHandler.downloadDatafile(sdkKey: sdkKey, returnCacheIfNoChange: false) { [weak self] result in
             guard let self = self else { return }
 
             // override to update always if periodic datafile polling is enabled
             // this is necessary for the case that the first cache download gets the updated datafile
-            guard doUpdateConfigOnNewDatafile || self.isPeriodicPollingEnabled else { return }
+            guard doUpdateConfigOnNewDatafile || datafileHandler.hasPeriodicInterval(sdkKey: self.sdkKey) else { return }
             
             if case .success(let data) = result, let datafile = data {
                 // new datafile came in

--- a/Tests/OptimizelyTests-APIs/OptimizelyClientTests_Init_Async.swift
+++ b/Tests/OptimizelyTests-APIs/OptimizelyClientTests_Init_Async.swift
@@ -1,5 +1,5 @@
 /****************************************************************************
-* Copyright 2020, Optimizely, Inc. and contributors                        *
+* Copyright 2020-2021, Optimizely, Inc. and contributors                   *
 *                                                                          *
 * Licensed under the Apache License, Version 2.0 (the "License");          *
 * you may not use this file except in compliance with the License.         *
@@ -56,9 +56,8 @@ class OptimizelyClientTests_Init_Async: XCTestCase {
         let testSdkKey = OTUtils.randomSdkKey  // unique but consistent with registry + start
         
         let handler = FakeDatafileHandler(mode: .successWithData)
-        HandlerRegistryService.shared.registerBinding(binder: Binder(service: OPTDatafileHandler.self).sdkKey(key: testSdkKey).using(instance: handler).to(factory: FakeDatafileHandler.init).reInitializeStrategy(strategy: .reUse).singetlon())
-        
-        let optimizely = OptimizelyClient(sdkKey: testSdkKey)
+        let optimizely = OptimizelyClient(sdkKey: testSdkKey,
+                                          datafileHandler: handler)
 
         let exp = expectation(description: "x")
         optimizely.start { result in
@@ -74,9 +73,8 @@ class OptimizelyClientTests_Init_Async: XCTestCase {
         let testSdkKey = OTUtils.randomSdkKey  // unique but consistent with registry + start
         
         let handler = FakeDatafileHandler(mode: .failure)
-        HandlerRegistryService.shared.registerBinding(binder: Binder(service: OPTDatafileHandler.self).sdkKey(key: testSdkKey).using(instance: handler).to(factory: FakeDatafileHandler.init).reInitializeStrategy(strategy: .reUse).singetlon())
-        
-        let optimizely = OptimizelyClient(sdkKey: testSdkKey)
+        let optimizely = OptimizelyClient(sdkKey: testSdkKey,
+                                          datafileHandler: handler)
 
         let exp = expectation(description: "x")
         optimizely.start { result in
@@ -95,9 +93,8 @@ class OptimizelyClientTests_Init_Async: XCTestCase {
         let testSdkKey = OTUtils.randomSdkKey  // unique but consistent with registry + start
         
         let handler = FakeDatafileHandler(mode: .failedToLoadFromCache)
-        HandlerRegistryService.shared.registerBinding(binder: Binder(service: OPTDatafileHandler.self).sdkKey(key: testSdkKey).using(instance: handler).to(factory: FakeDatafileHandler.init).reInitializeStrategy(strategy: .reUse).singetlon())
-        
-        let optimizely = OptimizelyClient(sdkKey: testSdkKey)
+        let optimizely = OptimizelyClient(sdkKey: testSdkKey,
+                                          datafileHandler: handler)
 
         let exp = expectation(description: "x")
         optimizely.start { result in
@@ -115,10 +112,9 @@ class OptimizelyClientTests_Init_Async: XCTestCase {
     func testInitAsync_enablePeriodicPolling() {
         let testSdkKey = OTUtils.randomSdkKey  // unique but consistent with registry + start
         
-        let handler = FakeDatafileHandler(mode: .successWithData)
-        HandlerRegistryService.shared.registerBinding(binder: Binder(service: OPTDatafileHandler.self).sdkKey(key: testSdkKey).using(instance: handler).to(factory: FakeDatafileHandler.init).reInitializeStrategy(strategy: .reUse).singetlon())
-        
+        let handler = FakeDatafileHandler(mode: .successWithData)        
         let optimizely = OptimizelyClient(sdkKey: testSdkKey,
+                                          datafileHandler: handler,
                                           periodicDownloadInterval: 1)
         
         let exp = expectation(description: "x")

--- a/Tests/OptimizelyTests-APIs/OptimizelyClientTests_Init_Sync.swift
+++ b/Tests/OptimizelyTests-APIs/OptimizelyClientTests_Init_Sync.swift
@@ -1,5 +1,5 @@
 /****************************************************************************
-* Copyright 2020, Optimizely, Inc. and contributors                        *
+* Copyright 2020-2021, Optimizely, Inc. and contributors                   *
 *                                                                          *
 * Licensed under the Apache License, Version 2.0 (the "License");          *
 * you may not use this file except in compliance with the License.         *
@@ -70,9 +70,8 @@ class OptimizelyClientTests_Init_Sync: XCTestCase {
         let testSdkKey = OTUtils.randomSdkKey  // unique but consistent with registry + start
         
         let handler = FakeDatafileHandler(mode: .successWithData)
-        HandlerRegistryService.shared.registerBinding(binder: Binder(service: OPTDatafileHandler.self).sdkKey(key: testSdkKey).using(instance: handler).to(factory: FakeDatafileHandler.init).reInitializeStrategy(strategy: .reUse).singetlon())
-        
-        let optimizely = OptimizelyClient(sdkKey: testSdkKey)
+        let optimizely = OptimizelyClient(sdkKey: testSdkKey,
+                                          datafileHandler: handler)
 
         try! optimizely.start(datafile: datafile,
                               doUpdateConfigOnNewDatafile: true)
@@ -85,9 +84,8 @@ class OptimizelyClientTests_Init_Sync: XCTestCase {
         let testSdkKey = OTUtils.randomSdkKey  // unique but consistent with registry + start
         
         let handler = FakeDatafileHandler(mode: .successWithNil)
-        HandlerRegistryService.shared.registerBinding(binder: Binder(service: OPTDatafileHandler.self).sdkKey(key: testSdkKey).using(instance: handler).to(factory: FakeDatafileHandler.init).reInitializeStrategy(strategy: .reUse).singetlon())
-        
-        let optimizely = OptimizelyClient(sdkKey: testSdkKey)
+        let optimizely = OptimizelyClient(sdkKey: testSdkKey,
+                                          datafileHandler: handler)
 
         try! optimizely.start(datafile: datafile,
                               doUpdateConfigOnNewDatafile: true)
@@ -100,9 +98,8 @@ class OptimizelyClientTests_Init_Sync: XCTestCase {
         let testSdkKey = OTUtils.randomSdkKey  // unique but consistent with registry + start
         
         let handler = FakeDatafileHandler(mode: .failure)
-        HandlerRegistryService.shared.registerBinding(binder: Binder(service: OPTDatafileHandler.self).sdkKey(key: testSdkKey).using(instance: handler).to(factory: FakeDatafileHandler.init).reInitializeStrategy(strategy: .reUse).singetlon())
-        
-        let optimizely = OptimizelyClient(sdkKey: testSdkKey)
+        let optimizely = OptimizelyClient(sdkKey: testSdkKey,
+                                          datafileHandler: handler)
 
         try! optimizely.start(datafile: datafile,
                               doUpdateConfigOnNewDatafile: true)
@@ -115,9 +112,8 @@ class OptimizelyClientTests_Init_Sync: XCTestCase {
         let testSdkKey = OTUtils.randomSdkKey  // unique but consistent with registry + start
         
         let handler = FakeDatafileHandler(mode: .successWithData)
-        HandlerRegistryService.shared.registerBinding(binder: Binder(service: OPTDatafileHandler.self).sdkKey(key: testSdkKey).using(instance: handler).to(factory: FakeDatafileHandler.init).reInitializeStrategy(strategy: .reUse).singetlon())
-        
-        let optimizely = OptimizelyClient(sdkKey: testSdkKey)
+        let optimizely = OptimizelyClient(sdkKey: testSdkKey,
+                                          datafileHandler: handler)
 
         try! optimizely.start(datafile: datafile,
                               doUpdateConfigOnNewDatafile: false)
@@ -130,9 +126,8 @@ class OptimizelyClientTests_Init_Sync: XCTestCase {
         let testSdkKey = OTUtils.randomSdkKey  // unique but consistent with registry + start
         
         let handler = FakeDatafileHandler(mode: .successWithData)
-        HandlerRegistryService.shared.registerBinding(binder: Binder(service: OPTDatafileHandler.self).sdkKey(key: testSdkKey).using(instance: handler).to(factory: FakeDatafileHandler.init).reInitializeStrategy(strategy: .reUse).singetlon())
-        
-        let optimizely = OptimizelyClient(sdkKey: testSdkKey)
+        let optimizely = OptimizelyClient(sdkKey: testSdkKey,
+                                          datafileHandler: handler)
 
         try! optimizely.start(datafile: datafile,
                               doUpdateConfigOnNewDatafile: true,
@@ -147,9 +142,8 @@ class OptimizelyClientTests_Init_Sync: XCTestCase {
         let testSdkKey = OTUtils.randomSdkKey  // unique but consistent with registry + start
         
         let handler = FakeDatafileHandler(mode: .successWithData)
-        HandlerRegistryService.shared.registerBinding(binder: Binder(service: OPTDatafileHandler.self).sdkKey(key: testSdkKey).using(instance: handler).to(factory: FakeDatafileHandler.init).reInitializeStrategy(strategy: .reUse).singetlon())
-        
         let optimizely = OptimizelyClient(sdkKey: testSdkKey,
+                                          datafileHandler: handler,
                                           periodicDownloadInterval: 10)
 
         try! optimizely.start(datafile: datafile,
@@ -163,9 +157,8 @@ class OptimizelyClientTests_Init_Sync: XCTestCase {
         let testSdkKey = OTUtils.randomSdkKey  // unique but consistent with registry + start
         
         let handler = FakeDatafileHandler(mode: .successWithData)
-        HandlerRegistryService.shared.registerBinding(binder: Binder(service: OPTDatafileHandler.self).sdkKey(key: testSdkKey).using(instance: handler).to(factory: FakeDatafileHandler.init).reInitializeStrategy(strategy: .reUse).singetlon())
-        
         let optimizely = OptimizelyClient(sdkKey: testSdkKey,
+                                          datafileHandler: handler,
                                           periodicDownloadInterval: 10)
 
         try! optimizely.start(datafile: datafile,
@@ -185,9 +178,8 @@ class OptimizelyClientTests_Init_Sync: XCTestCase {
         let testSdkKey = OTUtils.randomSdkKey  // unique but consistent with registry + start
         
         let handler = FakeDatafileHandler(mode: .successWithData)
-        HandlerRegistryService.shared.registerBinding(binder: Binder(service: OPTDatafileHandler.self).sdkKey(key: testSdkKey).using(instance: handler).to(factory: FakeDatafileHandler.init).reInitializeStrategy(strategy: .reUse).singetlon())
-        
         let optimizely = OptimizelyClient(sdkKey: testSdkKey,
+                                          datafileHandler: handler,
                                           periodicDownloadInterval: 10)
 
         try! optimizely.start(datafile: datafile,

--- a/Tests/OptimizelyTests-APIs/OptimizelyClientTests_OptimizelyConfig.swift
+++ b/Tests/OptimizelyTests-APIs/OptimizelyClientTests_OptimizelyConfig.swift
@@ -1,5 +1,5 @@
 /****************************************************************************
-* Copyright 2019, Optimizely, Inc. and contributors                        *
+* Copyright 2019,2021, Optimizely, Inc. and contributors                   *
 *                                                                          *
 * Licensed under the Apache License, Version 2.0 (the "License");          *
 * you may not use this file except in compliance with the License.         *
@@ -72,16 +72,10 @@ class OptimizelyClientTests_OptimizelyConfig: XCTestCase {
         }
         
         let badUniqueSdkKey = "badUniqueSdkKey"
-
-        HandlerRegistryService.shared.registerBinding(binder: Binder(service: OPTDatafileHandler.self)
-            .sdkKey(key: badUniqueSdkKey)
-            .using(instance: FakeDatafileHandler())
-            .to(factory: FakeDatafileHandler.init)
-            .reInitializeStrategy(strategy: .reUse)
-            .singetlon())
-        
         var optimizelyConfig: OptimizelyConfig?
-        let optimizely = OptimizelyClient(sdkKey: badUniqueSdkKey, periodicDownloadInterval: 1)
+        let optimizely = OptimizelyClient(sdkKey: badUniqueSdkKey,
+                                          datafileHandler: FakeDatafileHandler(),
+                                          periodicDownloadInterval: 1)
         
         var exp: XCTestExpectation? = expectation(description: "datafile update event")
         _ = optimizely.notificationCenter!.addDatafileChangeNotificationListener { _ in

--- a/Tests/OptimizelyTests-APIs/OptimizelyClientTests_Others.swift
+++ b/Tests/OptimizelyTests-APIs/OptimizelyClientTests_Others.swift
@@ -1,5 +1,5 @@
 /****************************************************************************
-* Copyright 2019-2020, Optimizely, Inc. and contributors                   *
+* Copyright 2019-2021, Optimizely, Inc. and contributors                   *
 *                                                                          *
 * Licensed under the Apache License, Version 2.0 (the "License");          *
 * you may not use this file except in compliance with the License.         *
@@ -342,14 +342,8 @@ class OptimizelyClientTests_Others: XCTestCase {
         }
         
         let handler = FakeDatafileHandler()
-        HandlerRegistryService.shared.registerBinding(binder: Binder(service: OPTDatafileHandler.self)
-            .sdkKey(key: "testFetchedDatafileInvalid")
-            .using(instance: handler)
-            .to(factory: FakeDatafileHandler.init)
-            .reInitializeStrategy(strategy: .reUse)
-            .singetlon())
-        
-        let optimizely = OptimizelyClient(sdkKey: "testFetchedDatafileInvalid")
+        let optimizely = OptimizelyClient(sdkKey: "testFetchedDatafileInvalid",
+                                          datafileHandler: handler)
         
         let exp = expectation(description: "a")
         var failureOccured = false
@@ -378,15 +372,8 @@ class OptimizelyClientTests_Others: XCTestCase {
         }
 
         let handler = FakeDatafileHandler()
-        HandlerRegistryService.shared.registerBinding(binder: Binder(service: OPTDatafileHandler.self)
-            .sdkKey(key: "testHandlerReinitializeOnBackgroundDatafileUpdate")
-            .using(instance: handler)
-            .to(factory: FakeDatafileHandler.init)
-            .reInitializeStrategy(strategy: .reUse)
-            .singetlon())
-
-        
-        let optimizely = OptimizelyClient(sdkKey: "testHandlerReinitializeOnBackgroundDatafileUpdate")
+        let optimizely = OptimizelyClient(sdkKey: "testHandlerReinitializeOnBackgroundDatafileUpdate",
+                                          datafileHandler: handler)
 
         // all handlers before transfer
         

--- a/Tests/OptimizelyTests-Common/DatafileHandlerTests.swift
+++ b/Tests/OptimizelyTests-Common/DatafileHandlerTests.swift
@@ -303,6 +303,22 @@ class DatafileHandlerTests: XCTestCase {
         // finally remove the datafile when complete.
         try? FileManager.default.removeItem(at: fileUrl!)
     }
+    
+    func testSetPeriodicInterval() {
+        let handler = DefaultDatafileHandler()
+        XCTAssert(handler.timers.property!.keys.isEmpty)
+        
+        handler.setPeriodicInterval(sdkKey: "abc", interval: 123)
+        XCTAssert(handler.timers.property!.keys.contains("abc"))
+        XCTAssert(handler.timers.property!["abc"]!.interval == 123)
+    }
+    
+    func testHasPeriodicInterval() {
+        let handler = DefaultDatafileHandler()
+        handler.setPeriodicInterval(sdkKey: "abc", interval: 123)
+        XCTAssertFalse(handler.hasPeriodicInterval(sdkKey: "x"))
+        XCTAssertTrue(handler.hasPeriodicInterval(sdkKey: "abc"))
+    }
 
     func testPeriodicDownload() {
         class FakeDatafileHandler: DefaultDatafileHandler {
@@ -422,10 +438,9 @@ class DatafileHandlerTests: XCTestCase {
         expection.isInverted = true
         
         let handler = FakeDatafileHandler()
-
-        HandlerRegistryService.shared.registerBinding(binder: Binder(service: OPTDatafileHandler.self).sdkKey(key: "testPeriodicDownloadWithOptimizlyClient_SameRevision").using(instance: handler).to(factory: FakeDatafileHandler.init).reInitializeStrategy(strategy: .reUse).singetlon())
-        
-        let optimizely = OptimizelyClient(sdkKey: "testPeriodicDownloadWithOptimizlyClient_SameRevision", periodicDownloadInterval: 1)
+        let optimizely = OptimizelyClient(sdkKey: "testPeriodicDownloadWithOptimizlyClient_SameRevision",
+                                          datafileHandler: handler,
+                                          periodicDownloadInterval: 1)
         
         _ = optimizely.notificationCenter!.addDatafileChangeNotificationListener { _ in
             optimizely.datafileHandler?.stopAllUpdates()
@@ -456,10 +471,9 @@ class DatafileHandlerTests: XCTestCase {
         }
         let expection = XCTestExpectation(description: "Expect 10 periodic downloads")
         let handler = FakeDatafileHandler()
-
-        HandlerRegistryService.shared.registerBinding(binder: Binder(service: OPTDatafileHandler.self).sdkKey(key: "testPeriodicDownloadWithOptimizlyClient_DifferentRevision").using(instance: handler).to(factory: FakeDatafileHandler.init).reInitializeStrategy(strategy: .reUse).singetlon())
-        
-        let optimizely = OptimizelyClient(sdkKey: "testPeriodicDownloadWithOptimizlyClient_DifferentRevision", periodicDownloadInterval: 1)
+        let optimizely = OptimizelyClient(sdkKey: "testPeriodicDownloadWithOptimizlyClient_DifferentRevision",
+                                          datafileHandler: handler,
+                                          periodicDownloadInterval: 1)
         
         var count = 0
 

--- a/Tests/OptimizelyTests-Common/DecisionListenerTests.swift
+++ b/Tests/OptimizelyTests-Common/DecisionListenerTests.swift
@@ -1143,7 +1143,8 @@ class FakeManager: OptimizelyClient {
                   eventDispatcher: OPTEventDispatcher? = nil,
                   userProfileService: OPTUserProfileService? = nil,
                   defaultLogLevel: OptimizelyLogLevel? = nil,
-                  defaultDecideOptions: [OptimizelyDecideOption]? = nil) {
+                  defaultDecideOptions: [OptimizelyDecideOption]? = nil,
+                  defaultDataFileHandler: OPTDatafileHandler? = nil) {
         
         super.init(sdkKey: sdkKey, logger: logger, eventDispatcher: eventDispatcher, userProfileService: userProfileService, defaultLogLevel: defaultLogLevel, defaultDecideOptions: defaultDecideOptions)
         HandlerRegistryService.shared.removeAll()

--- a/Tests/OptimizelyTests-Common/DecisionListenerTests.swift
+++ b/Tests/OptimizelyTests-Common/DecisionListenerTests.swift
@@ -1141,19 +1141,25 @@ class FakeManager: OptimizelyClient {
     override init(sdkKey: String,
                   logger: OPTLogger? = nil,
                   eventDispatcher: OPTEventDispatcher? = nil,
+                  datafileHandler: OPTDatafileHandler? = nil,
                   userProfileService: OPTUserProfileService? = nil,
                   defaultLogLevel: OptimizelyLogLevel? = nil,
-                  defaultDecideOptions: [OptimizelyDecideOption]? = nil,
-                  defaultDataFileHandler: OPTDatafileHandler? = nil) {
+                  defaultDecideOptions: [OptimizelyDecideOption]? = nil) {
         
-        super.init(sdkKey: sdkKey, logger: logger, eventDispatcher: eventDispatcher, userProfileService: userProfileService, defaultLogLevel: defaultLogLevel, defaultDecideOptions: defaultDecideOptions)
+        super.init(sdkKey: sdkKey,
+                   logger: logger,
+                   eventDispatcher: eventDispatcher,
+                   datafileHandler: datafileHandler,
+                   userProfileService: userProfileService,
+                   defaultLogLevel: defaultLogLevel,
+                   defaultDecideOptions: defaultDecideOptions)
         HandlerRegistryService.shared.removeAll()
         
         let userProfileService = userProfileService ?? DefaultUserProfileService()
         self.registerServices(sdkKey: sdkKey,
                               logger: logger ?? DefaultLogger(),
                               eventDispatcher: eventDispatcher ?? DefaultEventDispatcher.sharedInstance,
-                              datafileHandler: DefaultDatafileHandler(),
+                              datafileHandler: datafileHandler ?? DefaultDatafileHandler(),
                               decisionService: FakeDecisionService(userProfileService: userProfileService),
                               notificationCenter: DefaultNotificationCenter())
     }


### PR DESCRIPTION
As consumers of the SDK we have a need to support custom reading and writing of the data files within Optimizely. This PR makes changes to allow for this customization by supporting the injection of an `OPTDatafileHandler` that can implement these custom behaviors.

There are three main areas of this PR:
* Allow for injecting a `OPTDatafileHandler` during the construction of the `OptimizelyClient`. If not supplied then the standard `DefaultDatafileHandler` is utilized. 
* Open the existing implementation of `DefaultDatafileHandler` so that it can be extended by consumers of the SDK and injected via `OptimizelyClient` construction.
* Open the existing implementation of `DataStoreFile` so that it can be easily extended to support custom reading and writing of `Data`, and utilized in extended versions of  `OPTDatafileHandler`/ `DefaultDatafileHandler`.

