### PR TITLE
fix(ProjectConfig): remove sources of race conditions in ProjectConfig

### DIFF
--- a/DemoObjCApp/DemoObjcApp.xcodeproj/xcshareddata/xcschemes/DemoObjciOS.xcscheme
+++ b/DemoObjCApp/DemoObjcApp.xcodeproj/xcshareddata/xcschemes/DemoObjciOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1250"
+   LastUpgradeVersion = "1320"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/DemoObjCApp/DemoObjcApp.xcodeproj/xcshareddata/xcschemes/DemoObjctvOS.xcscheme
+++ b/DemoObjCApp/DemoObjcApp.xcodeproj/xcshareddata/xcschemes/DemoObjctvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1250"
+   LastUpgradeVersion = "1320"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/DemoSwiftApp/DemoSwiftApp.xcodeproj/xcshareddata/xcschemes/DemoSwiftiOS.xcscheme
+++ b/DemoSwiftApp/DemoSwiftApp.xcodeproj/xcshareddata/xcschemes/DemoSwiftiOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1250"
+   LastUpgradeVersion = "1320"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/DemoSwiftApp/DemoSwiftApp.xcodeproj/xcshareddata/xcschemes/DemoSwifttvOS.xcscheme
+++ b/DemoSwiftApp/DemoSwiftApp.xcodeproj/xcshareddata/xcschemes/DemoSwifttvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1250"
+   LastUpgradeVersion = "1320"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/DemoSwiftApp/DemoSwiftApp.xcodeproj/xcshareddata/xcschemes/DemoSwiftwatchOS.xcscheme
+++ b/DemoSwiftApp/DemoSwiftApp.xcodeproj/xcshareddata/xcschemes/DemoSwiftwatchOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1240"
+   LastUpgradeVersion = "1320"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/OptimizelySwiftSDK.xcodeproj/project.pbxproj
+++ b/OptimizelySwiftSDK.xcodeproj/project.pbxproj
@@ -1723,6 +1723,22 @@
 		75C71A4625E454460084187E /* SDKVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E75167322C520D400B2B157 /* SDKVersion.swift */; };
 		75C71C3925E45A2B0084187E /* WatchBackgroundNotifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75C71C3825E45A2B0084187E /* WatchBackgroundNotifier.swift */; };
 		7B4A4C11E9A503E68F2FCC69 /* libPods-OptimizelyTests-Common-iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 33BE1D8564FE425132F728C0 /* libPods-OptimizelyTests-Common-iOS.a */; };
+		84E7ABBB27D2A1F100447CAE /* ThreadSafeLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84E7ABBA27D2A1F100447CAE /* ThreadSafeLogger.swift */; };
+		84E7ABBC27D2A1F100447CAE /* ThreadSafeLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84E7ABBA27D2A1F100447CAE /* ThreadSafeLogger.swift */; };
+		84E7ABBD27D2A1F100447CAE /* ThreadSafeLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84E7ABBA27D2A1F100447CAE /* ThreadSafeLogger.swift */; };
+		84E7ABBE27D2A1F100447CAE /* ThreadSafeLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84E7ABBA27D2A1F100447CAE /* ThreadSafeLogger.swift */; };
+		84E7ABBF27D2A1F100447CAE /* ThreadSafeLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84E7ABBA27D2A1F100447CAE /* ThreadSafeLogger.swift */; };
+		84E7ABC027D2A1F100447CAE /* ThreadSafeLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84E7ABBA27D2A1F100447CAE /* ThreadSafeLogger.swift */; };
+		84E7ABC127D2A1F100447CAE /* ThreadSafeLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84E7ABBA27D2A1F100447CAE /* ThreadSafeLogger.swift */; };
+		84E7ABC227D2A1F100447CAE /* ThreadSafeLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84E7ABBA27D2A1F100447CAE /* ThreadSafeLogger.swift */; };
+		84E7ABC327D2A1F100447CAE /* ThreadSafeLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84E7ABBA27D2A1F100447CAE /* ThreadSafeLogger.swift */; };
+		84E7ABC427D2A1F100447CAE /* ThreadSafeLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84E7ABBA27D2A1F100447CAE /* ThreadSafeLogger.swift */; };
+		84E7ABC527D2A1F100447CAE /* ThreadSafeLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84E7ABBA27D2A1F100447CAE /* ThreadSafeLogger.swift */; };
+		84E7ABC627D2A1F100447CAE /* ThreadSafeLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84E7ABBA27D2A1F100447CAE /* ThreadSafeLogger.swift */; };
+		84E7ABC727D2A1F100447CAE /* ThreadSafeLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84E7ABBA27D2A1F100447CAE /* ThreadSafeLogger.swift */; };
+		84E7ABC827D2A1F100447CAE /* ThreadSafeLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84E7ABBA27D2A1F100447CAE /* ThreadSafeLogger.swift */; };
+		84E7ABC927D2A1F100447CAE /* ThreadSafeLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84E7ABBA27D2A1F100447CAE /* ThreadSafeLogger.swift */; };
+		84E7ABCA27D2A1F100447CAE /* ThreadSafeLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84E7ABBA27D2A1F100447CAE /* ThreadSafeLogger.swift */; };
 		BD1C3E8524E4399C0084B4DA /* SemanticVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B97DD93249D327F003DE606 /* SemanticVersion.swift */; };
 		BD64853C2491474500F30986 /* Optimizely.h in Headers */ = {isa = PBXBuildFile; fileRef = 6E75167A22C520D400B2B157 /* Optimizely.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BD64853E2491474500F30986 /* Audience.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E75169822C520D400B2B157 /* Audience.swift */; };
