### PR TITLE
[FSSDK-9124] fix for ODP INVALID_IDENTIFIER_EXCEPTION code

### DIFF
--- a/Sources/ODP/OdpSegmentApiManager.swift
+++ b/Sources/ODP/OdpSegmentApiManager.swift
@@ -85,7 +85,8 @@ import Foundation
          "customer"
        ],
        "extensions": {
-         "classification": "InvalidIdentifierException"
+            "code": "INVALID_IDENTIFIER_EXCEPTION",
+            "classification": "DataFetchingException"
        }
      }
    ],
@@ -162,7 +163,7 @@ open class OdpSegmentApiManager {
             // most meaningful ODP errors are returned in 200 success JSON under {"errors": ...}
             if let odpErrors: [[String: Any]] = dict.extractComponent(keyPath: "errors") {
                 if let odpError = odpErrors.first, let errorClass: String = odpError.extractComponent(keyPath: "extensions.classification") {
-                    if errorClass == "InvalidIdentifierException" {
+                    if let errorCode: String = odpError.extractComponent(keyPath: "extensions.code"), errorCode == "INVALID_IDENTIFIER_EXCEPTION" {
                         returnError = .invalidSegmentIdentifier
                     } else {
                         returnError = .fetchSegmentsFailed(errorClass)

--- a/Tests/OptimizelyTests-Common/OdpSegmentApiManagerTests.swift
+++ b/Tests/OptimizelyTests-Common/OdpSegmentApiManagerTests.swift
@@ -435,7 +435,8 @@ extension OdpSegmentApiManagerTests {
             "customer"
           ],
           "extensions": {
-            "classification": "InvalidIdentifierException"
+            "code": "INVALID_IDENTIFIER_EXCEPTION",
+            "classification": "DataFetchingException"
           }
         }
       ],


### PR DESCRIPTION
## Summary

Support a new format for ODP `InvalidIdentifierException` (when SDK fetches segments with a non-registered userId).

```
       "extensions": {
            "code": "INVALID_IDENTIFIER_EXCEPTION",
            "classification": "DataFetchingException"
       }
```

## Test plan
Add unit tests to cover the new response format.

## Issues
- [FSSDK-9124](https://jira.sso.episerver.net/browse/FSSDK-9124)
