### PR TITLE
Fix invalidate url sessions

### DIFF
--- a/Sources/Customization/DefaultDatafileHandler.swift
+++ b/Sources/Customization/DefaultDatafileHandler.swift
@@ -69,6 +69,8 @@ open class DefaultDatafileHandler: OPTDatafileHandler {
             }
             
             let session = self.getSession(resourceTimeoutInterval: resourceTimeoutInterval)
+            // without this the URLSession will leak, see docs on URLSession and https://stackoverflow.com/questions/67318867
+            defer { session.finishTasksAndInvalidate() }
             
             guard let request = self.getRequest(sdkKey: sdkKey) else { return }
             

--- a/Sources/Customization/DefaultEventDispatcher.swift
+++ b/Sources/Customization/DefaultEventDispatcher.swift
@@ -184,6 +184,9 @@ open class DefaultEventDispatcher: BackgroundingCallbacks, OPTEventDispatcher {
         }
         
         let session = getSession()
+        // without this the URLSession will leak, see docs on URLSession and https://stackoverflow.com/questions/67318867
+        defer { session.finishTasksAndInvalidate() }
+        
         var request = URLRequest(url: event.url)
         request.httpMethod = "POST"
         request.httpBody = event.body

--- a/Tests/OptimizelyTests-APIs/OptimizelyClientTests_DatafileHandler.swift
+++ b/Tests/OptimizelyTests-APIs/OptimizelyClientTests_DatafileHandler.swift
@@ -28,6 +28,7 @@ class OptimizelyClientTests_DatafileHandler: XCTestCase {
     override func tearDown() {
         OTUtils.clearAllBinders()
         OTUtils.clearAllTestStorage(including: sdkKey)
+        XCTAssertEqual(MockUrlSession.validSessions, 0, "all MockUrlSession must be invalidated")
     }
 
     func testOptimizelyClientWithCachedDatafile() {

--- a/Tests/OptimizelyTests-Common/DatafileHandlerTests.swift
+++ b/Tests/OptimizelyTests-Common/DatafileHandlerTests.swift
@@ -332,13 +332,12 @@ class DatafileHandlerTests: XCTestCase {
         var localFileUrl:URL?
         // override getSession to return our own session.
         override func getSession(resourceTimeoutInterval: Double?) -> URLSession {
-            var session = MockUrlSession(statusCode: 200)
-            // will return 500
             if let _ = resourceTimeoutInterval {
-                session = MockUrlSession(withError: true)
+                // will return 500
+                return MockUrlSession(withError: true)
+            } else {
+                return MockUrlSession(statusCode: 200)
             }
-            
-            return session
         }
     }
 

--- a/Tests/OptimizelyTests-Common/DatafileHandlerTests.swift
+++ b/Tests/OptimizelyTests-Common/DatafileHandlerTests.swift
@@ -28,6 +28,7 @@ class DatafileHandlerTests: XCTestCase {
     override func tearDown() {
         OTUtils.clearAllBinders()
         OTUtils.clearAllTestStorage(including: sdkKey)
+        XCTAssertEqual(MockUrlSession.validSessions, 0, "all MockUrlSession must be invalidated")
     }
 
     func testDatafileHandler() {

--- a/Tests/OptimizelyTests-Common/EventDispatcherTests.swift
+++ b/Tests/OptimizelyTests-Common/EventDispatcherTests.swift
@@ -26,6 +26,7 @@ class EventDispatcherTests: XCTestCase {
 
     override func tearDown() {
         OTUtils.clearAllEventQueues()
+        XCTAssertEqual(MockUrlSession.validSessions, 0, "all MockUrlSession must be invalidated")
     }
 
     func testDefaultDispatcher() {

--- a/Tests/OptimizelyTests-Common/NetworkReachabilityTests.swift
+++ b/Tests/OptimizelyTests-Common/NetworkReachabilityTests.swift
@@ -26,6 +26,7 @@ class NetworkReachabilityTests: XCTestCase {
 
     override func tearDown() {
         OTUtils.clearAllTestStorage(including: sdkKey)
+        XCTAssertEqual(MockUrlSession.validSessions, 0, "all MockUrlSession must be invalidated")
     }
 
     // Reachability (NWPathMonitor) can be tested with real devices only (no simulators), but framework logic testing is not supported on devices.

--- a/Tests/OptimizelyTests-MultiClients/DatafileHandlerTests_MultiClients.swift
+++ b/Tests/OptimizelyTests-MultiClients/DatafileHandlerTests_MultiClients.swift
@@ -32,6 +32,7 @@ class DatafileHandlerTests_MultiClients: XCTestCase {
     override func tearDown() {
         OTUtils.clearAllBinders()
         OTUtils.clearAllTestStorage()
+        XCTAssertEqual(MockUrlSession.validSessions, 0, "all MockUrlSession must be invalidated")
     }
     
     // MARK: - downloadDatafile

--- a/Tests/OptimizelyTests-MultiClients/MultiClientsTests.swift
+++ b/Tests/OptimizelyTests-MultiClients/MultiClientsTests.swift
@@ -28,6 +28,7 @@ class MultiClientsTests: XCTestCase {
 
     override func tearDown() {
         OTUtils.clearAllTestStorage(including: testSdkKeyBasename)
+        XCTAssertEqual(MockUrlSession.validSessions, 0, "all MockUrlSession must be invalidated")
     }
     
     func testMultiClients() {

--- a/Tests/TestUtils/MockUrlSession.swift
+++ b/Tests/TestUtils/MockUrlSession.swift
@@ -22,6 +22,7 @@ import Foundation
 // the response also includes the url for the data download.
 // the cdn url is used to get the datafile if the datafile is not in cache
 class MockUrlSession: URLSession {
+    static var validSessions = 0
     var statusCode: Int
     var withError: Bool
     var localResponseData: String?
@@ -53,6 +54,7 @@ class MockUrlSession: URLSession {
     }
 
     init(handler: MockDatafileHandler? = nil, statusCode: Int = 0, withError: Bool = false, localResponseData: String? = nil) {
+        Self.validSessions += 1
         self.handler = handler
         self.statusCode = statusCode
         self.withError = withError
@@ -60,6 +62,7 @@ class MockUrlSession: URLSession {
     }
    
     init(handler: MockDatafileHandler? = nil, settingsMap: [String: (Int, Bool)]) {
+        Self.validSessions += 1
         self.handler = handler
         self.statusCode = 0
         self.withError = false
@@ -109,4 +112,7 @@ class MockUrlSession: URLSession {
         }
     }
 
+    override func finishTasksAndInvalidate() {
+        Self.validSessions -= 1
+    }
 }


### PR DESCRIPTION
## Summary

According to Apple, [we should avoid creating instances of `URLSession`](https://developer.apple.com/videos/play/wwdc2017-709/?time=1977):

> But if you do allocate URLSessions dynamically, remember to clean up afterwards. Either finish tasks and invalidate or invalidate and cancel. But if you don't clean up, you'll leak memory.

## Detail

In the project I'm working on, we got this weird error:
```
Error Domain=NSPOSIXErrorDomain
Code=28 
“No space left on device” 
UserInfo={_kCFStreamErrorCodeKey=28, _kCFStreamErrorDomainKey=1}
```

Googling that lead us to discover that "space" here is probably not referring to RAM or disk space, but that as of iOS 14 this error shows up when you have too many URLSessions going at once:

* [Stack Overflow](https://stackoverflow.com/questions/67318867/error-domain-nsposixerrordomain-code-28-no-space-left-on-device-userinfo-kcf)
* [Apple dev forums thread](https://developer.apple.com/forums/thread/679107)

## Test plan
- Count instances of `MockUrlSession` that were created but not called `finishTasksAndInvalidate()` before it's destroyed.
- Assert that all `MockUrlSession` are invalidated on every `tearDown` that uses `MockUrlSession`

## Issues
- N/A
