### PR TITLE
fix: clean up build warnings

### DIFF
--- a/DemoObjCApp/DemoObjcApp.xcodeproj/project.pbxproj
+++ b/DemoObjCApp/DemoObjcApp.xcodeproj/project.pbxproj
@@ -435,7 +435,7 @@
 		6EF7496721E40467008B22A0 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1250;
+				LastUpgradeCheck = 1340;
 				ORGANIZATIONNAME = Optimizely;
 				TargetAttributes = {
 					6EF7498D21E404BB008B22A0 = {

--- a/DemoObjCApp/DemoObjcApp.xcodeproj/xcshareddata/xcschemes/DemoObjciOS.xcscheme
+++ b/DemoObjCApp/DemoObjcApp.xcodeproj/xcshareddata/xcschemes/DemoObjciOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "1340"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/DemoObjCApp/DemoObjcApp.xcodeproj/xcshareddata/xcschemes/DemoObjctvOS.xcscheme
+++ b/DemoObjCApp/DemoObjcApp.xcodeproj/xcshareddata/xcschemes/DemoObjctvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "1340"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/DemoObjCApp/Samples/SamplesForAPI.m
+++ b/DemoObjCApp/Samples/SamplesForAPI.m
@@ -217,13 +217,12 @@
         
         // enumerate feature experiments
         
-        NSDictionary<NSString*, id<OptimizelyExperiment>> *experimentsMap = featuresMap[featKey].experimentsMap;
-        NSArray *experimentKeys = experimentsMap.allKeys;
+        NSArray *experiments = featuresMap[featKey].experimentRules;
         
-        for(NSString *expKey in experimentKeys) {
-            NSLog(@"[OptimizelyConfig]   - experimentKey = %@", expKey);
+        for(id<OptimizelyExperiment> exp in experiments) {
+            NSLog(@"[OptimizelyConfig]   - experimentKey = %@", exp.key);
             
-            NSDictionary<NSString*, id<OptimizelyVariation>> *variationsMap = experimentsMap[expKey].variationsMap;
+            NSDictionary<NSString*, id<OptimizelyVariation>> *variationsMap = exp.variationsMap;
             NSArray *variationKeys = variationsMap.allKeys;
             
             for(NSString *varKey in variationKeys) {

--- a/DemoSwiftApp/DemoSwiftApp.xcodeproj/project.pbxproj
+++ b/DemoSwiftApp/DemoSwiftApp.xcodeproj/project.pbxproj
@@ -555,7 +555,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 1230;
-				LastUpgradeCheck = 1320;
+				LastUpgradeCheck = 1340;
 				ORGANIZATIONNAME = Optimizely;
 				TargetAttributes = {
 					252D7DEC21C8800800134A7A = {

--- a/DemoSwiftApp/DemoSwiftApp.xcodeproj/xcshareddata/xcschemes/DemoSwiftiOS.xcscheme
+++ b/DemoSwiftApp/DemoSwiftApp.xcodeproj/xcshareddata/xcschemes/DemoSwiftiOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "1340"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/DemoSwiftApp/DemoSwiftApp.xcodeproj/xcshareddata/xcschemes/DemoSwifttvOS.xcscheme
+++ b/DemoSwiftApp/DemoSwiftApp.xcodeproj/xcshareddata/xcschemes/DemoSwifttvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "1340"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/DemoSwiftApp/DemoSwiftApp.xcodeproj/xcshareddata/xcschemes/DemoSwiftwatchOS.xcscheme
+++ b/DemoSwiftApp/DemoSwiftApp.xcodeproj/xcshareddata/xcschemes/DemoSwiftwatchOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "1340"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/OptimizelySwiftSDK.xcodeproj/project.pbxproj
+++ b/OptimizelySwiftSDK.xcodeproj/project.pbxproj
@@ -3433,7 +3433,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 1230;
-				LastUpgradeCheck = 1320;
+				LastUpgradeCheck = 1340;
 				ORGANIZATIONNAME = Optimizely;
 				TargetAttributes = {
 					6E14CD622423F80B00010234 = {

--- a/OptimizelySwiftSDK.xcodeproj/xcshareddata/xcschemes/OptimizelySwiftSDK-iOS.xcscheme
+++ b/OptimizelySwiftSDK.xcodeproj/xcshareddata/xcschemes/OptimizelySwiftSDK-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "1340"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/OptimizelySwiftSDK.xcodeproj/xcshareddata/xcschemes/OptimizelySwiftSDK-macOS.xcscheme
+++ b/OptimizelySwiftSDK.xcodeproj/xcshareddata/xcschemes/OptimizelySwiftSDK-macOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "1340"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/OptimizelySwiftSDK.xcodeproj/xcshareddata/xcschemes/OptimizelySwiftSDK-tvOS.xcscheme
+++ b/OptimizelySwiftSDK.xcodeproj/xcshareddata/xcschemes/OptimizelySwiftSDK-tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "1340"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/OptimizelySwiftSDK.xcodeproj/xcshareddata/xcschemes/OptimizelySwiftSDK-watchOS.xcscheme
+++ b/OptimizelySwiftSDK.xcodeproj/xcshareddata/xcschemes/OptimizelySwiftSDK-watchOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "1340"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Sources/Data Model/Audience/AttributeValue.swift
+++ b/Sources/Data Model/Audience/AttributeValue.swift
@@ -115,7 +115,7 @@ extension AttributeValue {
     
     func isExactMatch(with target: Any, condition: String = "", name: String = "") throws -> Bool {
         
-        if !self.isValidForExactMatcher() || (self.doubleValue?.isInfinite ?? false) {
+        if !self.isValidForExactMatcher || (self.doubleValue?.isInfinite ?? false) {
             throw OptimizelyError.evaluateAttributeInvalidCondition(condition)
         }
         
@@ -265,7 +265,7 @@ extension AttributeValue {
         }
     }
     
-    func isValidForExactMatcher() -> Bool {
+    var isValidForExactMatcher: Bool {
         switch self {
         case (.string): return true
         case (.int): return true

--- a/Sources/Optimizely/OptimizelyConfig+ObjC.swift
+++ b/Sources/Optimizely/OptimizelyConfig+ObjC.swift
@@ -137,7 +137,10 @@ class ObjcFeature: NSObject, ObjcOptimizelyFeature {
         self.key = feature.key
         self.experimentRules = feature.experimentRules.map { ObjcExperiment($0) }
         self.deliveryRules = feature.deliveryRules.map { ObjcExperiment($0) }
-        self.experimentsMap = feature.experimentsMap.mapValues { ObjcExperiment($0) }
+        
+        let expKeyValuePair = feature.experimentRules.map { ($0.key, ObjcExperiment($0)) }
+        self.experimentsMap = Dictionary(uniqueKeysWithValues: expKeyValuePair)
+
         self.variablesMap = feature.variablesMap.mapValues { ObjcVariable($0) }
     }
 }

--- a/Tests/OptimizelyTests-APIs/OptimizelyClientTests_OptimizelyConfig.swift
+++ b/Tests/OptimizelyTests-APIs/OptimizelyClientTests_OptimizelyConfig.swift
@@ -158,17 +158,11 @@ class OptimizelyClientTests_OptimizelyConfig: XCTestCase {
         let feature1 = optimizelyConfig.featuresMap["mutex_group_feature"]!
         let feature2 = optimizelyConfig.featuresMap["feature_exp_no_traffic"]!
 
-        // FeatureFlag: experimentsMap
-        
-        XCTAssertEqual(feature1.experimentsMap.count, 2)
-        XCTAssertEqual(feature2.experimentsMap.count, 1)
+        // FeatureFlag: experiments
+                
+        var experiment1 = feature1.experimentRules[0]
+        var experiment2 = feature1.experimentRules[1]
 
-        print("   Feature1 > Experiments: \(feature1.experimentsMap.keys)")
-        print("   Feature2 > Experiments: \(feature2.experimentsMap.keys)")
-
-        var experiment1 = feature1.experimentsMap["experiment_4000"]!
-        var experiment2 = feature1.experimentsMap["duplicate_experiment_key"]!
-        
         XCTAssertEqual(experiment1.variationsMap.count, 2)
         XCTAssertEqual(experiment2.variationsMap.count, 1)
 
@@ -308,7 +302,7 @@ extension OptimizelyFeature {
             "id": self.id,
             "experimentRules": self.experimentRules.map{ $0.dict },
             "deliveryRules": self.deliveryRules.map{ $0.dict },
-            "experimentsMap": self.experimentsMap.mapValues{ $0.dict },
+            "experimentsMap": Dictionary(uniqueKeysWithValues: self.experimentRules.map { ($0.key, $0.dict) }), // experimentsMap is deprecated. do not use it.
             "variablesMap": self.variablesMap.mapValues{ $0.dict }
         ]
     }

--- a/Tests/OptimizelyTests-APIs/OptimizelyClientTests_OptimizelyConfig_Objc.m
+++ b/Tests/OptimizelyTests-APIs/OptimizelyClientTests_OptimizelyConfig_Objc.m
@@ -127,9 +127,9 @@
 
 -(NSDictionary*)dictForOptimizelyFeature: (id <OptimizelyFeature>)feature {
     NSMutableDictionary *expMap = [NSMutableDictionary new];
-    for(NSString *key in feature.experimentsMap.allKeys){
-        id<OptimizelyExperiment> value = feature.experimentsMap[key];
-        expMap[key] = [self dictForOptimizelyExperiment:value];
+    for(id<OptimizelyExperiment> exp in feature.experimentRules){
+        NSString *key = exp.key;
+        expMap[key] = [self dictForOptimizelyExperiment:exp];
     }
     
     NSMutableDictionary *varMap = [NSMutableDictionary new];

--- a/Tests/OptimizelyTests-DataModel/AttributeValueTests.swift
+++ b/Tests/OptimizelyTests-DataModel/AttributeValueTests.swift
@@ -471,15 +471,15 @@ extension AttributeValueTests {
     
     func testIsValidForExactMatcher() {
         var attr = AttributeValue.string("valid")
-        XCTAssertTrue(attr.isValidForExactMatcher())
+        XCTAssertTrue(attr.isValidForExactMatcher)
         attr = AttributeValue.int(1)
-        XCTAssertTrue(attr.isValidForExactMatcher())
+        XCTAssertTrue(attr.isValidForExactMatcher)
         attr = AttributeValue.double(1)
-        XCTAssertTrue(attr.isValidForExactMatcher())
+        XCTAssertTrue(attr.isValidForExactMatcher)
         attr = AttributeValue.bool(true)
-        XCTAssertTrue(attr.isValidForExactMatcher())
+        XCTAssertTrue(attr.isValidForExactMatcher)
         attr = AttributeValue.others
-        XCTAssertFalse(attr.isValidForExactMatcher())
+        XCTAssertFalse(attr.isValidForExactMatcher)
     }
     
     


### PR DESCRIPTION
## Summary
- Remove warnings about deprecated OptimizelyConfig.experimentsMap (used in SDK for objc wrapper)
- Clean up other lint errors

## Test plan
- Pass all existing unit and FSC tests.

## Issues
- FSSDK-8671
