### PR TITLE
[FSSDK-9062] add more support for sendOdpEvent error handling

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -47,7 +47,8 @@ jobs:
 
   unittests: 
     if: "${{ github.event.inputs.PREP == '' && github.event.inputs.RELEASE == '' }}" 
-    uses: optimizely/swift-sdk/.github/workflows/unit_tests.yml@master
+    ##uses: optimizely/swift-sdk/.github/workflows/unit_tests.yml@master
+    uses: optimizely/swift-sdk/.github/workflows/unit_tests.yml@jae/empty-odp-action
 
   prepare_for_release:
     runs-on: macos-12

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -16,6 +16,7 @@ jobs:
         # - each xcode version has own simulator os versions.
         # - so to run tests with the target simulator, we have to find a proper xcode version pre-installed and support the target simulator os version.
         #   also, the xcode version (simulator_xcode_version) and simulator os versions (os) are moving target. We have to change these time to time.
+        # - see "https://github.com/actions/runner-images/blob/main/images/macos/macos-11-Readme.md" for installed macOS, xcode and simulator versions.
         include:
           - os: 15.2
             device: "iPhone 11"
@@ -23,14 +24,14 @@ jobs:
             test_sdk: "iphonesimulator"
             platform: "iOS Simulator"
             os_type: "iOS"
-            simulator_xcode_version: 13.2
-          - os: 14.4
+            simulator_xcode_version: 13.2.1
+          - os: 14.5
             device: "iPhone 8"
             scheme: "OptimizelySwiftSDK-iOS"
             test_sdk: "iphonesimulator"
             platform: "iOS Simulator"
             os_type: "iOS"
-            simulator_xcode_version: 12.4
+            simulator_xcode_version: 12.5.1
           - os: 13.7
             # good to have tests with older OS versions, but it looks like this is min OS+xcode versions supported by github actions
             device: "iPad Air (3rd generation)"

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -7,7 +7,7 @@ env:
 
 jobs:
   unittests:
-    runs-on: macos-11
+    runs-on: macos-12
     strategy:
       fail-fast: false
       matrix:
@@ -18,35 +18,35 @@ jobs:
         #   also, the xcode version (simulator_xcode_version) and simulator os versions (os) are moving target. We have to change these time to time.
         # - see "https://github.com/actions/runner-images/blob/main/images/macos/macos-11-Readme.md" for installed macOS, xcode and simulator versions.
         include:
-          - os: 15.2
+          - os: 16.1
             device: "iPhone 12"
             scheme: "OptimizelySwiftSDK-iOS"
             test_sdk: "iphonesimulator"
             platform: "iOS Simulator"
             os_type: "iOS"
-            simulator_xcode_version: 13.2.1
-          - os: 14.5
+            simulator_xcode_version: 14.1
+          - os: 15.5
             device: "iPhone 12"
             scheme: "OptimizelySwiftSDK-iOS"
             test_sdk: "iphonesimulator"
             platform: "iOS Simulator"
             os_type: "iOS"
-            simulator_xcode_version: 12.5.1
-          - os: 13.7
+            simulator_xcode_version: 13.4.1
+          - os: 15.0
             # good to have tests with older OS versions, but it looks like this is min OS+xcode versions supported by github actions
-            device: "iPad Air (3rd generation)"
+            device: "iPad Air (4th generation)"
             scheme: "OptimizelySwiftSDK-iOS"
             test_sdk: "iphonesimulator"
             platform: "iOS Simulator"
             os_type: "iOS"
-            simulator_xcode_version: 11.7
-          - os: 13.4
-            device: "Apple TV 4K"
+            simulator_xcode_version: 13.1
+          - os: 16.0
+            device: "Apple TV"
             scheme: "OptimizelySwiftSDK-tvOS"
             test_sdk: "appletvsimulator"
             platform: "tvOS Simulator"
             os_type: "tvOS"
-            simulator_xcode_version: 11.7
+            simulator_xcode_version: 14.1
     steps:
       - uses: actions/checkout@v3
       - uses: maxim-lobanov/setup-xcode@v1

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -32,15 +32,15 @@ jobs:
             platform: "iOS Simulator"
             os_type: "iOS"
             simulator_xcode_version: 13.4.1
