### PR TITLE
[FSSDK-9061] fix retries on odp event failures

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -47,8 +47,7 @@ jobs:
 
   unittests: 
     if: "${{ github.event.inputs.PREP == '' && github.event.inputs.RELEASE == '' }}" 
-    ##uses: optimizely/swift-sdk/.github/workflows/unit_tests.yml@master
-    uses: optimizely/swift-sdk/.github/workflows/unit_tests.yml@jae/empty-odp-action
+    uses: optimizely/swift-sdk/.github/workflows/unit_tests.yml@master
 
   prepare_for_release:
     runs-on: macos-12

--- a/Sources/Customization/DefaultEventDispatcher.swift
+++ b/Sources/Customization/DefaultEventDispatcher.swift
@@ -207,6 +207,13 @@ open class DefaultEventDispatcher: BackgroundingCallbacks, OPTEventDispatcher {
         let config = URLSessionConfiguration.ephemeral
         return URLSession(configuration: config)
     }
+    
+    // MARK: - Tests
+
+    open func close() {
+        self.flushEvents()
+        self.queueLock.sync {}
+    }
 
 }
 
@@ -256,13 +263,6 @@ extension DefaultEventDispatcher {
             timer.invalidate()
         }
         timer.property = nil
-    }
-    
-    // MARK: - Tests
-
-    open func close() {
-        self.flushEvents()
-        self.queueLock.sync {}
     }
     
 }

--- a/Sources/ODP/OdpEventManager.swift
+++ b/Sources/ODP/OdpEventManager.swift
@@ -159,17 +159,17 @@ open class OdpEventManager {
                 self.apiMgr.sendOdpEvents(apiKey: odpApiKey,
                                           apiHost: odpApiHost,
                                           events: events) { error in
+                    if let error = error {
+                        self.logger.e(error.reason)
+                    }
+
                     odpError = error
                     sync.leave()  // our send is done.
                 }
                 sync.wait()  // wait for send completed
                 
-                if let error = odpError {
-                    self.logger.e(error.reason)
-                }
-
                 // retry only for recoverable errors (connection failures or 5xx server errors)
-                if case .odpEventFailed(_, let canRetry) = odpError, canRetry {
+                if let error = odpError, case .odpEventFailed(_, let canRetry) = error, canRetry {
                     failureCount += 1
                     
                     if failureCount >= self.maxFailureCount {

--- a/Sources/ODP/OdpSegmentManager.swift
+++ b/Sources/ODP/OdpSegmentManager.swift
@@ -33,7 +33,6 @@ public class OdpSegmentManager {
                 cacheTimeoutInSecs: Int,
                 apiManager: OdpSegmentApiManager? = nil,
                 resourceTimeoutInSecs: Int? = nil) {
-        self.odpConfig = odpConfig ?? OdpConfig()
         self.apiMgr = apiManager ?? OdpSegmentApiManager(timeout: resourceTimeoutInSecs)
         
         self.segmentsCache = LruCache<String, [String]>(size: cacheSize,

--- a/Sources/Utils/LogMessage.swift
+++ b/Sources/Utils/LogMessage.swift
@@ -63,6 +63,7 @@ enum LogMessage {
     case unrecognizedAttribute(_ key: String)
     case eventBatchFailed
     case eventSendRetyFailed(_ count: Int)
+    case odpEventSendRetyFailed(_ count: Int)
     case failedToConvertMapToString
     case failedToAssignValue
     case valueForKeyNotFound(_ key: String)
@@ -123,8 +124,9 @@ extension LogMessage: CustomStringConvertible {
         case .unrecognizedAttribute(let key):                                   message = "Unrecognized attribute (\(key)) provided. Pruning before sending event to Optimizely."
         case .eventBatchFailed:                                                 message = "Failed to batch events"
         case .eventSendRetyFailed(let count):                                   message = "Event dispatch retries failed (\(count)) times"
+        case .odpEventSendRetyFailed(let count):                                message = "ODP event dispatch retries failed (\(count)) times"
         case .failedToConvertMapToString:                                       message = "Provided map could not be converted to string."
-        case .failedToAssignValue:                                      message = "Value for path could not be assigned to provided type."
+        case .failedToAssignValue:                                              message = "Value for path could not be assigned to provided type."
         case .valueForKeyNotFound(let key):                                     message = "Value for JSON key (\(key)) not found."
         }
         

--- a/Tests/OptimizelyTests-Common/OptimizelyDecisionTests.swift
+++ b/Tests/OptimizelyTests-Common/OptimizelyDecisionTests.swift
@@ -18,12 +18,13 @@ import XCTest
 
 class OptimizelyDecisionTests: XCTestCase {
     
+    let optimizely = OptimizelyClient(sdkKey: "sdkKey")
     let variables = OptimizelyJSON(map: ["k1": "v1"])!
-    let user = OptimizelyUserContext(optimizely: OptimizelyClient(sdkKey: "sdkKey"),
-                                     userId: "userId")
+    var user: OptimizelyUserContext!
     var decision: OptimizelyDecision!
     
     override func setUpWithError() throws {
+        user = OptimizelyUserContext(optimizely: optimizely, userId: "userId")
         decision = OptimizelyDecision(variationKey: "value-variationKey",
                                       enabled: true,
                                       variables: variables,
@@ -84,8 +85,7 @@ class OptimizelyDecisionTests: XCTestCase {
                                variables: variables,
                                ruleKey: "value-ruleKey",
                                flagKey: "value-flagKey",
-                               userContext: OptimizelyUserContext(optimizely: OptimizelyClient(sdkKey: "sdkKey"),
-                                                                  userId: "wrong-user"),
+                               userContext: OptimizelyUserContext(optimizely: optimizely, userId: "wrong-user"),
                                reasons: [])
         XCTAssert(d != decision)
 
@@ -116,7 +116,7 @@ class OptimizelyDecisionTests: XCTestCase {
     
     func testOptimizelyDecision_description2() {
         let variables = OptimizelyJSON(map: ["k2": true])!
-        let user = OptimizelyUserContext(optimizely: OptimizelyClient(sdkKey: "sdkKey"),
+        let user = OptimizelyUserContext(optimizely: optimizely,
                                          userId: "userId",
                                          attributes: ["age": 18])
         

--- a/Tests/TestUtils/OTUtils.swift
+++ b/Tests/TestUtils/OTUtils.swift
@@ -20,6 +20,7 @@ import XCTest
 class OTUtils {
     
     static let testSdkKeyBasename = "testSdkKey"
+    static let dummyClient = OptimizelyClient(sdkKey: "any-key")
 
     static func isEqualWithEncodeThenDecode<T: Codable & Equatable>(_ model: T) -> Bool {
         let jsonData = try! JSONEncoder().encode(model)
@@ -324,7 +325,8 @@ class OTUtils {
     // MARK: - decide
     
     static func user(userId: String? = nil, attributes: [String: Any?]? = nil) -> OptimizelyUserContext {
-        return OptimizelyUserContext(optimizely: OptimizelyClient(sdkKey: "any-key"),
+        // use a dummyClient to hold the weak reference in the user-context
+        return OptimizelyUserContext(optimizely: dummyClient,
                                      userId: userId ?? "any-user",
                                      attributes: attributes)
     }


### PR DESCRIPTION
## Summary
- Add support for retries (up to 3 times) when ODP event dispatch fails on connection or server errors. ODP events are discarded after max retries.
- Check reachability before dispatching to avoid discarding all events in the queue when network is down.

## Test plan
- Add unit tests with event errors and reachability scenarios

## Issues
- [FSSDK-9061](https://jira.sso.episerver.net/browse/FSSDK-9061)