@@ -2132,6 +2148,7 @@
 		6EF8DE3024BF7D69008B9488 /* DecisionReasons.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DecisionReasons.swift; sourceTree = "<group>"; };
 		75C719BB25E4519B0084187E /* Optimizely.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Optimizely.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		75C71C3825E45A2B0084187E /* WatchBackgroundNotifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchBackgroundNotifier.swift; sourceTree = "<group>"; };
+		84E7ABBA27D2A1F100447CAE /* ThreadSafeLogger.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThreadSafeLogger.swift; sourceTree = "<group>"; };
 		BD6485812491474500F30986 /* Optimizely.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Optimizely.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C78CAF572445AD8D009FE876 /* OptimizelyJSON.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptimizelyJSON.swift; sourceTree = "<group>"; };
 		C78CAF652446DB91009FE876 /* OptimizelyClientTests_OptimizelyJSON.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptimizelyClientTests_OptimizelyJSON.swift; sourceTree = "<group>"; };
@@ -2413,6 +2430,7 @@
 				6E75166E22C520D400B2B157 /* MurmurHash3.swift */,
 				6E75166F22C520D400B2B157 /* HandlerRegistryService.swift */,
 				6E75167022C520D400B2B157 /* LogMessage.swift */,
+				84E7ABBA27D2A1F100447CAE /* ThreadSafeLogger.swift */,
 				6E75167122C520D400B2B157 /* AtomicProperty.swift */,
 				6E424BDC263228E90081004A /* AtomicArray.swift */,
 				6E424BFB263228FD0081004A /* AtomicDictionary.swift */,
@@ -3761,6 +3779,7 @@
 				6E14CD732423F96F00010234 /* OptimizelyResult.swift in Sources */,
 				6E14CD7E2423F98D00010234 /* DefaultNotificationCenter.swift in Sources */,
 				6E14CD8B2423F9A100010234 /* UserAttribute.swift in Sources */,
+				84E7ABC227D2A1F100447CAE /* ThreadSafeLogger.swift in Sources */,
 				6E14CD702423F94800010234 /* OptimizelyLogLevel.swift in Sources */,
 				6E14CD782423F97E00010234 /* DefaultEventDispatcher.swift in Sources */,
 				6E8A3D4B2637408500DAEA13 /* MockDatafileHandler.swift in Sources */,
@@ -3919,6 +3938,7 @@
 				6E424CBD26324B1D0081004A /* LogMessage.swift in Sources */,
 				6E424CBE26324B1D0081004A /* AtomicProperty.swift in Sources */,
 				6E2F8AFF26B22E8000DCEEB9 /* ConcurrencyTests_SingleClient.swift in Sources */,
+				84E7ABC127D2A1F100447CAE /* ThreadSafeLogger.swift in Sources */,
 				6E424CBF26324B1D0081004A /* AtomicArray.swift in Sources */,
 				6E424CC026324B1D0081004A /* AtomicDictionary.swift in Sources */,
 				6E5D12212638DDF4000ABFC3 /* MockEventDispatcher.swift in Sources */,