-          - os: 15.0
+          - os: 15.5
             # good to have tests with older OS versions, but it looks like this is min OS+xcode versions supported by github actions
             device: "iPad Air (4th generation)"
             scheme: "OptimizelySwiftSDK-iOS"
             test_sdk: "iphonesimulator"
             platform: "iOS Simulator"
             os_type: "iOS"
-            simulator_xcode_version: 13.1
-          - os: 16.0
+            simulator_xcode_version: 13.4.1
+          - os: 16.1
             device: "Apple TV"
             scheme: "OptimizelySwiftSDK-tvOS"
             test_sdk: "appletvsimulator"
@@ -79,9 +79,9 @@ jobs:
 
           # github actions are very poor in supporting iOS simulators:
           # - to find pre-installed xcode version, run this:
-          ls /Applications/
+          ##ls /Applications/
           # - to find supported simulator os versions, run this (and find simulator with non-error "datapath")
-          xcrun simctl list --json devices
+          ##xcrun simctl list --json devices
 
           # switch to the target xcode version
           sudo xcode-select -switch /Applications/Xcode_$SIMULATOR_XCODE_VERSION.app

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -19,14 +19,14 @@ jobs:
         # - see "https://github.com/actions/runner-images/blob/main/images/macos/macos-11-Readme.md" for installed macOS, xcode and simulator versions.
         include:
           - os: 15.2
-            device: "iPhone 11"
+            device: "iPhone 12"
             scheme: "OptimizelySwiftSDK-iOS"
             test_sdk: "iphonesimulator"
             platform: "iOS Simulator"
             os_type: "iOS"
             simulator_xcode_version: 13.2.1
           - os: 14.5
-            device: "iPhone 8"
+            device: "iPhone 12"
             scheme: "OptimizelySwiftSDK-iOS"
             test_sdk: "iphonesimulator"
             platform: "iOS Simulator"
@@ -72,7 +72,7 @@ jobs:
           NAME: ${{ matrix.device }}
         run: |
           gem install coveralls-lcov
-          gem install cocoapods -v '1.9.3'
+          gem install cocoapods -v '1.11.3'
           pod repo update
           pod install
           HOMEBREW_NO_INSTALL_CLEANUP=true brew update && brew install jq

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -78,9 +78,9 @@ jobs:
 
           # github actions are very poor in supporting iOS simulators:
           # - to find pre-installed xcode version, run this:
-          # > ls /Applications/
+          ls /Applications/
           # - to find supported simulator os versions, run this (and find simulator with non-error "datapath")
-          # > xcrun simctl list --json devices
+          xcrun simctl list --json devices
 
           # switch to the target xcode version
           sudo xcode-select -switch /Applications/Xcode_$SIMULATOR_XCODE_VERSION.app

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -52,7 +52,7 @@ jobs:
       - uses: maxim-lobanov/setup-xcode@v1
         with:
           # macos version and supported simulator_xcode_versions are all related to this xcode_version, so be careful when you upgrade this.
-          xcode-version: 12.4
+          xcode-version: 14.1
       - name: set SDK Branch if PR
         if: ${{ github.event_name == 'pull_request' }}
         run: |

--- a/Scripts/test_all.sh
+++ b/Scripts/test_all.sh
@@ -5,19 +5,21 @@
 # More about XCode and its compatible simulators can be found here: https://github.com/actions/virtual-environments/blob/main/images/macos/macos-10.15-Readme.md
 # https://github.com/actions/virtual-environments/issues/551
 
-deviceModels=("iPhone 11" "iPhone 11" "iPhone 11" "Apple TV")
-osVersions=("13.7" "14.4" "15.0" "16.4")
-#xcodeVersions=("10.3" "11.3.1" "12.4" "10.3" "11.3.1" "12.4")
+deviceModels=("iPhone 12" "iPhone 8" "iPad Air (4th generation)" "Apple TV")
+osVersions=("16.0" "14.4" "15.0" "16.0")
+xcodeVersions=("14.3" "14.3" "14.3" "14.3")
 platforms=("iOS" "iOS" "iOS" "tvOS")
 testSdks=("iphonesimulator" "iphonesimulator" "iphonesimulator" "appletvsimulator")
 
 for i in "${!deviceModels[@]}"; do
