### PR TITLE
fix(notification): add support for multiple clients

### DIFF
--- a/DemoSwiftApp/AppDelegate.swift
+++ b/DemoSwiftApp/AppDelegate.swift
@@ -70,10 +70,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 print("Optimizely SDK initiliazation failed: \(error)")
             case .success:
                 print("Optimizely SDK initialized successfully!")
-            #if !os(iOS)
             @unknown default:
                 print("Optimizely SDK initiliazation failed with unknown result")
-            #endif
             }
 
             self.startWithRootViewController()
@@ -129,10 +127,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 print("Optimizely SDK initiliazation failed: \(error)")
             case .success:
                 print("Optimizely SDK initialized successfully!")
-            #if !os(iOS)
             @unknown default:
                 print("Optimizely SDK initiliazation failed with unknown result")
-            #endif
             }
             self.startWithRootViewController()
             

--- a/OptimizelySwiftSDK.xcodeproj/project.pbxproj
+++ b/OptimizelySwiftSDK.xcodeproj/project.pbxproj
@@ -574,6 +574,7 @@
 		6E623F0F253F9045000617D0 /* DecisionInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E623F01253F9045000617D0 /* DecisionInfo.swift */; };
 		6E636B912236C91F00AF3CEF /* Optimizely.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6EBAEB6C21E3FEF800D13AA9 /* Optimizely.framework */; };
 		6E636BA02236C96700AF3CEF /* Optimizely.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6EBAEB6C21E3FEF800D13AA9 /* Optimizely.framework */; };
+		6E6419DA2657059700C49555 /* NotificationCenterTests_MultiClients.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E6419D92657059700C49555 /* NotificationCenterTests_MultiClients.swift */; };
 		6E6BE00B237F547200FE8274 /* optimizely_config_datafile.json in Resources */ = {isa = PBXBuildFile; fileRef = 6E6BE009237F547200FE8274 /* optimizely_config_datafile.json */; };
 		6E6BE00C237F547200FE8274 /* optimizely_config_expected.json in Resources */ = {isa = PBXBuildFile; fileRef = 6E6BE00A237F547200FE8274 /* optimizely_config_expected.json */; };
 		6E7516A622C520D400B2B157 /* DefaultLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E75165F22C520D400B2B157 /* DefaultLogger.swift */; };
@@ -1850,6 +1851,7 @@
 		6E623F01253F9045000617D0 /* DecisionInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecisionInfo.swift; sourceTree = "<group>"; };
 		6E636B8C2236C91F00AF3CEF /* OptimizelyTests-APIs-iOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "OptimizelyTests-APIs-iOS.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		6E636B9B2236C96700AF3CEF /* OptimizelyTests-Legacy-iOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "OptimizelyTests-Legacy-iOS.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		6E6419D92657059700C49555 /* NotificationCenterTests_MultiClients.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationCenterTests_MultiClients.swift; sourceTree = "<group>"; };
 		6E6BE009237F547200FE8274 /* optimizely_config_datafile.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = optimizely_config_datafile.json; sourceTree = "<group>"; };
 		6E6BE00A237F547200FE8274 /* optimizely_config_expected.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = optimizely_config_expected.json; sourceTree = "<group>"; };
 		6E75165F22C520D400B2B157 /* DefaultLogger.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DefaultLogger.swift; sourceTree = "<group>"; };
@@ -2236,6 +2238,7 @@
 				6E474C8C263C889E00ABDFF8 /* UserProfileServiceTests_MultiClients.swift */,
 				6EE591192649CF640013AD66 /* LoggerTests_MultiClients.swift */,
 				6EE5918D264AF44B0013AD66 /* HandlerRegistryServiceTests_MultiClients.swift */,
+				6E6419D92657059700C49555 /* NotificationCenterTests_MultiClients.swift */,
 			);
 			path = "OptimizelyTests-MultiClients";
 			sourceTree = "<group>";