@@ -3942,6 +3962,7 @@
 				6EF8DE3224BF7D69008B9488 /* DecisionReasons.swift in Sources */,
 				6E75192522C520D500B2B157 /* DataStoreQueueStack.swift in Sources */,
 				6E7516FB22C520D400B2B157 /* OptimizelyLogLevel.swift in Sources */,
+				84E7ABBC27D2A1F100447CAE /* ThreadSafeLogger.swift in Sources */,
 				6E75184D22C520D400B2B157 /* ProjectConfig.swift in Sources */,
 				6E623F03253F9045000617D0 /* DecisionInfo.swift in Sources */,
 				6E75171322C520D400B2B157 /* OptimizelyClient+ObjC.swift in Sources */,
@@ -4026,6 +4047,7 @@
 				6E75177A22C520D400B2B157 /* SDKVersion.swift in Sources */,
 				6E7516C622C520D400B2B157 /* DefaultEventDispatcher.swift in Sources */,
 				6E75189C22C520D400B2B157 /* Experiment.swift in Sources */,
+				84E7ABC727D2A1F100447CAE /* ThreadSafeLogger.swift in Sources */,
 				6E75176222C520D400B2B157 /* AtomicProperty.swift in Sources */,
 				6E75180C22C520D400B2B157 /* DataStoreFile.swift in Sources */,
 				6E8A3D502637408500DAEA13 /* MockDatafileHandler.swift in Sources */,
@@ -4110,6 +4132,7 @@
 				6E7517CC22C520D400B2B157 /* DefaultBucketer.swift in Sources */,
 				6E75178E22C520D400B2B157 /* OptimizelyClient+Extension.swift in Sources */,
 				6E75172E22C520D400B2B157 /* Constants.swift in Sources */,
+				84E7ABC327D2A1F100447CAE /* ThreadSafeLogger.swift in Sources */,
 				6E9B11E022C548A200C22D81 /* OptimizelyClientTests_Group.swift in Sources */,
 				6E75187422C520D400B2B157 /* Variation.swift in Sources */,
 				C78CAFA924486E0A009FE876 /* OptimizelyJSON+ObjC.swift in Sources */,
@@ -4216,6 +4239,7 @@
 				6E623F0B253F9045000617D0 /* DecisionInfo.swift in Sources */,
 				6E75193722C520D500B2B157 /* OPTDataStore.swift in Sources */,
 				6E75191322C520D500B2B157 /* BackgroundingCallbacks.swift in Sources */,
+				84E7ABC627D2A1F100447CAE /* ThreadSafeLogger.swift in Sources */,
 				6E75172522C520D400B2B157 /* OptimizelyResult.swift in Sources */,
 				6E75173122C520D400B2B157 /* Constants.swift in Sources */,
 				6E75184722C520D400B2B157 /* Event.swift in Sources */,
@@ -4330,6 +4354,7 @@
 				6E7517C522C520D400B2B157 /* DefaultDatafileHandler.swift in Sources */,
 				6E75190922C520D500B2B157 /* Attribute.swift in Sources */,
 				6E75177B22C520D400B2B157 /* SDKVersion.swift in Sources */,
+				84E7ABC827D2A1F100447CAE /* ThreadSafeLogger.swift in Sources */,
 				6E7E9B562523F8C6009E4426 /* OptimizelyUserContextTests_Decide_Legacy.swift in Sources */,
 				6EC6DD3C24ABF6990017D296 /* OptimizelyClient+Decide.swift in Sources */,
 				6E75192D22C520D500B2B157 /* DataStoreQueueStack.swift in Sources */,
@@ -4469,6 +4494,7 @@
 				6E75184A22C520D400B2B157 /* Event.swift in Sources */,
 				6E75191622C520D500B2B157 /* BackgroundingCallbacks.swift in Sources */,
 				6E9B11A522C5488300C22D81 /* ConditionHolderTests_Evaluate.swift in Sources */,
+				84E7ABC927D2A1F100447CAE /* ThreadSafeLogger.swift in Sources */,
 				6E9B119122C5488300C22D81 /* EventForDispatchTests.swift in Sources */,
 				6E7517EA22C520D400B2B157 /* DefaultDecisionService.swift in Sources */,
 				6E75171C22C520D400B2B157 /* OptimizelyClient+ObjC.swift in Sources */,
