### PR TITLE
fix: change the types of event revenue and value fields

### DIFF
--- a/Sources/Data Model/DispatchEvents/BatchEvent.swift
+++ b/Sources/Data Model/DispatchEvents/BatchEvent.swift
@@ -120,8 +120,8 @@ struct DispatchEvent: Codable, Equatable {
     let timestamp: Int64
     let uuid: String
     var tags: [String: AttributeValue]?
-    var revenue: AttributeValue?
-    var value: AttributeValue?
+    var revenue: Int64?
+    var value: Double?
     
     enum CodingKeys: String, CodingKey {
         case entityID = "entity_id"
@@ -138,8 +138,8 @@ struct DispatchEvent: Codable, Equatable {
          entityID: String,
          uuid: String,
          tags: [String: AttributeValue]? = [:],
-         value: AttributeValue? = nil,
-         revenue: AttributeValue? = nil) {
+         value: Double? = nil,
+         revenue: Int64? = nil) {
         
         // TODO: add validation and throw here for invalid value (int, double) and revenue (int) types
        

--- a/Sources/Data Model/DispatchEvents/BatchEvent.swift
+++ b/Sources/Data Model/DispatchEvents/BatchEvent.swift
@@ -140,9 +140,7 @@ struct DispatchEvent: Codable, Equatable {
          tags: [String: AttributeValue]? = [:],
          value: Double? = nil,
          revenue: Int64? = nil) {
-        
-        // TODO: add validation and throw here for invalid value (int, double) and revenue (int) types
-       
+               
         self.timestamp = timestamp
         self.key = key
         self.entityID = entityID

--- a/Sources/Data Model/DispatchEvents/BatchEvent.swift
+++ b/Sources/Data Model/DispatchEvents/BatchEvent.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2019-2021, Optimizely, Inc. and contributors
+// Copyright 2019-2022, Optimizely, Inc. and contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Sources/Implementation/Events/BatchEventBuilder.swift
+++ b/Sources/Implementation/Events/BatchEventBuilder.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2019, 2021, Optimizely, Inc. and contributors
+// Copyright 2019, 2021-2022, Optimizely, Inc. and contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Sources/Implementation/Events/BatchEventBuilder.swift
+++ b/Sources/Implementation/Events/BatchEventBuilder.swift
@@ -108,7 +108,7 @@ class BatchEventBuilder {
     
     // MARK: - Event Tags
     
-    static func filterEventTags(_ eventTags: [String: Any]?) -> ([String: AttributeValue], AttributeValue?, AttributeValue?) {
+    static func filterEventTags(_ eventTags: [String: Any]?) -> ([String: AttributeValue], Double?, Int64?) {
         guard let eventTags = eventTags else {
             return ([:], nil, nil)
         }
@@ -124,28 +124,27 @@ class BatchEventBuilder {
     }
     
     static func filterTagsWithInvalidTypes(_ eventTags: [String: Any]) -> [String: AttributeValue] {
-        let filteredTags = eventTags.mapValues { AttributeValue(value: $0) }.filter { $0.value != nil } as? [String: AttributeValue]
-        return filteredTags ?? [:]
+        return eventTags.compactMapValues { AttributeValue(value: $0) }
     }
     
-    static func extractValueEventTag(_ eventTags: [String: AttributeValue]) -> AttributeValue? {
+    static func extractValueEventTag(_ eventTags: [String: AttributeValue]) -> Double? {
         guard let valueFromTags = eventTags[DispatchEvent.valueKey] else { return nil }
         
         // export {value, revenue} only for {double, int64} types
-        var value: AttributeValue?
+        var value: Double?
         
         switch valueFromTags {
-        case .double:
+        case .double(let attrValue):
             // valid value type
-            value = valueFromTags
-        case .int(let int64Value):
-            value = AttributeValue(value: Double(int64Value))
+            value = attrValue
+        case .int(let attrValue):
+            value = Double(attrValue)
         default:
             value = nil
         }
         
         if let value = value {
-            logger.i(.extractValueFromEventTags(value.stringValue))
+            logger.i(.extractValueFromEventTags("\(value)"))
         } else {
             logger.i(.failedToExtractValueFromEventTags(valueFromTags.stringValue))
         }
@@ -153,25 +152,25 @@ class BatchEventBuilder {
         return value
     }
     
-    static func extractRevenueEventTag(_ eventTags: [String: AttributeValue]) -> AttributeValue? {
+    static func extractRevenueEventTag(_ eventTags: [String: AttributeValue]) -> Int64? {
         guard let revenueFromTags = eventTags[DispatchEvent.revenueKey] else { return nil }
         
         // export {value, revenue} only for {double, int64} types
-        var revenue: AttributeValue?
+        var revenue: Int64?
         
         switch revenueFromTags {
-        case .int:
+        case .int(let value):
             // valid revenue type
-            revenue = revenueFromTags
-        case .double(let doubleValue):
+            revenue = Int64(value)
+        case .double(let value):
             // not accurate but acceptable ("3.14" -> "3")
-            revenue = AttributeValue(value: Int64(doubleValue))
+            revenue = Int64(value)
         default:
             revenue = nil
         }
         
         if let revenue = revenue {
-            logger.i(.extractRevenueFromEventTags(revenue.stringValue))
+            logger.i(.extractRevenueFromEventTags("\(revenue)"))
         } else {
             logger.i(.failedToExtractRevenueFromEventTags(revenueFromTags.stringValue))
         }

--- a/Tests/OptimizelyTests-Common/BatchEventBuilderTest.swift
+++ b/Tests/OptimizelyTests-Common/BatchEventBuilderTest.swift
@@ -38,16 +38,26 @@ class BatchEventBuilderTests: XCTestCase {
     }
 
     func testConversionEventWithNoExperiment() {
-        let conversion = BatchEventBuilder.createConversionEvent(config: (optimizely?.config)!, eventKey: eventWithNoExperimentKey, userId: userId, attributes: ["anyattribute": "value", "broswer_type": "firefox"], eventTags: nil)
+        // serialized to JSON
+        let conversion = BatchEventBuilder.createConversionEvent(config: (optimizely?.config)!,
+                                                                 eventKey: eventWithNoExperimentKey,
+                                                                 userId: userId,
+                                                                 attributes: ["anyattribute": "value", "broswer_type": "firefox"],
+                                                                 eventTags: ["browser": "chrome",
+                                                                             "revenue": 123,
+                                                                             "value": 32.5])
         
         XCTAssertNotNil(conversion)
         
+        // deserialized from JSON
         let batchEvent = try? JSONDecoder().decode(BatchEvent.self, from: conversion!)
         
         XCTAssertNotNil(batchEvent)
         
         XCTAssert((batchEvent?.enrichDecisions)! == true)
-        
+        XCTAssertEqual(batchEvent?.visitors[0].visitorID, userId)
+        XCTAssertEqual(batchEvent?.visitors[0].snapshots[0].events[0].revenue, 123)
+        XCTAssertEqual(batchEvent?.visitors[0].snapshots[0].events[0].value, 32.5)
     }
 
 }

--- a/Tests/OptimizelyTests-Common/BatchEventBuilderTest.swift
+++ b/Tests/OptimizelyTests-Common/BatchEventBuilderTest.swift
@@ -43,9 +43,7 @@ class BatchEventBuilderTests: XCTestCase {
                                                                  eventKey: eventWithNoExperimentKey,
                                                                  userId: userId,
                                                                  attributes: ["anyattribute": "value", "broswer_type": "firefox"],
-                                                                 eventTags: ["browser": "chrome",
-                                                                             "revenue": 123,
-                                                                             "value": 32.5])
+                                                                 eventTags: ["browser": "chrome"])
         
         XCTAssertNotNil(conversion)
         
@@ -56,8 +54,6 @@ class BatchEventBuilderTests: XCTestCase {
         
         XCTAssert((batchEvent?.enrichDecisions)! == true)
         XCTAssertEqual(batchEvent?.visitors[0].visitorID, userId)
-        XCTAssertEqual(batchEvent?.visitors[0].snapshots[0].events[0].revenue, 123)
-        XCTAssertEqual(batchEvent?.visitors[0].snapshots[0].events[0].value, 32.5)
     }
 
 }

--- a/Tests/OptimizelyTests-Common/BatchEventBuilderTest.swift
+++ b/Tests/OptimizelyTests-Common/BatchEventBuilderTest.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2019-2021, Optimizely, Inc. and contributors
+// Copyright 2019-2022, Optimizely, Inc. and contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Tests/OptimizelyTests-Common/BatchEventBuilderTests_EventTags.swift
+++ b/Tests/OptimizelyTests-Common/BatchEventBuilderTests_EventTags.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2019, 2021, Optimizely, Inc. and contributors
+// Copyright 2019, 2021-2022, Optimizely, Inc. and contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Tests/OptimizelyTests-Common/BatchEventBuilderTests_EventTags.swift
+++ b/Tests/OptimizelyTests-Common/BatchEventBuilderTests_EventTags.swift
@@ -70,42 +70,6 @@ class BatchEventBuilderTests_EventTags: XCTestCase {
         XCTAssertEqual(de["value"] as! Double, 32.5, "value field must be copied")
     }
 
-    func testEventTagsWhenRevenueAndValue_acceptedNumbers() {
-        let eventKey = "event_single_targeted_exp"
-        let eventTags: [String: Any] = ["browser": "chrome",
-                                        "revenue": 123.4,
-                                        "value": 325]
-        
-        try! optimizely.track(eventKey: eventKey, userId: userId, attributes: nil, eventTags: eventTags)
-        
-        let de = getDispatchEvent(dispatcher: eventDispatcher)!
-        let tags = de["tags"] as! [String: Any]
-
-        XCTAssertEqual(tags["browser"] as! String, "chrome")
-        XCTAssertEqual(tags["revenue"] as! Double, 123.4)
-        XCTAssertEqual(tags["value"] as! Int, 325)
-        XCTAssertEqual(de["revenue"] as! Int, 123, "double is accepted revenue type, but converted to an integer")
-        XCTAssertEqual(de["value"] as! Double, 325, "integer is accepted value type, but convereted to a double")
-    }
-
-    func testEventTagsWhenRevenueAndValue_invalidStrings() {
-        let eventKey = "event_single_targeted_exp"
-        let eventTags: [String: Any] = ["browser": "chrome",
-                                        "revenue": "123",
-                                        "value": "32.5"]
-        
-        try! optimizely.track(eventKey: eventKey, userId: userId, attributes: nil, eventTags: eventTags)
-        
-        let de = getDispatchEvent(dispatcher: eventDispatcher)!
-        let tags = de["tags"] as! [String: Any]
-
-        XCTAssertEqual(tags["browser"] as! String, "chrome")
-        XCTAssertEqual(tags["revenue"] as! String, "123")
-        XCTAssertEqual(tags["value"] as! String, "32.5")
-        XCTAssertNil(de["revenue"], "invalid revenue type not extracted")
-        XCTAssertNil(de["value"], "invalid value type not extracted")
-    }
-
 }
 
 // MARK: - invalid types in tags

--- a/Tests/OptimizelyTests-Common/BatchEventBuilderTests_EventTags.swift
+++ b/Tests/OptimizelyTests-Common/BatchEventBuilderTests_EventTags.swift
@@ -315,7 +315,36 @@ extension BatchEventBuilderTests_EventTags {
         XCTAssertEqual(de["revenue"] as! Int, 40, "value must be valid for revenue")
         XCTAssertEqual(de["value"] as! Double, 32, "value must be valid for value")
     }
-
+    
+    func testEventTagsWithRevenueAndValue_toJSON() {
+        
+        // valid revenue/value types
+        
+        let conversion1 = BatchEventBuilder.createConversionEvent(config: (optimizely?.config)!, eventKey: eventKey, userId: userId, attributes: [:],
+                                                                  eventTags: ["browser": "chrome",
+                                                                              "revenue": 123,
+                                                                              "value": 32.5])
+        
+        // invalid revenue/value types
+        
+        let conversion2 = BatchEventBuilder.createConversionEvent(config: (optimizely?.config)!, eventKey: eventKey, userId: userId, attributes: [:],
+                                                                  eventTags: ["browser": "chrome",
+                                                                              "revenue": true,
+                                                                              "value": "invalid"])
+        
+        // deserialized from JSON
+        let batchEvent1 = try? JSONDecoder().decode(BatchEvent.self, from: conversion1!)
+        let batchEvent2 = try? JSONDecoder().decode(BatchEvent.self, from: conversion2!)
+        
+        XCTAssertEqual(batchEvent1?.visitors[0].visitorID, userId)
+        XCTAssertEqual(batchEvent1?.visitors[0].snapshots[0].events[0].revenue, 123)
+        XCTAssertEqual(batchEvent1?.visitors[0].snapshots[0].events[0].value, 32.5)
+        
+        XCTAssertEqual(batchEvent2?.visitors[0].visitorID, userId)
+        XCTAssertNil(batchEvent2?.visitors[0].snapshots[0].events[0].revenue, "invalid type not extracted")
+        XCTAssertNil(batchEvent2?.visitors[0].snapshots[0].events[0].value, "invalid type not extracted")
+    }
+    
 }
 
 // MARK: - Utils

--- a/Tests/OptimizelyTests-Common/BatchEventBuilderTests_EventTags.swift
+++ b/Tests/OptimizelyTests-Common/BatchEventBuilderTests_EventTags.swift
@@ -70,6 +70,42 @@ class BatchEventBuilderTests_EventTags: XCTestCase {
         XCTAssertEqual(de["value"] as! Double, 32.5, "value field must be copied")
     }
 
+    func testEventTagsWhenRevenueAndValue_acceptedNumbers() {
+        let eventKey = "event_single_targeted_exp"
+        let eventTags: [String: Any] = ["browser": "chrome",
+                                        "revenue": 123.4,
+                                        "value": 325]
+        
+        try! optimizely.track(eventKey: eventKey, userId: userId, attributes: nil, eventTags: eventTags)
+        
+        let de = getDispatchEvent(dispatcher: eventDispatcher)!
+        let tags = de["tags"] as! [String: Any]
+
+        XCTAssertEqual(tags["browser"] as! String, "chrome")
+        XCTAssertEqual(tags["revenue"] as! Double, 123.4)
+        XCTAssertEqual(tags["value"] as! Int, 325)
+        XCTAssertEqual(de["revenue"] as! Int, 123, "double is accepted revenue type, but converted to an integer")
+        XCTAssertEqual(de["value"] as! Double, 325, "integer is accepted value type, but convereted to a double")
+    }
+
+    func testEventTagsWhenRevenueAndValue_invalidStrings() {
+        let eventKey = "event_single_targeted_exp"
+        let eventTags: [String: Any] = ["browser": "chrome",
+                                        "revenue": "123",
+                                        "value": "32.5"]
+        
+        try! optimizely.track(eventKey: eventKey, userId: userId, attributes: nil, eventTags: eventTags)
+        
+        let de = getDispatchEvent(dispatcher: eventDispatcher)!
+        let tags = de["tags"] as! [String: Any]
+
+        XCTAssertEqual(tags["browser"] as! String, "chrome")
+        XCTAssertEqual(tags["revenue"] as! String, "123")
+        XCTAssertEqual(tags["value"] as! String, "32.5")
+        XCTAssertNil(de["revenue"], "invalid revenue type not extracted")
+        XCTAssertNil(de["value"], "invalid value type not extracted")
+    }
+
 }
 
 // MARK: - invalid types in tags


### PR DESCRIPTION
## Summary
The revenue and value fields of events are changed to integer and float types. 
- These changes are for internal only. There will be no change visible to users.
- They were implemented as AttributeValue type (the core types were validated when extracted).
 
## Test plan
- Pass existing unit and FSC tests

## Issues
- FSSDK-8562
- https://github.com/optimizely/swift-sdk/issues/244
