### PR TITLE
Updating doc urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,17 +8,17 @@
 
 This repository houses the Swift SDK for use with Optimizely Full Stack and Optimizely Rollouts for Mobile and OTT.
 
-Optimizely Full Stack is A/B testing and feature flag management for product development teams. Experiment in any application. Make every feature on your roadmap an opportunity to learn. Learn more at https://www.optimizely.com/platform/full-stack/, or see the [documentation](https://docs.developers.optimizely.com/full-stack/docs).
+Optimizely Full Stack is A/B testing and feature flag management for product development teams. Experiment in any application. Make every feature on your roadmap an opportunity to learn. Learn more at https://www.optimizely.com/platform/full-stack/, or see the [documentation](https://docs.developers.optimizely.com/experimentation/v4.0.0-full-stack/docs/welcome).
 
-Optimizely Rollouts is free feature flags for development teams. Easily roll out and roll back features in any application without code deploys. Mitigate risk for every feature on your roadmap. Learn more at https://www.optimizely.com/rollouts/, or see the [documentation](https://docs.developers.optimizely.com/rollouts/docs).
+Optimizely Rollouts is free feature flags for development teams. Easily roll out and roll back features in any application without code deploys. Mitigate risk for every feature on your roadmap. Learn more at https://www.optimizely.com/rollouts/, or see the [documentation](https://docs.developers.optimizely.com/experimentation/v3.1.0-full-stack/docs/introduction-to-rollouts).
 
 
 ## Getting Started
 
 ### Using the SDK
 
-See the [Mobile developer documentation](https://docs.developers.optimizely.com/full-stack/docs/install-sdk-swift) to learn how to set
-up an Optimizely X project and start using the SDK.
+See the [Swift SDK developer documentation](https://docs.developers.optimizely.com/experimentation/v4.0.0-full-stack/docs/swift-sdk) to learn how to set
+up an Optimizely project and start using the SDK.
 
 ### Requirements
 * iOS 10.0+ / tvOS 10.0+ / watchOS 3.0+
@@ -86,7 +86,7 @@ Please see [CONTRIBUTING](CONTRIBUTING.md).
 
 ### Credits
 
-First-party code (under OptimizelySwiftSDK is copyright Optimizely, Inc. and contributors, licensed under Apache 2.0.
+First-party code (under OptimizelySwiftSDK is copyright Optimizely, Inc. and contributors, licensed under Apache 2.0.)
 
 ### Additional Code
 


### PR DESCRIPTION
## Summary
- Updated the dev doc URLs in the readme

The "why", or other context.
As part of the larger Optimizely developer documentation consolidation, the links to the documentation have changed.

## Test plan
N/A

## Issues
N/A