@@ -4633,6 +4659,7 @@
 				6E9B115122C5486E00C22D81 /* NotificationCenterTests.swift in Sources */,
 				6E75184322C520D400B2B157 /* Event.swift in Sources */,
 				6E75193F22C520D500B2B157 /* OPTDecisionService.swift in Sources */,
+				84E7ABC027D2A1F100447CAE /* ThreadSafeLogger.swift in Sources */,
 				6E7516CD22C520D400B2B157 /* OPTLogger.swift in Sources */,
 				6E7517FB22C520D400B2B157 /* DataStoreUserDefaults.swift in Sources */,
 			);
@@ -4699,6 +4726,7 @@
 				6E75184522C520D400B2B157 /* Event.swift in Sources */,
 				6E75191122C520D500B2B157 /* BackgroundingCallbacks.swift in Sources */,
 				6E9B118F22C5488100C22D81 /* ConditionHolderTests_Evaluate.swift in Sources */,
+				84E7ABC427D2A1F100447CAE /* ThreadSafeLogger.swift in Sources */,
 				6E9B117B22C5488100C22D81 /* EventForDispatchTests.swift in Sources */,
 				6E7517E522C520D400B2B157 /* DefaultDecisionService.swift in Sources */,
 				6E75171722C520D400B2B157 /* OptimizelyClient+ObjC.swift in Sources */,
@@ -4805,6 +4833,7 @@
 				6E8A3D4E2637408500DAEA13 /* MockDatafileHandler.swift in Sources */,
 				6E9B11E222C548AF00C22D81 /* OtherTests.swift in Sources */,
 				6E75185E22C520D400B2B157 /* FeatureVariable.swift in Sources */,
+				84E7ABC527D2A1F100447CAE /* ThreadSafeLogger.swift in Sources */,
 				6E7518BE22C520D400B2B157 /* Variable.swift in Sources */,
 				6E7518CA22C520D400B2B157 /* Audience.swift in Sources */,
 				6E75187622C520D400B2B157 /* Variation.swift in Sources */,
@@ -4893,6 +4922,7 @@
 				6E8A3D532637408500DAEA13 /* MockDatafileHandler.swift in Sources */,
 				6E9B11E422C548B100C22D81 /* OtherTests.swift in Sources */,
 				6E75186322C520D400B2B157 /* FeatureVariable.swift in Sources */,
+				84E7ABCA27D2A1F100447CAE /* ThreadSafeLogger.swift in Sources */,
 				6E7518C322C520D400B2B157 /* Variable.swift in Sources */,
 				6E7518CF22C520D400B2B157 /* Audience.swift in Sources */,
 				6E75187B22C520D400B2B157 /* Variation.swift in Sources */,
@@ -4937,6 +4967,7 @@
 				6EF8DE3124BF7D69008B9488 /* DecisionReasons.swift in Sources */,
 				6E7517BC22C520D400B2B157 /* DefaultDatafileHandler.swift in Sources */,
 				6E7516CA22C520D400B2B157 /* OPTLogger.swift in Sources */,
+				84E7ABBB27D2A1F100447CAE /* ThreadSafeLogger.swift in Sources */,
 				6E75182822C520D400B2B157 /* BatchEvent.swift in Sources */,
 				6E623F02253F9045000617D0 /* DecisionInfo.swift in Sources */,
 				6E75184022C520D400B2B157 /* Event.swift in Sources */,
@@ -5021,6 +5052,7 @@
 				6E75177422C520D400B2B157 /* SDKVersion.swift in Sources */,
 				6E7516C022C520D400B2B157 /* DefaultEventDispatcher.swift in Sources */,
 				6E75189622C520D400B2B157 /* Experiment.swift in Sources */,
+				84E7ABBF27D2A1F100447CAE /* ThreadSafeLogger.swift in Sources */,
 				6E75175C22C520D400B2B157 /* AtomicProperty.swift in Sources */,
 				6E75180622C520D400B2B157 /* DataStoreFile.swift in Sources */,
 				6E8A3D482637408500DAEA13 /* MockDatafileHandler.swift in Sources */,
