### PR TITLE
[FSSDK-8951] Updating travis release version to 3.10.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -109,7 +109,7 @@ jobs:
       os: osx
       osx_image: xcode12.4
       env:
-        - VERSION=3.10.1
+        - VERSION=3.10.2
       install:
         # install hub
         - wget https://github.com/github/hub/releases/download/v2.11.2/hub-darwin-amd64-2.11.2.tgz -O /tmp/hub-darwin-amd64-2.11.2.tgz && tar -xvf /tmp/hub-darwin-amd64-2.11.2.tgz -C /usr/local/opt && ln -s /usr/local/opt/hub-darwin-amd64-2.11.2/bin/hub /usr/local/bin/hub
@@ -126,7 +126,7 @@ jobs:
       os: osx
       osx_image: xcode12.4
       env:
-        - VERSION=3.10.1
+        - VERSION=3.10.2
       install:
         # install hub
         - wget https://github.com/github/hub/releases/download/v2.11.2/hub-darwin-amd64-2.11.2.tgz -O /tmp/hub-darwin-amd64-2.11.2.tgz && tar -xvf /tmp/hub-darwin-amd64-2.11.2.tgz -C /usr/local/opt && ln -s /usr/local/opt/hub-darwin-amd64-2.11.2/bin/hub /usr/local/bin/hub


### PR DESCRIPTION
## Summary
- Updating travis release version to 3.10.2
