### PR TITLE
[FSSDK-8918] fix: clean up UIKit import errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Optimizely Swift SDK Changelog
 
 ## 4.0.0-beta
-April 28, 2023
+May 1, 2023
 
 ### New Features  
 

--- a/Scripts/build_all.sh
+++ b/Scripts/build_all.sh
@@ -32,6 +32,8 @@ main() {
 
   xcodebuild -workspace OptimizelySwiftSDK.xcworkspace -scheme OptimizelySwiftSDK-iOS -configuration Release "${action}"
   xcodebuild -workspace OptimizelySwiftSDK.xcworkspace -scheme OptimizelySwiftSDK-tvOS -configuration Release "${action}"
+  xcodebuild -workspace OptimizelySwiftSDK.xcworkspace -scheme OptimizelySwiftSDK-macOS -configuration Release "${action}"
+  xcodebuild -workspace OptimizelySwiftSDK.xcworkspace -scheme OptimizelySwiftSDK-watchOS -configuration Release "${action}"
 }
 
 main

--- a/Scripts/run_prep.sh
+++ b/Scripts/run_prep.sh
@@ -7,10 +7,6 @@
 # Additionally, it needs the following environment variables:
 # VERSION - defined in swift.yml
 
-
-set -x
-
-
 COLOR_RESET='\033[0m'
 COLOR_MAGENTA='\033[0;35m'
 COLOR_CYAN='\033[0;36m'

--- a/Sources/Protocols/BackgroundingCallbacks.swift
+++ b/Sources/Protocols/BackgroundingCallbacks.swift
@@ -15,10 +15,11 @@
 //
 
 import Foundation
-#if os(macOS)
-import Cocoa
-#elseif os(watchOS)
+
+#if os(watchOS)
 import WatchKit
+#elseif os(macOS)
+import Cocoa
 #else
 import UIKit
 #endif

--- a/Sources/Protocols/BackgroundingCallbacks.swift
+++ b/Sources/Protocols/BackgroundingCallbacks.swift
@@ -17,7 +17,9 @@
 import Foundation
 #if os(macOS)
 import Cocoa
-#else // iOS, tvOS
+#elseif os(watchOS)
+import WatchKit
+#else
 import UIKit
 #endif
 

--- a/Sources/Utils/Utils.swift
+++ b/Sources/Utils/Utils.swift
@@ -112,7 +112,7 @@ class Utils {
     static func isStringType(_ value: Any) -> Bool {
         return (value is String)
     }
-        
+    
     // MARK: - NSNumber
     
     static func isNSNumberBoolType(_ value: Any) -> Bool {
@@ -195,4 +195,12 @@ class Utils {
         }
         return "Invalid conditions format."
     }
+    
+    // valid versions: 3.0, 2.1.2, 1.0.0-beta, ...
+    // invalid versions: "mac os 10.3", ...
+    static func isValidVersion(_ version: String) -> Bool {
+        let comps = version.split(separator: ".")
+        return comps.count > 1 && Int(comps.first!) != nil
+    }
+
 }

--- a/Sources/Utils/Utils.swift
+++ b/Sources/Utils/Utils.swift
@@ -15,10 +15,11 @@
 //
 
 import Foundation
-#if os(macOS)
-import Cocoa
-#elseif os(watchOS)
+
+#if os(watchOS)
 import WatchKit
+#elseif os(macOS)
+import Cocoa
 #else
 import UIKit
 #endif
@@ -46,6 +47,8 @@ class Utils {
     static var osVersion: String {
         #if os(watchOS)
         return WKInterfaceDevice.current().systemVersion
+        #elseif os(macOS)
+        return ProcessInfo().operatingSystemVersionString
         #else
         return UIDevice.current.systemVersion
         #endif
@@ -54,6 +57,8 @@ class Utils {
     static var deviceModel: String {
         #if os(watchOS)
         return WKInterfaceDevice.current().model
+        #elseif os(macOS)
+        return "N/A"
         #else
         return UIDevice.current.model
         #endif

--- a/Sources/Utils/Utils.swift
+++ b/Sources/Utils/Utils.swift
@@ -15,7 +15,9 @@
 //
 
 import Foundation
-#if os(watchOS)
+#if os(macOS)
+import Cocoa
+#elseif os(watchOS)
 import WatchKit
 #else
 import UIKit

--- a/Tests/OptimizelyTests-Common/OdpEventManagerTests.swift
+++ b/Tests/OptimizelyTests-Common/OdpEventManagerTests.swift
@@ -559,8 +559,8 @@ class OdpEventManagerTests: XCTestCase {
         XCTAssert((data["idempotence_id"] as! String).count > 3)
         XCTAssert((data["data_source_type"] as! String) == "sdk")
         XCTAssert((data["data_source"] as! String) == "swift-sdk")
-        XCTAssert((data["data_source_version"] as! String).count > 3)
-        XCTAssert((data["os_version"] as! String).count > 3)
+        XCTAssert(Utils.isValidVersion(data["data_source_version"] as! String))
+        XCTAssert(Utils.isValidVersion(data["os_version"] as! String))
         
         // os-dependent
         


### PR DESCRIPTION
## Summary
Cocoapods complain iOS specific features (UIKit, UIDevice) for other platforms.
Fix to support all platforms

## Test plan
- build with other platforms (macOS, watchOS)

## Issues
- [FSSDK-8918](https://jira.sso.episerver.net/browse/FSSDK-8918)