-  #export PLATFORM="${platforms[$i]} Simulator"
-  #export OS="${osVersions[$i]}"
-  #export NAME="${deviceModels[$i]}"
-  #export OS_TYPE="${platforms[$i]}"
-  #export SIMULATOR_XCODE_VERSION="${xcodeVersions[$i]}"
+  export PLATFORM="${platforms[$i]} Simulator"
+  export OS="${osVersions[$i]}"
+  export NAME="${deviceModels[$i]}"
+  export OS_TYPE="${platforms[$i]}"
+  export SIMULATOR_XCODE_VERSION="${xcodeVersions[$i]}"
+  
   Scripts/prepare_simulator.sh
   echo "Testing OptimizelySwiftSDK-${platforms[$i]} (${deviceModels[$i]},OS=${osVersions[$i]})"
+  
   xcrun xcodebuild -workspace OptimizelySwiftSDK.xcworkspace -scheme "OptimizelySwiftSDK-${platforms[$i]}" -sdk "${testSdks[$i]}" -destination "platform=${platforms[$i]} Simulator,name=${deviceModels[$i]},OS=${osVersions[$i]}" test
 done

--- a/Scripts/test_all.sh
+++ b/Scripts/test_all.sh
@@ -1,21 +1,22 @@
+
 #!/bin/bash -e
 # Since github actions only provides limit simulators with each xcode, we need to link simulators from other versions of xcode to be used by current xcode.
 # We must use old simulators with current xcode since older xcode versions do not support swift 5 which is required by Swift SDK. 
 # More about XCode and its compatible simulators can be found here: https://github.com/actions/virtual-environments/blob/main/images/macos/macos-10.15-Readme.md
 # https://github.com/actions/virtual-environments/issues/551
 
-deviceModels=("iPhone SE" "iPhone 8" "iPhone 11" "Apple TV" "Apple TV" "Apple TV 4K")
-osVersions=("12.4" "13.3" "14.4" "12.4" "13.3" "14.3")
-xcodeVersions=("10.3" "11.3.1" "12.4" "10.3" "11.3.1" "12.4")
-platforms=("iOS" "iOS" "iOS" "tvOS" "tvOS" "tvOS")
-testSdks=("iphonesimulator" "iphonesimulator" "iphonesimulator" "appletvsimulator" "appletvsimulator" "appletvsimulator")
+deviceModels=("iPhone 11" "iPhone 11" "iPhone 11" "Apple TV")
+osVersions=("13.7" "14.4" "15.0" "16.4")
+#xcodeVersions=("10.3" "11.3.1" "12.4" "10.3" "11.3.1" "12.4")
+platforms=("iOS" "iOS" "iOS" "tvOS")
+testSdks=("iphonesimulator" "iphonesimulator" "iphonesimulator" "appletvsimulator")
 
 for i in "${!deviceModels[@]}"; do
-  export PLATFORM="${platforms[$i]} Simulator"
-  export OS="${osVersions[$i]}"
-  export NAME="${deviceModels[$i]}"
-  export OS_TYPE="${platforms[$i]}"
-  export SIMULATOR_XCODE_VERSION="${xcodeVersions[$i]}"
+  #export PLATFORM="${platforms[$i]} Simulator"
+  #export OS="${osVersions[$i]}"
+  #export NAME="${deviceModels[$i]}"
+  #export OS_TYPE="${platforms[$i]}"
+  #export SIMULATOR_XCODE_VERSION="${xcodeVersions[$i]}"
   Scripts/prepare_simulator.sh
   echo "Testing OptimizelySwiftSDK-${platforms[$i]} (${deviceModels[$i]},OS=${osVersions[$i]})"
   xcrun xcodebuild -workspace OptimizelySwiftSDK.xcworkspace -scheme "OptimizelySwiftSDK-${platforms[$i]}" -sdk "${testSdks[$i]}" -destination "platform=${platforms[$i]} Simulator,name=${deviceModels[$i]},OS=${osVersions[$i]}" test

