### PR TITLE
fix(ats): remove odpConfig from OdpEventManager/OdpSegmentManager init params

### DIFF
--- a/Sources/ODP/OdpEventManager.swift
+++ b/Sources/ODP/OdpEventManager.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2022, Optimizely, Inc. and contributors 
+// Copyright 2022-2023, Optimizely, Inc. and contributors 
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");  
 // you may not use this file except in compliance with the License.
@@ -18,9 +18,9 @@ import Foundation
 import UIKit
 
 class OdpEventManager {
-    var odpConfig: OdpConfig
+    var odpConfig = OdpConfig()
     var apiMgr: OdpEventApiManager
-    
+
     var maxQueueSize = 100
     let maxBatchEvents = 10
     let queueLock: DispatchQueue
@@ -31,14 +31,11 @@ class OdpEventManager {
     /// OdpEventManager init
     /// - Parameters:
     ///   - sdkKey: datafile sdkKey
-    ///   - odpConfig: ODP config (apiKey, apiHost, ...)
     ///   - apiManager: OdpEventApiManager
     ///   - resourceTimeoutInSecs: timeout for event dispatch
     init(sdkKey: String,
-         odpConfig: OdpConfig? = nil,
          apiManager: OdpEventApiManager? = nil,
          resourceTimeoutInSecs: Int? = nil) {
-        self.odpConfig = odpConfig ?? OdpConfig()
         self.apiMgr = apiManager ?? OdpEventApiManager(timeout: resourceTimeoutInSecs)
         
         self.queueLock = DispatchQueue(label: "event")

--- a/Sources/ODP/OdpManager.swift
+++ b/Sources/ODP/OdpManager.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2022, Optimizely, Inc. and contributors 
+// Copyright 2022-2023, Optimizely, Inc. and contributors 
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");  
 // you may not use this file except in compliance with the License.
@@ -57,26 +57,14 @@ class OdpManager {
             return
         }
         
+        self.segmentManager = segmentManager ?? OdpSegmentManager(cacheSize: cacheSize,
+                                                                  cacheTimeoutInSecs: cacheTimeoutInSecs,
+                                                                  resourceTimeoutInSecs: timeoutForSegmentFetchInSecs)
+        self.eventManager = eventManager ?? OdpEventManager(sdkKey: sdkKey,
+                                                            resourceTimeoutInSecs: timeoutForEventDispatchInSecs)        
         self.odpConfig = OdpConfig()
-
-        if let segmentManager = segmentManager {
-            segmentManager.odpConfig = odpConfig
-            self.segmentManager = segmentManager
-        } else {
-            self.segmentManager = OdpSegmentManager(cacheSize: cacheSize,
-                                                    cacheTimeoutInSecs: cacheTimeoutInSecs,
-                                                    odpConfig: odpConfig,
-                                                    resourceTimeoutInSecs: timeoutForSegmentFetchInSecs)
-        }
-        
-        if let eventManager = eventManager {
-            eventManager.odpConfig = odpConfig
-            self.eventManager = eventManager
-        } else {
-            self.eventManager = OdpEventManager(sdkKey: sdkKey,
-                                                odpConfig: odpConfig,
-                                                resourceTimeoutInSecs: timeoutForEventDispatchInSecs)
-        }
+        self.segmentManager.odpConfig = odpConfig
+        self.eventManager.odpConfig = odpConfig
         
         self.eventManager.registerVUID(vuid: self.vuidManager.vuid)
     }

--- a/Sources/ODP/OdpSegmentManager.swift
+++ b/Sources/ODP/OdpSegmentManager.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2022, Optimizely, Inc. and contributors 
+// Copyright 2022-2023, Optimizely, Inc. and contributors 
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");  
 // you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 import Foundation
 
 class OdpSegmentManager {    
-    var odpConfig: OdpConfig
+    var odpConfig = OdpConfig()
     var segmentsCache: LruCache<String, [String]>
     var apiMgr: OdpSegmentApiManager
     
@@ -27,15 +27,12 @@ class OdpSegmentManager {
     /// - Parameters:
     ///   - cacheSize: segment cache size
     ///   - cacheTimeoutInSecs: segment cache timeout
-    ///   - odpConfig: ODP config (apiKey, apiHost, ...)
     ///   - apiManager: OdpSegmentApiManager
     ///   - resourceTimeoutInSecs: timeout for segment fetch
     init(cacheSize: Int,
          cacheTimeoutInSecs: Int,
-         odpConfig: OdpConfig? = nil,
          apiManager: OdpSegmentApiManager? = nil,
          resourceTimeoutInSecs: Int? = nil) {
-        self.odpConfig = odpConfig ?? OdpConfig()
         self.apiMgr = apiManager ?? OdpSegmentApiManager(timeout: resourceTimeoutInSecs)
         
         self.segmentsCache = LruCache<String, [String]>(size: cacheSize,

--- a/Tests/OptimizelyTests-Common/OdpEventApiManagerTests.swift
+++ b/Tests/OptimizelyTests-Common/OdpEventApiManagerTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2022, Optimizely, Inc. and contributors 
+// Copyright 2022-2023, Optimizely, Inc. and contributors 
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");  
 // you may not use this file except in compliance with the License.

--- a/Tests/OptimizelyTests-Common/OdpEventManagerTests.swift
+++ b/Tests/OptimizelyTests-Common/OdpEventManagerTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2022, Optimizely, Inc. and contributors 
+// Copyright 2022-2023, Optimizely, Inc. and contributors 
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");  
 // you may not use this file except in compliance with the License.
@@ -38,8 +38,8 @@ class OdpEventManagerTests: XCTestCase {
         odpConfig = OdpConfig()
         
         manager = OdpEventManager(sdkKey: "any",
-                                  odpConfig: odpConfig,
                                   apiManager: apiManager)
+        manager.odpConfig = odpConfig
     }
     
     override func tearDown() {
@@ -126,8 +126,9 @@ class OdpEventManagerTests: XCTestCase {
         _ = odpConfig.update(apiKey: "valid", apiHost: "host", segmentsToCheck: [])
         
         manager = OdpEventManager(sdkKey: "any",
-                                  odpConfig: odpConfig,
                                   apiManager: apiManager)
+        manager.odpConfig = odpConfig
+        
         manager.sendEvent(type: "t1",
                           action: "a1",
                           identifiers: ["id-key-1": "id-value-1"],
@@ -301,11 +302,12 @@ class OdpEventManagerTests: XCTestCase {
         let odpConfig2 = OdpConfig()
 
         let manager1 = OdpEventManager(sdkKey: "sdkKey-1",
-                                       odpConfig: odpConfig1,
                                        apiManager: apiManager1)
+        manager1.odpConfig = odpConfig1
+        
         let manager2 = OdpEventManager(sdkKey: "sdkKey-2",
-                                       odpConfig: odpConfig2,
                                        apiManager: apiManager2)
+        manager2.odpConfig = odpConfig2
         
         let event1 = OdpEvent(type: "t1", action: "a1", identifiers: [:], data: [:])
         let event2 = OdpEvent(type: "t2", action: "a2", identifiers: [:], data: [:])
@@ -395,8 +397,8 @@ class OdpEventManagerTests: XCTestCase {
         _ = odpConfig.update(apiKey: "test-key", apiHost: "test-host", segmentsToCheck: [])
 
         manager = OdpEventManager(sdkKey: "any",
-                                  odpConfig: odpConfig,
                                   apiManager: apiManager)
+        manager.odpConfig = odpConfig
 
         let event = OdpEvent(type: "t1", action: "a1", identifiers: [:], data: [:])
         manager.dispatch(event)

--- a/Tests/OptimizelyTests-Common/OdpManagerTests.swift
+++ b/Tests/OptimizelyTests-Common/OdpManagerTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2022, Optimizely, Inc. and contributors 
+// Copyright 2022-2023, Optimizely, Inc. and contributors 
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");  
 // you may not use this file except in compliance with the License.
@@ -106,7 +106,7 @@ class OdpManagerTests: XCTestCase {
     }
 
     func testRegisterVUIDCalledAutomatically_odpDisabled() {
-        let newEventManager = MockOdpEventManager(sdkKey: sdkKey, odpConfig: OdpConfig())
+        let newEventManager = MockOdpEventManager(sdkKey: sdkKey)
         
         _ = OdpManager(sdkKey: sdkKey,
                        disable: true,

--- a/Tests/OptimizelyTests-Common/OdpSegmentManagerTests.swift
+++ b/Tests/OptimizelyTests-Common/OdpSegmentManagerTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2022, Optimizely, Inc. and contributors 
+// Copyright 2022-2023, Optimizely, Inc. and contributors 
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");  
 // you may not use this file except in compliance with the License.
@@ -31,8 +31,8 @@ class OdpSegmentManagerTests: XCTestCase {
         
         manager = OdpSegmentManager(cacheSize: 10,
                                     cacheTimeoutInSecs: 10,
-                                    odpConfig: odpConfig,
                                     apiManager: apiManager)
+        manager.odpConfig = odpConfig
     }
     
     func testFetchSegmentsSuccess_cacheMiss() {

--- a/Tests/OptimizelyTests-Common/OptimizelyUserContextTests_ODP_2.swift
+++ b/Tests/OptimizelyTests-Common/OptimizelyUserContextTests_ODP_2.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2022, Optimizely, Inc. and contributors
+// Copyright 2022-2023, Optimizely, Inc. and contributors
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");  
 // you may not use this file except in compliance with the License.
@@ -39,7 +39,6 @@ class OptimizelyUserContextTests_ODP_2: XCTestCase {
                                     cacheSize: 10,
                                     cacheTimeoutInSecs: 10,
                                     eventManager: OdpEventManager(sdkKey: sdkKey,
-                                                                  odpConfig: nil,
                                                                   apiManager: odpEventApiManager))
         
         // identified event will sent but wait in the queue until project config is ready


### PR DESCRIPTION
## Summary
OdpConfig is removed from OdpEventManager/OdpSegmentManager init params, which will be better for supporting custom OdpManager.

## Test plan
- Unit tests

## Issues
- [FSSDK-8843](https://jira.sso.episerver.net/browse/FSSDK-8843)