@@ -3718,6 +3721,7 @@
 				6E424D0726324B620081004A /* Event.swift in Sources */,
 				6E424D0826324B620081004A /* ProjectConfig.swift in Sources */,
 				6E424D0926324B620081004A /* FeatureVariable.swift in Sources */,
+				6E6419DA2657059700C49555 /* NotificationCenterTests_MultiClients.swift in Sources */,
 				6E424D0A26324B620081004A /* Rollout.swift in Sources */,
 				6E2D5DAE26338CA00002077F /* AtomicDictionaryTests.swift in Sources */,
 				6E424D0B26324B620081004A /* Variation.swift in Sources */,

--- a/Sources/Utils/HandlerRegistryService.swift
+++ b/Sources/Utils/HandlerRegistryService.swift
@@ -30,7 +30,7 @@ class HandlerRegistryService {
     
     func registerBinding(binder: BinderProtocol) {
         let sk = ServiceKey(service: "\(type(of: binder.service))", sdkKey: binder.sdkKey)
-        binders.performAtomic{ prop in
+        binders.performAtomic { prop in
             if prop[sk] == nil {
                 prop[sk] = binder
             }
@@ -46,7 +46,7 @@ class HandlerRegistryService {
         let binderToUse = binders.property?[sk]
         
         func updateBinder(b: BinderProtocol) {
-            binders.performAtomic{ prop in
+            binders.performAtomic { prop in
                 prop[sk] = b
             }
         }

--- a/Tests/OptimizelyTests-Common/NotificationCenterTests.swift
+++ b/Tests/OptimizelyTests-Common/NotificationCenterTests.swift
@@ -56,63 +56,6 @@ class NotificationCenterTests: XCTestCase {
         super.tearDown()
     }
     
-    func sendActivate() {
-        notificationCenter.sendNotifications(type: NotificationType.activate.rawValue, args: [experiment!, "userId", nil, variation!, ["url": "https://url.com/", "body": Data()]])
-    }
-
-    func sendTrack() {
-        notificationCenter.sendNotifications(type: NotificationType.track.rawValue, args: ["eventKey", "userId", nil, nil, ["url": "https://url.com/", "body": Data()]])
-    }
-
-    func sendDecision() {
-        notificationCenter.sendNotifications(type: NotificationType.decision.rawValue, args: [Constants.DecisionType.featureVariable.rawValue, "userId", nil, ["url": "https://url.com/", "body": Data()]])
-    }
-
-    func sendDatafileChange() {
-        notificationCenter.sendNotifications(type: NotificationType.datafileChange.rawValue, args: [Data()])
-    }
-    
-    func sendLogEvent() {
-        notificationCenter.sendNotifications(type: NotificationType.logEvent.rawValue, args: ["https://url.com/", [:]])
-    }
-    
-    func addActivateListener() -> Int? {
-        let id = notificationCenter.addActivateNotificationListener { (_, _, _, _, _) in
-            self.called = true
-        }
-        return id
-    }
-    
-    func addTrackListener() -> Int? {
-        let id = notificationCenter.addTrackNotificationListener { (_, _, _, _, _) in
-            self.called = true
-        }
-        return id
-    }
-    
-    func addDecisionListener() -> Int? {
-        let id = notificationCenter.addDecisionNotificationListener { (_, _, _, _) in
-            self.called = true
-        }
-        return id
-    }
-    
-    func addDatafileChangeListener() -> Int? {
-        let id = notificationCenter.addDatafileChangeNotificationListener { (_) in
-            self.called = true
-        }
-        return id
-    }
-    
-    func addLogEventListener() -> Int? {
-        let id = notificationCenter.addLogEventNotificationListener { (_, _) in
-            self.called = true
-        }
-        return id
-    }
-
-    
-
     func testNotificationCenterAddRemoveActivate() {
         called = false
         
@@ -365,4 +308,61 @@ class NotificationCenterTests: XCTestCase {
         XCTAssertFalse(called)
     }
     
+    // MARK: - Utils
+
+    func sendActivate() {
+        notificationCenter.sendNotifications(type: NotificationType.activate.rawValue, args: [experiment!, "userId", nil, variation!, ["url": "https://url.com/", "body": Data()]])
+    }
+
+    func sendTrack() {
+        notificationCenter.sendNotifications(type: NotificationType.track.rawValue, args: ["eventKey", "userId", nil, nil, ["url": "https://url.com/", "body": Data()]])
+    }
+
+    func sendDecision() {
+        notificationCenter.sendNotifications(type: NotificationType.decision.rawValue, args: [Constants.DecisionType.featureVariable.rawValue, "userId", nil, ["url": "https://url.com/", "body": Data()]])
+    }
+
+    func sendDatafileChange() {
+        notificationCenter.sendNotifications(type: NotificationType.datafileChange.rawValue, args: [Data()])
+    }
+    
+    func sendLogEvent() {
+        notificationCenter.sendNotifications(type: NotificationType.logEvent.rawValue, args: ["https://url.com/", [:]])
+    }
+    
+    func addActivateListener() -> Int? {
+        let id = notificationCenter.addActivateNotificationListener { (_, _, _, _, _) in
+            self.called = true
+        }
+        return id
+    }
+    
+    func addTrackListener() -> Int? {
+        let id = notificationCenter.addTrackNotificationListener { (_, _, _, _, _) in
+            self.called = true
+        }
+        return id
+    }
+    
+    func addDecisionListener() -> Int? {
+        let id = notificationCenter.addDecisionNotificationListener { (_, _, _, _) in
+            self.called = true
+        }
+        return id
+    }
+    
+    func addDatafileChangeListener() -> Int? {
+        let id = notificationCenter.addDatafileChangeNotificationListener { (_) in
+            self.called = true
+        }
+        return id
+    }
+    
+    func addLogEventListener() -> Int? {
+        let id = notificationCenter.addLogEventNotificationListener { (_, _) in
+            self.called = true
+        }
+        return id
+    }
+
 }

--- a/Tests/OptimizelyTests-MultiClients/NotificationCenterTests_MultiClients.swift
+++ b/Tests/OptimizelyTests-MultiClients/NotificationCenterTests_MultiClients.swift
@@ -1,0 +1,250 @@
+//
+// Copyright 2021, Optimizely, Inc. and contributors 
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");  
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at   
+// 
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import XCTest
+
+class NotificationCenterTests_MultiClients: XCTestCase {
+    
+    let notificationCenter = DefaultNotificationCenter()
+    let lock = DispatchQueue(label: "notif-lock")
+    var counter = NotificationsCounter()
+
+    func testConcurrentSend() {
+        let numThreads = 10
+        let numEventsPerThread = 100
+        
+        counter = NotificationsCounter()
+        
+        _ = self.addTrackListener()
+        _ = self.addDecisionListener()
+        _ = self.addDatafileChangeListener()
+        _ = self.addLogEventListener()
+
+        let result = OTUtils.runConcurrent(count: numThreads) { thIdx in
+            (0..<numEventsPerThread).forEach { idx in
+                self.sendTrack()
+                self.sendDecision()
+                self.sendDatafileChange()
+                self.sendLogEvent()
+            }
+        }
+        
+        XCTAssertTrue(result, "Concurrent tasks timed out")
+        
+        self.lock.sync {}
+
+        XCTAssertEqual(counter.activate, 0)
+        XCTAssertEqual(counter.track, numThreads * numEventsPerThread)
+        XCTAssertEqual(counter.decision, numThreads * numEventsPerThread)
+        XCTAssertEqual(counter.datafileChange, numThreads * numEventsPerThread)
+        XCTAssertEqual(counter.logEvent, numThreads * numEventsPerThread)
+    }
+    
+    func testConcurrentAdd() {
+        let numThreads = 10
+        let numEventsPerThread = 100
+        
+        counter = NotificationsCounter()
+        
+        let result = OTUtils.runConcurrent(count: numThreads) { thIdx in
+            (0..<numEventsPerThread).forEach { idx in
+                _ = self.addTrackListener()
+                _ = self.addDecisionListener()
+                _ = self.addDatafileChangeListener()
+                _ = self.addLogEventListener()
+            }
+        }
+        
+        XCTAssertTrue(result, "Concurrent tasks timed out")
+        
+        self.sendTrack()
+        self.sendDecision()
+        self.sendDatafileChange()
+        self.sendLogEvent()
+
+        self.lock.sync {}
+
+        XCTAssertEqual(counter.activate, 0)
+        XCTAssertEqual(counter.track, numThreads * numEventsPerThread)
+        XCTAssertEqual(counter.decision, numThreads * numEventsPerThread)
+        XCTAssertEqual(counter.datafileChange, numThreads * numEventsPerThread)
+        XCTAssertEqual(counter.logEvent, numThreads * numEventsPerThread)
+    }
+    
+    func testConcurrentAddRemove() {
+        let numThreads = 10
+        let numEventsPerThread = 100
+        
+        counter = NotificationsCounter()
+        
+        let result = OTUtils.runConcurrent(count: numThreads) { thIdx in
+            (0..<numEventsPerThread).forEach { idx in
+                _ = self.addTrackListener()
+                _ = self.addDecisionListener()
+                let idDatafileChange = self.addDatafileChangeListener()
+                let idLogEvent = self.addLogEventListener()
+                
+                self.notificationCenter.removeNotificationListener(notificationId: idDatafileChange!)
+                self.notificationCenter.removeNotificationListener(notificationId: idLogEvent!)
+            }
+        }
+        
+        XCTAssertTrue(result, "Concurrent tasks timed out")
+
+        self.sendTrack()
+        self.sendDecision()
+        self.sendDatafileChange()
+        self.sendLogEvent()
+
+        self.lock.sync {}
+        
+        XCTAssertEqual(counter.activate, 0)
+        XCTAssertEqual(counter.track, numThreads * numEventsPerThread)
+        XCTAssertEqual(counter.decision, numThreads * numEventsPerThread)
+        XCTAssertEqual(counter.datafileChange, 0)
+        XCTAssertEqual(counter.logEvent, 0)
+    }
+    
+    func testConcurrentAddClear() {
+        let numThreads = 10
+        let numEventsPerThread = 100
+        
+        counter = NotificationsCounter()
+        
+        let result = OTUtils.runConcurrent(count: numThreads) { thIdx in
+            (0..<numEventsPerThread).forEach { idx in
+                _ = self.addTrackListener()
+                _ = self.addDecisionListener()
+                _ = self.addDatafileChangeListener()
+                _ = self.addLogEventListener()
+                
+                self.notificationCenter.clearNotificationListeners(type: .track)
+                self.notificationCenter.clearNotificationListeners(type: .decision)
+            }
+        }
+        
+        XCTAssertTrue(result, "Concurrent tasks timed out")
+
+        self.sendTrack()
+        self.sendDecision()
+        self.sendDatafileChange()
+        self.sendLogEvent()
+
+        self.lock.sync {}
+        
+        XCTAssertEqual(counter.activate, 0)
+        XCTAssertEqual(counter.track, 0)
+        XCTAssertEqual(counter.decision, 0)
+        XCTAssertEqual(counter.datafileChange, numThreads * numEventsPerThread)
+        XCTAssertEqual(counter.logEvent, numThreads * numEventsPerThread)
+    }
+    
+    func testConcurrentAddClearAll() {
+        let numThreads = 10
+        let numEventsPerThread = 100
+        
+        counter = NotificationsCounter()
+        
+        let result = OTUtils.runConcurrent(count: numThreads) { thIdx in
+            (0..<numEventsPerThread).forEach { idx in
+                _ = self.addTrackListener()
+                _ = self.addDecisionListener()
+                _ = self.addDatafileChangeListener()
+                _ = self.addLogEventListener()
+                
+                self.notificationCenter.clearAllNotificationListeners()
+            }
+        }
+        
+        XCTAssertTrue(result, "Concurrent tasks timed out")
+
+        self.sendTrack()
+        self.sendDecision()
+        self.sendDatafileChange()
+        self.sendLogEvent()
+
+        self.lock.sync {}
+        
+        XCTAssertEqual(counter.activate, 0)
+        XCTAssertEqual(counter.track, 0)
+        XCTAssertEqual(counter.decision, 0)
+        XCTAssertEqual(counter.datafileChange, 0)
+        XCTAssertEqual(counter.logEvent, 0)
+    }
+
+    // MARK: - Utils
+    
+    struct NotificationsCounter {
+        var activate = 0
+        var track = 0
+        var decision = 0
+        var datafileChange = 0
+        var logEvent = 0
+    }
+    
+    func sendTrack() {
+        notificationCenter.sendNotifications(type: NotificationType.track.rawValue, args: ["eventKey", "userId", nil, nil, ["url": "https://url.com/", "body": Data()]])
+    }
+
+    func sendDecision() {
+        notificationCenter.sendNotifications(type: NotificationType.decision.rawValue, args: [Constants.DecisionType.featureVariable.rawValue, "userId", nil, ["url": "https://url.com/", "body": Data()]])
+    }
+
+    func sendDatafileChange() {
+        notificationCenter.sendNotifications(type: NotificationType.datafileChange.rawValue, args: [Data()])
+    }
+    
+    func sendLogEvent() {
+        notificationCenter.sendNotifications(type: NotificationType.logEvent.rawValue, args: ["https://url.com/", [:]])
+    }
+    
+    func addTrackListener() -> Int? {
+        let id = notificationCenter.addTrackNotificationListener { (_, _, _, _, _) in
+            self.lock.async {
+                self.counter.track += 1
+            }
+        }
+        return id
+    }
+    
+    func addDecisionListener() -> Int? {
+        let id = notificationCenter.addDecisionNotificationListener { (_, _, _, _) in
+            self.lock.async {
+                self.counter.decision += 1
+            }
+        }
+        return id
+    }
+    
+    func addDatafileChangeListener() -> Int? {
+        let id = notificationCenter.addDatafileChangeNotificationListener { (_) in
+            self.lock.async {
+                self.counter.datafileChange += 1
+            }
+        }
+        return id
+    }
+    
+    func addLogEventListener() -> Int? {
+        let id = notificationCenter.addLogEventNotificationListener { (_, _) in
+            self.lock.async {
+                self.counter.logEvent += 1
+            }
+        }
+        return id
+    }
+
+}

--- a/Tests/OptimizelyTests-MultiClients/NotificationCenterTests_MultiClients.swift
+++ b/Tests/OptimizelyTests-MultiClients/NotificationCenterTests_MultiClients.swift
@@ -98,7 +98,9 @@ class NotificationCenterTests_MultiClients: XCTestCase {
                 let idLogEvent = self.addLogEventListener()
                 
                 self.notificationCenter.removeNotificationListener(notificationId: idDatafileChange!)
-                self.notificationCenter.removeNotificationListener(notificationId: idLogEvent!)
+                if idx % 2 == 0 {
+                    self.notificationCenter.removeNotificationListener(notificationId: idLogEvent!)
+                }
             }
         }
         
@@ -115,7 +117,7 @@ class NotificationCenterTests_MultiClients: XCTestCase {
         XCTAssertEqual(counter.track, numThreads * numEventsPerThread)
         XCTAssertEqual(counter.decision, numThreads * numEventsPerThread)
         XCTAssertEqual(counter.datafileChange, 0)
-        XCTAssertEqual(counter.logEvent, 0)
+        XCTAssertEqual(counter.logEvent, numThreads * numEventsPerThread / 2)
     }
     
     func testConcurrentAddClear() {


### PR DESCRIPTION
Fix NotificationCenter to support multiple clients (sdkKeys).

- full thread-safety for additional concurrency requirements
- no resource conflicts for multiple sdkKeys support