### PR TITLE
chore: update unit tests settings for github actions

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -18,7 +18,6 @@ on:
 
 env:
   VERSION: 3.10.1
-  XCODE_VERSION: 12.4.0
 
 jobs:
 
@@ -38,7 +37,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: $XCODE_VERSION
+        xcode-version: 12.4
     - env:
         SRCCLR_API_TOKEN: ${{ secrets.SRCCLR_API_TOKEN }}
       run: |
@@ -60,7 +59,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: $XCODE_VERSION
+        xcode-version: 12.4
     - id: prepare_for_release
       name: Prepare for release
       env:
@@ -83,7 +82,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: $XCODE_VERSION
+        xcode-version: 12.4
     - name: Push to cocoapods.org
       env:
         GITHUB_TOKEN: ${{ secrets.CI_USER_TOKEN }}

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -18,7 +18,7 @@ on:
 
 env:
   VERSION: 3.10.1
-  XCODE_VERSION: 12.4
+  XCODE_VERSION: 12.4.0
 
 jobs:
 

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -48,7 +48,8 @@ jobs:
 
   unittests: 
     if: "${{ github.event.inputs.PREP == '' && github.event.inputs.RELEASE == '' }}" 
-    # TODO change to @master again
+
+    # [jae] TODO: change to @master again
     #uses: optimizely/swift-sdk/.github/workflows/unit_tests.yml@master
     uses: optimizely/swift-sdk/.github/workflows/unit_tests.yml@test-actions
 

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -50,7 +50,7 @@ jobs:
 
     #[TODO]: change to @master again
     #uses: optimizely/swift-sdk/.github/workflows/unit_tests.yml@master
-    uses: optimizely/swift-sdk/.github/workflows/unit_tests.yml@test-actions
+    uses: optimizely/swift-sdk/.github/workflows/unit_tests.yml@jae/version-update
 
   prepare_for_release:
     runs-on: macos-latest

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -49,7 +49,7 @@ jobs:
   unittests: 
     if: "${{ github.event.inputs.PREP == '' && github.event.inputs.RELEASE == '' }}" 
 
-    # [jae] TODO: change to @master again
+    #[TODO]: change to @master again
     #uses: optimizely/swift-sdk/.github/workflows/unit_tests.yml@master
     uses: optimizely/swift-sdk/.github/workflows/unit_tests.yml@test-actions
 

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -18,6 +18,7 @@ on:
 
 env:
   VERSION: 3.10.1
+  XCODE_VERSION: 12.4
 
 jobs:
 
@@ -37,7 +38,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: '12.4'
+        xcode-version: $XCODE_VERSION
     - env:
         SRCCLR_API_TOKEN: ${{ secrets.SRCCLR_API_TOKEN }}
       run: |
@@ -56,7 +57,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: '12.4'
+        xcode-version: $XCODE_VERSION
     - id: prepare_for_release
       name: Prepare for release
       env:
@@ -79,7 +80,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: '12.4'
+        xcode-version: $XCODE_VERSION
     - name: Push to cocoapods.org
       env:
         GITHUB_TOKEN: ${{ secrets.CI_USER_TOKEN }}

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -48,7 +48,9 @@ jobs:
 
   unittests: 
     if: "${{ github.event.inputs.PREP == '' && github.event.inputs.RELEASE == '' }}" 
-    uses: optimizely/swift-sdk/.github/workflows/unit_tests.yml@master
+    # TODO change to @master again
+    #uses: optimizely/swift-sdk/.github/workflows/unit_tests.yml@master
+    uses: optimizely/swift-sdk/.github/workflows/unit_tests.yml@test-actions
 
   prepare_for_release:
     runs-on: macos-latest

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -11,6 +11,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # github actions are very poor in supporting iOS simulators:
+        # - multiple Xcode versions are pre installed (not all versions and they change supported xcode versions frequently)
+        # - each xcode version has own simulator os versions.
+        # - so to run tests with the target simulator, we have to find a proper xcode version pre-installed and support the target simulator os version.
+        #   also, the xcode version (simulator_xcode_version) and simulator os versions (os) are moving target. We have to change these time to time.
         include:
           - os: 15.2
             device: "iPhone 11"
