### PR TITLE
[FSSDK-8918] chore: fix release script

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -85,6 +85,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.CI_USER_TOKEN }}
         BRANCH: ${{ github.ref_name }}
+        COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
         COCOAPODS_VERSION: '1.11.3'
       run: |
         gem install cocoapods -v $COCOAPODS_VERSION

--- a/Scripts/run_release.sh
+++ b/Scripts/run_release.sh
@@ -8,6 +8,12 @@ set -e
 # COCOAPODS_TRUNK_TOKEN - should be defined in job settings so that we can `pod trunk push`
 
 function release_github {
+  LAST_RELEASE=$(git describe --abbrev=0 --tags)
+  if [[ ${LAST_RELEASE} == "v${VERSION}" ]]; then
+    echo "${LAST_RELEASE} tag exists already (probably created while in the current release process). Skipping..."
+    return
+  fi
+
   CHANGELOG="CHANGELOG.md"
 
   # check that CHANGELOG.md has been updated
@@ -23,7 +29,6 @@ function release_github {
   DESCRIPTION=$(awk "/^${NEW_VERSION}$/,/^${LAST_VERSION:-nothingmatched}$/" ${CHANGELOG} | grep -v "^${LAST_VERSION:-nothingmatched}$")
 
   hub release create v${VERSION} -m "Release ${VERSION}" -m "${DESCRIPTION}" -t "${BRANCH}"
-
 }
 
 function release_cocoapods {


### PR DESCRIPTION
## Summary
Fix release script
- add COCOAPODS_TRUNK_TOKEN env variable.
- auto tag generation can be skipped when retried.

## Issues
- [FSSDK-8918](https://jira.sso.episerver.net/browse/FSSDK-8918)
