### PR TITLE
[FSSDK-8554] add blocking version of fetchQualifiedSegments

### DIFF
--- a/DemoSwiftApp/AppDelegate.swift
+++ b/DemoSwiftApp/AppDelegate.swift
@@ -136,7 +136,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             // For sample codes for APIs, see "Samples/SamplesForAPI.swift"
             //SamplesForAPI.checkOptimizelyConfig(optimizely: self.optimizely)
             //SamplesForAPI.checkOptimizelyUserContext(optimizely: self.optimizely)
-            //SamplesForAPI.checkAudienceSegments(optimizely: self.optimizely)
+            SamplesForAPI.checkAudienceSegments(optimizely: self.optimizely)
         }
     }
     

--- a/DemoSwiftApp/AppDelegate.swift
+++ b/DemoSwiftApp/AppDelegate.swift
@@ -136,7 +136,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             // For sample codes for APIs, see "Samples/SamplesForAPI.swift"
             //SamplesForAPI.checkOptimizelyConfig(optimizely: self.optimizely)
             //SamplesForAPI.checkOptimizelyUserContext(optimizely: self.optimizely)
-            SamplesForAPI.checkAudienceSegments(optimizely: self.optimizely)
+            //SamplesForAPI.checkAudienceSegments(optimizely: self.optimizely)
         }
     }
     


### PR DESCRIPTION
## Summary
- blocking version of `fetchQualifiedSegments` is added (convenient with asynchronous OptimizelyClient start)
- clean up non-blocking version of `fetchQualifiedSegments` (remove segments in completion handler)

## Test plan
- add unit tests for blocking `fetchQualifiedSegments`

## Issues
- [FSSDK-8554](https://jira.sso.episerver.net/browse/FSSDK-8554)