@@ -27,6 +32,7 @@ jobs:
             os_type: "iOS"
             simulator_xcode_version: 12.4
           - os: 13.7
+            # good to have tests with older OS versions, but it looks like this is min OS+xcode versions supported by github actions
             device: "iPad Air (3rd generation)"
             scheme: "OptimizelySwiftSDK-iOS"
             test_sdk: "iphonesimulator"
@@ -70,16 +76,10 @@ jobs:
           HOMEBREW_NO_INSTALL_CLEANUP=true brew update && brew install jq
 
           # github actions are very poor in supporting iOS simulators:
-          # - multiple Xcode versions are pre installed (not all versions and they change supported xcode versions frequently)
-          # - each xcode version has own simulator os versions.
-          # - so to run tests with the target simulator, we have to find a proper xcode version pre-installed and support the target simulator os version.
-          #   also, the xcode version (simulator_xcode_version) and simulator os versions (os) are moving target. We have to change these time to time.
-          #
-          # to find pre-installed xcode version, run this:
-          #> ls /Applications/
-          #
-          # to find supported simulator os versions, run this (and find simulator with non-error "datapath")
-          #> xcrun simctl list --json devices
+          # - to find pre-installed xcode version, run this:
+          # > ls /Applications/
+          # - to find supported simulator os versions, run this (and find simulator with non-error "datapath")
+          # > xcrun simctl list --json devices
 
           # switch to the target xcode version
           sudo xcode-select -switch /Applications/Xcode_$SIMULATOR_XCODE_VERSION.app

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -12,13 +12,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: 14.4
+          - os: 15.2
             device: "iPhone 11"
             scheme: "OptimizelySwiftSDK-iOS"
             test_sdk: "iphonesimulator"
             platform: "iOS Simulator"
             os_type: "iOS"
-            simulator_xcode_version: 12.4
+            simulator_xcode_version: 13.2
           - os: 13.3
             device: "iPhone 8"
             scheme: "OptimizelySwiftSDK-iOS"
@@ -68,6 +68,13 @@ jobs:
           pod repo update
           pod install
           HOMEBREW_NO_INSTALL_CLEANUP=true brew update && brew install jq
+
+
+          #debug
+          ls /Applications/
+          xcrun simctl list --json devices
+
+
           Scripts/prepare_simulator.sh
           Scripts/run_unit_tests.sh
       - name: Check on failures (Archive Test Results)

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -72,6 +72,7 @@ jobs:
 
           #debug
           ls /Applications/
+          sudo xcode-select -switch /Applications/Xcode_$SIMULATOR_XCODE_VERSION.app
           xcrun simctl list --json devices
 
 

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -69,12 +69,20 @@ jobs:
           pod install
           HOMEBREW_NO_INSTALL_CLEANUP=true brew update && brew install jq
 
+          # github actions are very poor in supporting iOS simulators:
+          # - multiple Xcode versions are pre installed (not all versions and they change supported xcode versions frequently)
+          # - each xcode version has own simulator os versions.
+          # - so to run tests with the target simulator, we have to find a proper xcode version pre-installed and support the target simulator os version.
+          #   also, the xcode version (simulator_xcode_version) and simulator os versions (os) are moving target. We have to change these time to time.
+          #
+          # to find pre-installed xcode version, run this:
+          #> ls /Applications/
+          #
+          # to find supported simulator os versions, run this (and find simulator with non-error "datapath")
+          #> xcrun simctl list --json devices
 
-          #debug
-          ls /Applications/
+          # switch to the target xcode version
           sudo xcode-select -switch /Applications/Xcode_$SIMULATOR_XCODE_VERSION.app
-          xcrun simctl list --json devices
-
 
           Scripts/prepare_simulator.sh
           Scripts/run_unit_tests.sh

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -19,27 +19,27 @@ jobs:
             platform: "iOS Simulator"
             os_type: "iOS"
             simulator_xcode_version: 13.2