--- a/Sources/Extensions/OptimizelyClient+Extension.swift
+++ b/Sources/Extensions/OptimizelyClient+Extension.swift
@@ -51,6 +51,7 @@ extension OptimizelyClient {
     ///   - eventDispatcher: custom EventDispatcher (optional)
     ///   - datafileHandler: custom datafile handler (optional)
     ///   - userProfileService: custom UserProfileService (optional)
+    ///   - odpManager: custom OdpManager (optional)
     ///   - periodicDownloadInterval: interval in secs for periodic background datafile download.
     ///         The recommended value is 10 * 60 secs (you can also set this to nil to use the recommended value).
     ///         Set this to 0 to disable periodic downloading.

--- a/Sources/ODP/OdpEventApiManager.swift
+++ b/Sources/ODP/OdpEventApiManager.swift
@@ -30,7 +30,7 @@ import Foundation
  {"title":"Accepted","status":202,"timestamp":"2022-06-30T20:59:52.046Z"}
 */
 
-public class OdpEventApiManager {
+open class OdpEventApiManager {
     let resourceTimeoutInSecs: Int?
 
     /// OdpEventApiManager init

--- a/Sources/ODP/OdpEventManager.swift
+++ b/Sources/ODP/OdpEventManager.swift
@@ -101,6 +101,7 @@ open class OdpEventManager {
     
     // MARK: - dispatch
     
+    // open for FSC testing support
     open func dispatch(_ event: OdpEvent) {
         if eventQueue.count < maxQueueSize {
             eventQueue.save(item: event)

--- a/Sources/ODP/OdpManager.swift
+++ b/Sources/ODP/OdpManager.swift
@@ -116,17 +116,35 @@ public class OdpManager {
     ///   - identifiers: a dictionary for identifiers.
     ///   - data: a dictionary for associated data. The default event data will be added to this data before sending to the ODP server.
     /// - Throws: `OptimizelyError` if error is detected
-    func sendEvent(type: String, action: String, identifiers: [String: String], data: [String: Any?]) throws {
+    func sendEvent(type: String?, action: String, identifiers: [String: String], data: [String: Any?]) throws {
         guard enabled else { throw OptimizelyError.odpNotEnabled }
         guard odpConfig.eventQueueingAllowed else { throw OptimizelyError.odpNotIntegrated }
         guard eventManager.isDataValidType(data) else { throw OptimizelyError.odpInvalidData }
+
+        if action.isEmpty { throw OptimizelyError.odpInvalidAction }
         
-        var identifiersWithVuid = identifiers
+        let typeUpdated = (type ?? "").isEmpty ? Constants.ODP.eventType : type!
+        
+        // add vuid to all events by default
+        
+        var identifiersUpdated = identifiers
         if identifiers[Constants.ODP.keyForVuid] == nil {
-            identifiersWithVuid[Constants.ODP.keyForVuid] = vuidManager.vuid
+            identifiersUpdated[Constants.ODP.keyForVuid] = vuidManager.vuid
         }
         
-        eventManager.sendEvent(type: type, action: action, identifiers: identifiersWithVuid, data: data)
+        // replace aliases (fs-user-id, FS_USER_ID, FS-USER-ID) with "fs_user_id".
+        
+        for (idKey, idValue) in identifiersUpdated {
+            if idKey == Constants.ODP.keyForUserId { break }
+            
+            if [Constants.ODP.keyForUserId, Constants.ODP.keyForUserIdAlias].contains(idKey.lowercased()) {
+                identifiersUpdated.removeValue(forKey: idKey)
+                identifiersUpdated[Constants.ODP.keyForUserId] = idValue
+                break;
+            }
+        }
+        
+        eventManager.sendEvent(type: typeUpdated, action: action, identifiers: identifiersUpdated, data: data)
     }
     
     func updateOdpConfig(apiKey: String?, apiHost: String?, segmentsToCheck: [String]) {

--- a/Sources/ODP/OdpManager.swift
+++ b/Sources/ODP/OdpManager.swift
@@ -140,7 +140,7 @@ public class OdpManager {
             if [Constants.ODP.keyForUserId, Constants.ODP.keyForUserIdAlias].contains(idKey.lowercased()) {
                 identifiersUpdated.removeValue(forKey: idKey)
                 identifiersUpdated[Constants.ODP.keyForUserId] = idValue
-                break;
+                break
             }
         }
         

--- a/Sources/ODP/OdpSegmentManager.swift
+++ b/Sources/ODP/OdpSegmentManager.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 
-public class OdpSegmentManager {    
+open class OdpSegmentManager {    
     var odpConfig = OdpConfig()
     var segmentsCache: LruCache<String, [String]>
     var apiMgr: OdpSegmentApiManager
@@ -33,7 +33,6 @@ public class OdpSegmentManager {
                 cacheTimeoutInSecs: Int,
                 apiManager: OdpSegmentApiManager? = nil,
                 resourceTimeoutInSecs: Int? = nil) {
-        self.odpConfig = odpConfig ?? OdpConfig()
         self.apiMgr = apiManager ?? OdpSegmentApiManager(timeout: resourceTimeoutInSecs)
         
         self.segmentsCache = LruCache<String, [String]>(size: cacheSize,

--- a/Sources/Optimizely+Decide/OptimizelyClient+Decide.swift
+++ b/Sources/Optimizely+Decide/OptimizelyClient+Decide.swift
@@ -44,8 +44,7 @@ extension OptimizelyClient {
         return createUserContext(userId: userId,
                                  attributes: (attributes ?? [:]) as [String: Any])
     }
-    
-    
+        
     /// Create a user context to be used internally without sending an ODP identify event.
     ///
     /// - Parameters:

--- a/Sources/Optimizely/OptimizelyClient.swift
+++ b/Sources/Optimizely/OptimizelyClient.swift
@@ -59,7 +59,7 @@ open class OptimizelyClient: NSObject {
     
     var decisionService: OPTDecisionService!
     public var notificationCenter: OPTNotificationCenter?
-    var odpManager: OdpManager!
+    public var odpManager: OdpManager!
     let sdkSettings: OptimizelySdkSettings
     
     // MARK: - Public interfaces
@@ -72,6 +72,7 @@ open class OptimizelyClient: NSObject {
     ///   - eventDispatcher: custom EventDispatcher (optional)
     ///   - datafileHandler: custom datafile handler (optional)
     ///   - userProfileService: custom UserProfileService (optional)
+    ///   - odpManager: custom OdpManager (optional)
     ///   - defaultLogLevel: default log level (optional. default = .info)
     ///   - defaultDecisionOptions: default decision options (optional)
     ///   - settings: SDK configuration (optional)

--- a/Sources/Optimizely/OptimizelyClient.swift
+++ b/Sources/Optimizely/OptimizelyClient.swift
@@ -941,7 +941,7 @@ extension OptimizelyClient {
                              action: String,
                              identifiers: [String: String] = [:],
                              data: [String: Any?] = [:]) throws {
-        try odpManager.sendEvent(type: type ?? Constants.ODP.eventType,
+        try odpManager.sendEvent(type: type,
                              action: action,
                              identifiers: identifiers,
                              data: data)

--- a/Sources/Optimizely/OptimizelyError.swift
+++ b/Sources/Optimizely/OptimizelyError.swift
@@ -88,6 +88,7 @@ public enum OptimizelyError: Error {
     case odpNotIntegrated
     case odpNotEnabled
     case odpInvalidData
+    case odpInvalidAction
 }
 
 // MARK: - CustomStringConvertible
@@ -163,6 +164,7 @@ extension OptimizelyError: CustomStringConvertible, ReasonProtocol {
         case .odpNotIntegrated:                             message = "ODP is not integrated."
         case .odpNotEnabled:                                message = "ODP is not enabled."
         case .odpInvalidData:                               message = "ODP data is not valid."
+        case .odpInvalidAction:                             message = "ODP action is not valid (cannot be empty)."
         }
         
         return message

--- a/Sources/Utils/Constants.swift
+++ b/Sources/Utils/Constants.swift
@@ -26,6 +26,7 @@ struct Constants {
     struct ODP {
         static let keyForVuid = "vuid"
         static let keyForUserId = "fs_user_id"
+        static let keyForUserIdAlias = "fs-user-id"   // reserved (auto-converted to "fs_user_id")
         static let eventType = "fullstack"
     }
     

--- a/Tests/OptimizelyTests-APIs/OptimizelyClientTests_ODP.swift
+++ b/Tests/OptimizelyTests-APIs/OptimizelyClientTests_ODP.swift
@@ -79,7 +79,7 @@ class OptimizelyClientTests_ODP: XCTestCase {
         
         try? optimizely.sendOdpEvent(action: "a2")
         
-        XCTAssertEqual("fullstack", odpManager.eventType)
+        XCTAssertEqual(nil, odpManager.eventType)
         XCTAssertEqual("a2", odpManager.eventAction)
         XCTAssertEqual([:], odpManager.eventIdentifiers)
         XCTAssertEqual([:], odpManager.eventData as! [String: String])
@@ -165,7 +165,7 @@ class OptimizelyClientTests_ODP: XCTestCase {
             XCTFail("Should accept all valid data value types.")
         }
     }
-
+    
     // MARK: - vuid
     
     func testVuid() {
@@ -223,7 +223,7 @@ extension OptimizelyClientTests_ODP {
         var apiHost: String?
         var segmentsToCheck = [String]()
 
-        override func sendEvent(type: String, action: String, identifiers: [String : String], data: [String : Any?]) {
+        override func sendEvent(type: String?, action: String, identifiers: [String : String], data: [String : Any?]) {
             self.eventType = type
             self.eventAction = action
             self.eventIdentifiers = identifiers

--- a/Tests/OptimizelyTests-Common/OdpManagerTests.swift
+++ b/Tests/OptimizelyTests-Common/OdpManagerTests.swift
@@ -196,6 +196,42 @@ class OdpManagerTests: XCTestCase {
 
         XCTAssertNil(eventManager.receivedType, "sendEvent requeut should be discarded if ODP disabled.")
     }
+    
+    func testSendEvent_emptyAction() {
+        do {
+            try manager.sendEvent(type: nil, action: "", identifiers: [:], data: [:])
+            XCTFail()
+        } catch OptimizelyError.odpInvalidAction {
+            XCTAssert(true)
+        } catch {
+            XCTFail("OptimizelyError expected if data has an empty action.")
+        }
+    }
+
+    func testSendEvent_emptyOrNilType() {
+        try? manager.sendEvent(type: nil, action: "a1", identifiers: [:], data: [:])
+        XCTAssertEqual(eventManager.receivedType, "fullstack")
+        
+        try? manager.sendEvent(type: "", action: "a1", identifiers: [:], data: [:])
+        XCTAssertEqual(eventManager.receivedType, "fullstack")
+    }
+
+    func testSendEvent_aliasIdentifiers() {
+        try? manager.sendEvent(type: nil, action: "a1", identifiers: ["fs_user_id": "v1"], data: [:])
+        XCTAssertEqual(eventManager.receivedIdentifiers, ["fs_user_id": "v1", "vuid": manager.vuid])
+        
+        try? manager.sendEvent(type: nil, action: "a1", identifiers: ["fs-user-id": "v1"], data: [:])
+        XCTAssertEqual(eventManager.receivedIdentifiers, ["fs_user_id": "v1", "vuid": manager.vuid])
+
+        try? manager.sendEvent(type: nil, action: "a1", identifiers: ["FS_USER_ID": "v1"], data: [:])
+        XCTAssertEqual(eventManager.receivedIdentifiers, ["fs_user_id": "v1", "vuid": manager.vuid])
+
+        try? manager.sendEvent(type: nil, action: "a1", identifiers: ["FS-USER-ID": "v1"], data: [:])
+        XCTAssertEqual(eventManager.receivedIdentifiers, ["fs_user_id": "v1", "vuid": manager.vuid])
+        
+        try? manager.sendEvent(type: nil, action: "a1", identifiers: ["email": "e1", "FS-USER-ID": "v1"], data: [:])
+        XCTAssertEqual(eventManager.receivedIdentifiers, ["email": "e1", "fs_user_id": "v1", "vuid": manager.vuid])
+    }
 
     // MARK: - updateConfig
     


### PR DESCRIPTION
## Summary
Add more support for sendOdpEvent error handling:

- empty string for action: throws odpInvalidAction
- nil/empty for type: use default "fullstack" type
- replace identifiers alias (fs-user-id/FS-USER-ID/FS_USER_ID) with fs_user_id

Include other clean-ups:

- upgrade macOS (12), xcode(14.3), and simulators (15.5 and 16.1) in github actions (tests hangs with old versions).
- upgrade local tests (Scrtips/test_all.sh) to cover a range of iOS versions (github actions not good for full coverage).

## Test plan
- Add unit tests covering all cases

## Issues
- [FSSDK-9062](https://jira.sso.episerver.net/projects/FSSDK/issues/FSSDK-9062)