@@ -5169,6 +5201,7 @@
 				75C71A4225E454460084187E /* HandlerRegistryService.swift in Sources */,
 				75C71A4325E454460084187E /* LogMessage.swift in Sources */,
 				75C71A4425E454460084187E /* AtomicProperty.swift in Sources */,
+				84E7ABBE27D2A1F100447CAE /* ThreadSafeLogger.swift in Sources */,
 				75C71A4525E454460084187E /* Utils.swift in Sources */,
 				75C71A4625E454460084187E /* SDKVersion.swift in Sources */,
 			);
@@ -5187,6 +5220,7 @@
 				6EF8DE3324BF7D69008B9488 /* DecisionReasons.swift in Sources */,
 				BD6485432491474500F30986 /* DefaultDatafileHandler.swift in Sources */,
 				BD6485442491474500F30986 /* OPTLogger.swift in Sources */,
+				84E7ABBD27D2A1F100447CAE /* ThreadSafeLogger.swift in Sources */,
 				BD6485452491474500F30986 /* BatchEvent.swift in Sources */,
 				6E623F04253F9045000617D0 /* DecisionInfo.swift in Sources */,
 				BD6485462491474500F30986 /* Event.swift in Sources */,

--- a/OptimizelySwiftSDK.xcodeproj/project.pbxproj
+++ b/OptimizelySwiftSDK.xcodeproj/project.pbxproj
@@ -3124,7 +3124,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 1230;
-				LastUpgradeCheck = 1250;
+				LastUpgradeCheck = 1320;
 				ORGANIZATIONNAME = Optimizely;
 				TargetAttributes = {
 					6E14CD622423F80B00010234 = {

--- a/OptimizelySwiftSDK.xcodeproj/xcshareddata/xcschemes/OptimizelySwiftSDK-iOS.xcscheme
+++ b/OptimizelySwiftSDK.xcodeproj/xcshareddata/xcschemes/OptimizelySwiftSDK-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1250"
+   LastUpgradeVersion = "1320"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/OptimizelySwiftSDK.xcodeproj/xcshareddata/xcschemes/OptimizelySwiftSDK-macOS.xcscheme
+++ b/OptimizelySwiftSDK.xcodeproj/xcshareddata/xcschemes/OptimizelySwiftSDK-macOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1250"
+   LastUpgradeVersion = "1320"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/OptimizelySwiftSDK.xcodeproj/xcshareddata/xcschemes/OptimizelySwiftSDK-tvOS.xcscheme
+++ b/OptimizelySwiftSDK.xcodeproj/xcshareddata/xcschemes/OptimizelySwiftSDK-tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1250"
+   LastUpgradeVersion = "1320"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/OptimizelySwiftSDK.xcodeproj/xcshareddata/xcschemes/OptimizelySwiftSDK-watchOS.xcscheme
+++ b/OptimizelySwiftSDK.xcodeproj/xcshareddata/xcschemes/OptimizelySwiftSDK-watchOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1250"
+   LastUpgradeVersion = "1320"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Sources/Customization/DefaultDatafileHandler.swift
+++ b/Sources/Customization/DefaultDatafileHandler.swift
@@ -21,11 +21,11 @@ open class DefaultDatafileHandler: OPTDatafileHandler {
     public var endPointStringFormat = "https://cdn.optimizely.com/datafiles/%@.json"
     
     // thread-safe lazy logger load (after HandlerRegisterService ready)
-    private var loggerInstance: OPTLogger?
+    private let threadSafeLogger = ThreadSafeLogger()
     var logger: OPTLogger {
-        return OPTLoggerFactory.getLoggerThreadSafe(&loggerInstance)
+        return threadSafeLogger.logger
     }
-        
+
     // the timers for all sdk keys are atomic to allow for thread access.
     var timers = AtomicProperty(property: [String: (timer: Timer?, interval: Int)]())
     

--- a/Sources/Customization/DefaultDatafileHandler.swift
+++ b/Sources/Customization/DefaultDatafileHandler.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2019-2021, Optimizely, Inc. and contributors
+// Copyright 2019-2022, Optimizely, Inc. and contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Sources/Customization/DefaultEventDispatcher.swift
+++ b/Sources/Customization/DefaultEventDispatcher.swift
@@ -38,9 +38,9 @@ open class DefaultEventDispatcher: BackgroundingCallbacks, OPTEventDispatcher {
     }
         
     // thread-safe lazy logger load (after HandlerRegisterService ready)
-    private var loggerInstance: OPTLogger?
+    private let threadSafeLogger = ThreadSafeLogger()
     var logger: OPTLogger {
-        return OPTLoggerFactory.getLoggerThreadSafe(&loggerInstance)
+        return threadSafeLogger.logger
     }
 
     // for dispatching events

--- a/Sources/Customization/Protocols/OPTLogger.swift
+++ b/Sources/Customization/Protocols/OPTLogger.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2019, 2021, Optimizely, Inc. and contributors
+// Copyright 2019, 2021-2022, Optimizely, Inc. and contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Sources/Customization/Protocols/OPTLogger.swift
+++ b/Sources/Customization/Protocols/OPTLogger.swift
@@ -86,22 +86,4 @@ extension OPTLogger {
         return DefaultLogger()
     }
     
-    // thread-safe lazy logger load (after HandlerRegisterService ready)
-    // - "lazy var" is not thread-safe
-    // - call this thread-safe version for types that can be initialized before (for customiziation) or at the same time with OptimizelyClient (so HandlerRegisterService is not ready yet).
-    // - DefaultDatafileHandler, DefaultEventDispatcher, DefaultDecisionService, DefaultBucketer
-
-    static let lock = DispatchQueue(label: "logger")
-    
-    class func getLoggerThreadSafe(_ instance: inout OPTLogger?) -> OPTLogger {
-        var result: OPTLogger?
-        lock.sync {
-            if instance == nil {
-                instance = OPTLoggerFactory.getLogger()
-            }
-            result = instance!
-        }
-        return result!
-    }
-    
 }

--- a/Sources/Data Model/ProjectConfig.swift
+++ b/Sources/Data Model/ProjectConfig.swift
@@ -55,7 +55,6 @@ class ProjectConfig {
         }
 
         defer { self.project = project }  // deferred-init will call "didSet"
-        ProjectConfig.observer.update(project: project)
     }
     
     convenience init(datafile: String) throws {
@@ -156,44 +155,6 @@ class ProjectConfig {
         return rules
     }
 
-}
-
-// MARK: - Project Change Observer
-
-extension ProjectConfig {
-    
-    struct ProjectObserver {
-        var projectId: String? {
-            didSet {
-                if oldValue != nil, projectId != oldValue {
-                    NotificationCenter.default.post(name: .didReceiveOptimizelyProjectIdChange, object: nil)
-                }
-            }
-        }
-        
-        var revision: String? {
-            didSet {
-                if oldValue != nil, revision != oldValue {
-                    NotificationCenter.default.post(name: .didReceiveOptimizelyRevisionChange, object: nil)
-                }
-            }
-        }
-        
-        /// update obseverable properties
-        ///
-        /// - Parameter project: new Project values (pass nil for reset)
-        mutating func update(project: Project?) {
-            self.projectId = project?.projectId
-            self.revision = project?.revision
-        }
-        
-        mutating func reset() {
-            self.update(project: nil)
-        }
-    }
-    
-    static var observer = ProjectObserver()
-    
 }
 
 // MARK: - Persistent Data

--- a/Sources/Implementation/Datastore/DataStoreFile.swift
+++ b/Sources/Implementation/Datastore/DataStoreFile.swift
@@ -25,9 +25,9 @@ open class DataStoreFile<T>: OPTDataStore where T: Codable {
     public let url: URL
 
     // thread-safe lazy logger load (after HandlerRegisterService ready)
-    private var loggerInstance: OPTLogger?
+    private let threadSafeLogger = ThreadSafeLogger()
     var logger: OPTLogger {
-        return OPTLoggerFactory.getLoggerThreadSafe(&loggerInstance)
+        return threadSafeLogger.logger
     }
 
     public init(storeName: String, async: Bool = true) {

--- a/Sources/Implementation/Datastore/DataStoreFile.swift
+++ b/Sources/Implementation/Datastore/DataStoreFile.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2019-2021, Optimizely, Inc. and contributors
+// Copyright 2019-2022, Optimizely, Inc. and contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Sources/Implementation/Datastore/DataStoreUserDefaults.swift
+++ b/Sources/Implementation/Datastore/DataStoreUserDefaults.swift
@@ -28,9 +28,9 @@ public class DataStoreUserDefaults: OPTDataStore {
     static let dispatchQueue = DispatchQueue(label: "OPTDataStoreQueueUserDefaults")
 
     // thread-safe lazy logger load (after HandlerRegisterService ready)
-    private var loggerInstance: OPTLogger?
+    private let threadSafeLogger = ThreadSafeLogger()
     var logger: OPTLogger {
-        return OPTLoggerFactory.getLoggerThreadSafe(&loggerInstance)
+        return threadSafeLogger.logger
     }
 
     public func getItem(forKey: String) -> Any? {

--- a/Sources/Implementation/Datastore/DataStoreUserDefaults.swift
+++ b/Sources/Implementation/Datastore/DataStoreUserDefaults.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2019-2021, Optimizely, Inc. and contributors
+// Copyright 2019-2022, Optimizely, Inc. and contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Sources/Implementation/DefaultBucketer.swift
+++ b/Sources/Implementation/DefaultBucketer.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2019-2021, Optimizely, Inc. and contributors
+// Copyright 2019-2022, Optimizely, Inc. and contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Sources/Implementation/DefaultBucketer.swift
+++ b/Sources/Implementation/DefaultBucketer.swift
@@ -23,9 +23,9 @@ class DefaultBucketer: OPTBucketer {
     var MAX_HASH_VALUE: UInt64?
     
     // thread-safe lazy logger load (after HandlerRegisterService ready)
-    private var loggerInstance: OPTLogger?
+    private let threadSafeLogger = ThreadSafeLogger()
     var logger: OPTLogger {
-        return OPTLoggerFactory.getLoggerThreadSafe(&loggerInstance)
+        return threadSafeLogger.logger
     }
 
     init() {

--- a/Sources/Implementation/DefaultDecisionService.swift
+++ b/Sources/Implementation/DefaultDecisionService.swift
@@ -28,9 +28,9 @@ class DefaultDecisionService: OPTDecisionService {
     let userProfileService: OPTUserProfileService
     
     // thread-safe lazy logger load (after HandlerRegisterService ready)
-    private var loggerInstance: OPTLogger?
+    let threadSafeLogger = ThreadSafeLogger()
     var logger: OPTLogger {
-        return OPTLoggerFactory.getLoggerThreadSafe(&loggerInstance)
+        return threadSafeLogger.logger
     }
     
     // user-profile-service read-modify-write lock for supporting multiple clients

--- a/Sources/Implementation/DefaultDecisionService.swift
+++ b/Sources/Implementation/DefaultDecisionService.swift
@@ -28,7 +28,7 @@ class DefaultDecisionService: OPTDecisionService {
     let userProfileService: OPTUserProfileService
     
     // thread-safe lazy logger load (after HandlerRegisterService ready)
-    let threadSafeLogger = ThreadSafeLogger()
+    private let threadSafeLogger = ThreadSafeLogger()
     var logger: OPTLogger {
         return threadSafeLogger.logger
     }

--- a/Sources/Utils/Notifications.swift
+++ b/Sources/Utils/Notifications.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2019, 2021, Optimizely, Inc. and contributors
+// Copyright 2019, 2021-2022, Optimizely, Inc. and contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,7 +17,5 @@
 import Foundation
 
 extension Notification.Name {
-    static let didReceiveOptimizelyProjectIdChange = Notification.Name("didReceiveOptimizelyProjectIdChange")
-    static let didReceiveOptimizelyRevisionChange = Notification.Name("didReceiveOptimizelyRevisionChange")
     static let willSendOptimizelyEvents = Notification.Name("willSendOptimizelyEvents")
 }

--- a/Sources/Utils/ThreadSafeLogger.swift
+++ b/Sources/Utils/ThreadSafeLogger.swift
@@ -1,0 +1,40 @@
+//
+// Copyright 2022, Optimizely, Inc. and contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+
+class ThreadSafeLogger {
+    
+    // thread-safe lazy logger load (after HandlerRegisterService ready)
+    // - "lazy var" is not thread-safe
+    // - call this thread-safe version for types that should be initialized before (for customiziation) or at the same time with OptimizelyClient (so HandlerRegisterService is not ready yet), so required to be lazy-init.
+    // - [DefaultDatafileHandler, DefaultEventDispatcher, DefaultDecisionService, DefaultBucketer]
+    
+    private var instance: OPTLogger?
+    private let lock = DispatchQueue(label: "logger")
+
+    var logger: OPTLogger {
+        var result: OPTLogger?
+        lock.sync {
+            if instance == nil {
+                instance = OPTLoggerFactory.getLogger()
+            }
+            result = instance!
+        }
+        return result!
+    }
+    
+}

--- a/Sources/Utils/ThreadSafeLogger.swift
+++ b/Sources/Utils/ThreadSafeLogger.swift
@@ -18,9 +18,9 @@ import Foundation
 
 class ThreadSafeLogger {
     
-    // thread-safe lazy logger load (after HandlerRegisterService ready)
+    // thread-safe lazy logger (after HandlerRegisterService ready)
     // - "lazy var" is not thread-safe
-    // - call this thread-safe version for types that should be initialized before (for customiziation) or at the same time with OptimizelyClient (so HandlerRegisterService is not ready yet), so required to be lazy-init.
+    // - call this thread-safe version when required to be lazy-init. logger should be initialized before (for customiziation) or at the same time with OptimizelyClient (so HandlerRegisterService is not ready yet).
     // - [DefaultDatafileHandler, DefaultEventDispatcher, DefaultDecisionService, DefaultBucketer]
     
     private var instance: OPTLogger?
@@ -32,7 +32,7 @@ class ThreadSafeLogger {
             if instance == nil {
                 instance = OPTLoggerFactory.getLogger()
             }
-            result = instance!
+            result = instance
         }
         return result!
     }

--- a/Tests/OptimizelyTests-Batch-iOS/EventDispatcherTests_Batch.swift
+++ b/Tests/OptimizelyTests-Batch-iOS/EventDispatcherTests_Batch.swift
@@ -230,7 +230,7 @@ extension EventDispatcherTests_Batch {
     }
 
     func testBatchingEventsWhenProjectIdsNotEqual() {
-        // Batching set a boundary when an event has a different projectId from previous events.
+        // Batching sets a boundary when an event has a different projectId from previous events.
         // The remaining events will be sent as a separate batch (see "testFlushEventsWhenBatchFails()" for that).
         
         let events: [EventForDispatch] = [
@@ -252,7 +252,7 @@ extension EventDispatcherTests_Batch {
     }
 
     func testBatchingEventsWhenRevisionNotEqual() {
-        // Batching set a boundary when an event has a different revision from previous events.
+        // Batching sets a boundary when an event has a different revision from previous events.
         // The remaining events will be sent as a separate batch (see "testFlushEventsWhenBatchFails()" for that).
 
         let events: [EventForDispatch] = [

--- a/Tests/OptimizelyTests-MultiClients/EventDispatcherTests_MultiClients.swift
+++ b/Tests/OptimizelyTests-MultiClients/EventDispatcherTests_MultiClients.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021, Optimizely, Inc. and contributors 
+// Copyright 2021-2022, Optimizely, Inc. and contributors 
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");  
 // you may not use this file except in compliance with the License.
@@ -133,12 +133,6 @@ extension EventDispatcherTests_MultiClients {
                 (0..<numEventsPerThread).forEach{ e in
                     usleep(UInt32.random(in: 0..<UInt32(maxRandomIntervalInUsecs)))
                     dispatcher.dispatchEvent(event: OTUtils.makeEventForDispatch(), completionHandler: nil)
-                }
-                
-                // more stress with notifications
-                if injectNotifications, Bool.random() {
-                    NotificationCenter.default.post(name: .didReceiveOptimizelyProjectIdChange, object: nil)
-                    NotificationCenter.default.post(name: .didReceiveOptimizelyRevisionChange, object: nil)
                 }
             }
         }


### PR DESCRIPTION
## Summary
This fixes a couple of possible sources of race conditions in ProjectConfig.
- A logger is created thread-safe in a lazy mode. This fixes a bug that the reference for the logger instance was not fully protected in synchronization.
- The static observer of {projectId, revision} changes in datafile is not necessary since the event-batcher checks them for 
batch boundaries. It's cleaned up in this fix since it becomes a source of tricky race conditions. 

## Test plan
- Fix unit tests covering loggers and event-batcher.

## Issues
- [Issue #448](https://github.com/optimizely/swift-sdk/issues/448)
