### PR TITLE
feat(ats): remove auto ODP identify events from legacy APIs

### DIFF
--- a/Sources/Optimizely+Decide/OptimizelyClient+Decide.swift
+++ b/Sources/Optimizely+Decide/OptimizelyClient+Decide.swift
@@ -45,6 +45,20 @@ extension OptimizelyClient {
                                  attributes: (attributes ?? [:]) as [String: Any])
     }
     
+    
+    /// Create a user context to be used internally without sending an ODP identify event.
+    ///
+    /// - Parameters:
+    ///   - userId: The user ID to be used for bucketing.
+    ///   - attributes: A map of attribute names to current user attribute values.
+    /// - Returns: An OptimizelyUserContext associated with this OptimizelyClient
+    func makeInternalUserContext(userId: String,
+                                 attributes: OptimizelyAttributes? = nil) -> OptimizelyUserContext {
+        return OptimizelyUserContext(optimizely: self, userId: userId,
+                                     attributes: (attributes ?? [:]) as [String: Any],
+                                     identify: false)
+    }
+    
     func decide(user: OptimizelyUserContext,
                 key: String,
                 options: [OptimizelyDecideOption]? = nil) -> OptimizelyDecision {

--- a/Sources/Optimizely/OptimizelyClient.swift
+++ b/Sources/Optimizely/OptimizelyClient.swift
@@ -317,8 +317,7 @@ open class OptimizelyClient: NSObject {
         
         let variation = decisionService.getVariation(config: config,
                                                      experiment: experiment,
-                                                     user: createUserContext(userId: userId,
-                                                                             attributes: attributes),
+                                                     user: makeInternalUserContext(userId: userId, attributes: attributes),
                                                      options: nil).result
         
         let decisionType: Constants.DecisionType = config.isFeatureExperiment(id: experiment.id) ? .featureTest : .abTest
@@ -401,8 +400,7 @@ open class OptimizelyClient: NSObject {
         
         let pair = decisionService.getVariationForFeature(config: config,
                                                           featureFlag: featureFlag,
-                                                          user: createUserContext(userId: userId,
-                                                                                  attributes: attributes),
+                                                          user: makeInternalUserContext(userId: userId, attributes: attributes),
                                                           options: nil).result
         
         let source = pair?.source ?? Constants.DecisionSource.rollout.rawValue
@@ -553,8 +551,7 @@ open class OptimizelyClient: NSObject {
         
         let decision = decisionService.getVariationForFeature(config: config,
                                                               featureFlag: featureFlag,
-                                                              user: createUserContext(userId: userId,
-                                                                                      attributes: attributes),
+                                                              user: makeInternalUserContext(userId: userId, attributes: attributes),
                                                               options: nil).result
         if let decision = decision {
             if let featureVariable = decision.variation.variables?.filter({$0.id == variable.id}).first {
@@ -645,8 +642,7 @@ open class OptimizelyClient: NSObject {
         
         let decision = decisionService.getVariationForFeature(config: config,
                                                               featureFlag: featureFlag,
-                                                              user: createUserContext(userId: userId,
-                                                                                      attributes: attributes),
+                                                              user: makeInternalUserContext(userId: userId, attributes: attributes),
                                                               options: nil).result
         if let featureEnabled = decision?.variation.featureEnabled {
             enabled = featureEnabled

--- a/Tests/TestData/odp/decide_audience_segments.json
+++ b/Tests/TestData/odp/decide_audience_segments.json
@@ -202,6 +202,14 @@
       }
   ],
   "accountId": "10367498574",
-  "events": [],
+  "events": [
+      {
+        "experimentIds": [
+          "10420810910"
+        ],
+        "id": "10404198134",
+        "key": "event1"
+      }
+  ],
   "revision": "101"
 }


### PR DESCRIPTION
## Summary
Fix a bug that ODP event is automatically dispatched for legacy APIs (activate, etc by sharing createUserContext).

## Test plan
- Unit test validating no ODP event

## Issues
- [FSSDK-8413](https://jira.sso.episerver.net/browse/FSSDK-8413)
