### PR TITLE
[FSSDK-6907]: Adds a check to only save valid datafile in cache.

### DIFF
--- a/Sources/Customization/DefaultDatafileHandler.swift
+++ b/Sources/Customization/DefaultDatafileHandler.swift
@@ -168,7 +168,7 @@ open class DefaultDatafileHandler: OPTDatafileHandler {
                 }
                 return data
             } catch {
-                print("Error deserializing datafile: \(error.localizedDescription)")
+                self.logger.w("Error deserializing datafile: \(error.localizedDescription)")
             }
         }
         

--- a/Sources/Customization/DefaultDatafileHandler.swift
+++ b/Sources/Customization/DefaultDatafileHandler.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2019-2022, Optimizely, Inc. and contributors
+// Copyright 2019-2023, Optimizely, Inc. and contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -158,12 +158,18 @@ open class DefaultDatafileHandler: OPTDatafileHandler {
     open func getResponseData(sdkKey: String, response: HTTPURLResponse, url: URL?) -> Data? {
         if let url = url, let data = try? Data(contentsOf: url) {
             self.logger.d { String(data: data, encoding: .utf8) ?? "" }
-            self.saveDatafile(sdkKey: sdkKey, dataFile: data)
-            if let lastModified = response.getLastModified() {
-                self.sharedDataStore.setLastModified(sdkKey: sdkKey, lastModified: lastModified)
+            // Check datafile is valid json
+            do {
+                // Try deserializing datafile, isValidJSONObject is not applicable here
+                _ = try JSONSerialization.jsonObject(with: data)
+                self.saveDatafile(sdkKey: sdkKey, dataFile: data)
+                if let lastModified = response.getLastModified() {
+                    self.sharedDataStore.setLastModified(sdkKey: sdkKey, lastModified: lastModified)
+                }
+                return data
+            } catch {
+                print("Error deserializing datafile: \(error.localizedDescription)")
             }
-            
-            return data
         }
         
         return nil

--- a/Tests/OptimizelyTests-Common/DatafileHandlerTests.swift
+++ b/Tests/OptimizelyTests-Common/DatafileHandlerTests.swift
@@ -242,7 +242,7 @@ class DatafileHandlerTests: XCTestCase {
 
     func testPeriodicDownload() {
         let expection = XCTestExpectation(description: "Expect 10 periodic downloads")
-        let handler = MockDatafileHandler(statusCode: 200)
+        let handler = MockDatafileHandler(statusCode: 200, localResponseData: "{}")
         let now = Date()
         var count = 0
         var seconds = 0
@@ -263,7 +263,7 @@ class DatafileHandlerTests: XCTestCase {
     
     func testPeriodicDownload_PollingShouldNotBeAccumulatedWhileInBackground() {
         let expectation = XCTestExpectation(description: "polling")
-        let handler = MockDatafileHandler(statusCode: 200)
+        let handler = MockDatafileHandler(statusCode: 200, localResponseData: "{}")
         let now = Date()
         
         let updateInterval = 1
@@ -394,7 +394,7 @@ class DatafileHandlerTests: XCTestCase {
                 // will return 500
                 return MockUrlSession(withError: true)
             } else {
-                return MockUrlSession(statusCode: 200)
+                return MockUrlSession(statusCode: 200, localResponseData: "{}")
             }
         }
     }

--- a/Tests/OptimizelyTests-Common/NetworkReachabilityTests.swift
+++ b/Tests/OptimizelyTests-Common/NetworkReachabilityTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021, Optimizely, Inc. and contributors 
+// Copyright 2021, 2023 Optimizely, Inc. and contributors 
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");  
 // you may not use this file except in compliance with the License.
@@ -119,7 +119,7 @@ class NetworkReachabilityTests: XCTestCase {
     }
     
     func testFetchDatafile_numContiguousFails() {
-        let handler = MockDatafileHandler(withError: true)
+        let handler = MockDatafileHandler(withError: true, localResponseData: "{}")
         let reachability = handler.reachability
 
         var exp = expectation(description: "r")
@@ -164,7 +164,7 @@ class NetworkReachabilityTests: XCTestCase {
     }
 
     func testFetchDatafile_checkReachability() {
-        let handler = MockDatafileHandler(withError: true)
+        let handler = MockDatafileHandler(withError: true, localResponseData: "{}")
         let reachability = handler.reachability
         
         reachability.stop()
@@ -196,7 +196,7 @@ class NetworkReachabilityTests: XCTestCase {
         
         // no valid datafile cache
         
-        let handler = MockDatafileHandler(withError: true)
+        let handler = MockDatafileHandler(withError: true, localResponseData: "{}")
         let reachability = handler.reachability
         
         reachability.stop()

--- a/Tests/OptimizelyTests-MultiClients/DatafileHandlerTests_MultiClients.swift
+++ b/Tests/OptimizelyTests-MultiClients/DatafileHandlerTests_MultiClients.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2021, Optimizely, Inc. and contributors 
+// Copyright 2021, 2023, Optimizely, Inc. and contributors
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");  
 // you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ class DatafileHandlerTests_MultiClients: XCTestCase {
     
     func testConcurrentDownloadDatafiles() {
         // use a shared DatafileHandler instance
-        let mockHandler = MockDatafileHandler(statusCode: 200)
+        let mockHandler = MockDatafileHandler(statusCode: 200, localResponseData: "{}")
         
         sdkKeys = OTUtils.makeRandomSdkKeys(100)
 
@@ -153,7 +153,7 @@ class DatafileHandlerTests_MultiClients: XCTestCase {
     
     func testConcurrentAccessLastModified() {
         // use a shared DatafileHandler instance
-        let mockHandler = MockDatafileHandler(statusCode: 200)
+        let mockHandler = MockDatafileHandler(statusCode: 200, localResponseData: "{}")
 
         sdkKeys = OTUtils.makeRandomSdkKeys(100)
 
@@ -241,7 +241,7 @@ class DatafileHandlerTests_MultiClients: XCTestCase {
         }
         
         // use a shared DatafileHandler instance
-        let mockHandler = MockDatafileHandler(statusCode: 200)
+        let mockHandler = MockDatafileHandler(statusCode: 200, localResponseData: "{}")
         
         let numSdks = 50
         sdkKeys = OTUtils.makeRandomSdkKeys(numSdks)

--- a/Tests/TestUtils/MockUrlSession.swift
+++ b/Tests/TestUtils/MockUrlSession.swift
@@ -28,6 +28,7 @@ class MockUrlSession: URLSession {
     var localResponseData: String?
     var settingsMap: [String: (Int, Bool)]?
     var handler: MockDatafileHandler?
+    let lock = DispatchQueue(label: "mock-session-lock")
     
     class MockDownloadTask: URLSessionDownloadTask {
         var task: () -> Void
@@ -54,7 +55,9 @@ class MockUrlSession: URLSession {
     }
 
     init(handler: MockDatafileHandler? = nil, statusCode: Int = 0, withError: Bool = false, localResponseData: String? = nil) {
-        Self.validSessions += 1
+        lock.async {
+            Self.validSessions += 1
+        }
         self.handler = handler
         self.statusCode = statusCode
         self.withError = withError
@@ -62,7 +65,9 @@ class MockUrlSession: URLSession {
     }
    
     init(handler: MockDatafileHandler? = nil, settingsMap: [String: (Int, Bool)]) {
-        Self.validSessions += 1
+        lock.async {
+            Self.validSessions += 1
+        }
         self.handler = handler
         self.statusCode = 0
         self.withError = false
@@ -113,6 +118,8 @@ class MockUrlSession: URLSession {
     }
 
     override func finishTasksAndInvalidate() {
-        Self.validSessions -= 1
+        lock.async {
+            Self.validSessions -= 1
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Adds a check to only save valid datafile in cache.

## Test plan
- New unit tests added
- All previous unit tests should pass

## Issues
- [FSSDK-6907](https://jira.sso.episerver.net/browse/FSSDK-6907)