-          - os: 13.3
+          - os: 14.4
             device: "iPhone 8"
             scheme: "OptimizelySwiftSDK-iOS"
             test_sdk: "iphonesimulator"
             platform: "iOS Simulator"
             os_type: "iOS"
-            simulator_xcode_version: 11.7
-          - os: 12.4
+            simulator_xcode_version: 12.4
+          - os: 13.7
             device: "iPad Air"
             scheme: "OptimizelySwiftSDK-iOS"
             test_sdk: "iphonesimulator"
             platform: "iOS Simulator"
             os_type: "iOS"
-            simulator_xcode_version: 10.3
-          - os: 12.4
+            simulator_xcode_version: 11.7
+          - os: 13.4
             device: "Apple TV 4K"
             scheme: "OptimizelySwiftSDK-tvOS"
             test_sdk: "appletvsimulator"
             platform: "tvOS Simulator"
             os_type: "tvOS"
-            simulator_xcode_version: 10.3
+            simulator_xcode_version: 11.7
     steps:
       - uses: actions/checkout@v3
       - uses: maxim-lobanov/setup-xcode@v1

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -27,7 +27,7 @@ jobs:
             os_type: "iOS"
             simulator_xcode_version: 12.4
           - os: 13.7
-            device: "iPad Air"
+            device: "iPad Air (3rd generation)"
             scheme: "OptimizelySwiftSDK-iOS"
             test_sdk: "iphonesimulator"
             platform: "iOS Simulator"

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -25,7 +25,7 @@ jobs:
             test_sdk: "iphonesimulator"
             platform: "iOS Simulator"
             os_type: "iOS"
-            simulator_xcode_version: 11.3.1
+            simulator_xcode_version: 11.7
           - os: 12.4
             device: "iPad Air"
             scheme: "OptimizelySwiftSDK-iOS"

--- a/Scripts/prepare_simulator.sh
+++ b/Scripts/prepare_simulator.sh
@@ -13,6 +13,7 @@ set -eou pipefail
 # https://github.com/actions/virtual-environments/issues/551
 
 # Older than Xcode 12 (12.4?) has different paths
+MAJOR_SIMULATOR_XCODE_VERSION=$(echo $SIMULATOR_XCODE_VERSION | cut -d. -f1)
 if [ "$MAJOR_SIMULATOR_XCODE_VERSION" -lt 12 ]; then
     os_folder="iPhoneOS"
     os="${OS/./-}"

--- a/Scripts/prepare_simulator.sh
+++ b/Scripts/prepare_simulator.sh
@@ -12,7 +12,8 @@ set -eou pipefail
 # More about XCode and its compatible simulators can be found here: https://github.com/actions/virtual-environments/blob/main/images/macos/macos-10.15-Readme.md
 # https://github.com/actions/virtual-environments/issues/551
 
-if [ "$SIMULATOR_XCODE_VERSION" != 12.4 ]; then
+# Older than Xcode 12 (12.4?) has different paths
+if [ "$MAJOR_SIMULATOR_XCODE_VERSION" -lt 12 ]; then
     os_folder="iPhoneOS"
     os="${OS/./-}"
     name="${NAME// /-}"

--- a/Scripts/prepare_simulator.sh
+++ b/Scripts/prepare_simulator.sh
@@ -17,7 +17,7 @@ MAJOR_SIMULATOR_XCODE_VERSION=$(echo $SIMULATOR_XCODE_VERSION | cut -d. -f1)
 if [ "$MAJOR_SIMULATOR_XCODE_VERSION" -lt 12 ]; then
     os_folder="iPhoneOS"
     os="${OS/./-}"
-    name="${NAME// /-}"
+    name="${NAME//[ ()]/-}"
 
     sudo mkdir -p /Library/Developer/CoreSimulator/Profiles/Runtimes
 


### PR DESCRIPTION
## Summary
- github actions changed iOS support, so building failed for old unit tests settings. Update OS + xcode versions to valid values. 
- add OS15 to the unit tests.
- change min OS simulator to 13.x (due to github actions support limitation)
- add more instructions for future update (github actions iOS support is vulnerable)

## Test plan
- pass all tests in github actions

## Issues
- OASIS-8472
