### PR TITLE
[FSSDK-9600] Fix: Atomic property deadlocks issue 

### DIFF
--- a/OptimizelySwiftSDK.xcodeproj/project.pbxproj
+++ b/OptimizelySwiftSDK.xcodeproj/project.pbxproj
@@ -1980,6 +1980,7 @@
 		84F6BADE27FD011B004BE62A /* OptimizelyUserContextTests_ODP_Decide.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84F6BADC27FD011B004BE62A /* OptimizelyUserContextTests_ODP_Decide.swift */; };
 		98137C552A41E86F004896EB /* OptimizelyClientTests_Init_Async_Await.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98137C542A41E86F004896EB /* OptimizelyClientTests_Init_Async_Await.swift */; };
 		98137C572A42BA0F004896EB /* OptimizelyUserContextTests_ODP_Aync_Await.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98137C562A42BA0F004896EB /* OptimizelyUserContextTests_ODP_Aync_Await.swift */; };
+		989FE4632A8E892A00036C94 /* AtomicPropertyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 989FE4622A8E892A00036C94 /* AtomicPropertyTests.swift */; };
 		BD1C3E8524E4399C0084B4DA /* SemanticVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B97DD93249D327F003DE606 /* SemanticVersion.swift */; };
 		BD64853C2491474500F30986 /* Optimizely.h in Headers */ = {isa = PBXBuildFile; fileRef = 6E75167A22C520D400B2B157 /* Optimizely.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BD64853E2491474500F30986 /* Audience.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E75169822C520D400B2B157 /* Audience.swift */; };
@@ -2418,6 +2419,7 @@
 		84F6BADC27FD011B004BE62A /* OptimizelyUserContextTests_ODP_Decide.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OptimizelyUserContextTests_ODP_Decide.swift; sourceTree = "<group>"; };
 		98137C542A41E86F004896EB /* OptimizelyClientTests_Init_Async_Await.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptimizelyClientTests_Init_Async_Await.swift; sourceTree = "<group>"; };
 		98137C562A42BA0F004896EB /* OptimizelyUserContextTests_ODP_Aync_Await.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptimizelyUserContextTests_ODP_Aync_Await.swift; sourceTree = "<group>"; };
+		989FE4622A8E892A00036C94 /* AtomicPropertyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AtomicPropertyTests.swift; sourceTree = "<group>"; };
 		BD6485812491474500F30986 /* Optimizely.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Optimizely.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C78CAF572445AD8D009FE876 /* OptimizelyJSON.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptimizelyJSON.swift; sourceTree = "<group>"; };
 		C78CAF652446DB91009FE876 /* OptimizelyClientTests_OptimizelyJSON.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptimizelyClientTests_OptimizelyJSON.swift; sourceTree = "<group>"; };
@@ -2613,6 +2615,7 @@
 			children = (
 				6EA641F2262F4E6900E29532 /* DatafileHandlerTests_MultiClients.swift */,
 				6E424D7526324DBD0081004A /* AtomicArrayTests.swift */,
+				989FE4622A8E892A00036C94 /* AtomicPropertyTests.swift */,
 				6E2F8AFE26B22E8000DCEEB9 /* ConcurrencyTests_SingleClient.swift */,
 				6E2D5DAD26338CA00002077F /* AtomicDictionaryTests.swift */,
 				6E5D120C2638DCE1000ABFC3 /* EventDispatcherTests_MultiClients.swift */,
@@ -4265,6 +4268,7 @@
 				6E424D1326324B620081004A /* BackgroundingCallbacks.swift in Sources */,
 				845945C2287758A000D13E11 /* OdpConfig.swift in Sources */,
 				6E424D1426324B620081004A /* OPTNotificationCenter.swift in Sources */,
+				989FE4632A8E892A00036C94 /* AtomicPropertyTests.swift in Sources */,
 				6E424D5026324C4D0081004A /* OptimizelyDecideOption.swift in Sources */,
 				6E424D5126324C4D0081004A /* OptimizelyDecision.swift in Sources */,
 				6E424D1526324B620081004A /* DataStoreQueueStack.swift in Sources */,

--- a/Sources/Utils/AtomicProperty.swift
+++ b/Sources/Utils/AtomicProperty.swift
@@ -21,13 +21,13 @@ class AtomicProperty<T> {
     var property: T? {
         get {
             var retVal: T?
-            lock.withLock {
+            withLock {
                 retVal = _property
             }
             return retVal
         }
         set {
-            lock.withLock {
+            withLock {
                 self._property = newValue
             }
         }
@@ -45,12 +45,18 @@ class AtomicProperty<T> {
     // perform an atomic operation on the atomic property
     // the operation will not run if the property is nil.
     func performAtomic(atomicOperation: (_ prop:inout T) -> Void) {
-        lock.withLock {
+        withLock {
             if var prop = _property {
                 atomicOperation(&prop)
                 _property = prop
             }
         }
+    }
+    
+    private func withLock(callBack: () -> Void) {
+        lock.lock()
+        callBack()
+        lock.unlock()
     }
 
 }

--- a/Tests/OptimizelyTests-MultiClients/AtomicPropertyTests.swift
+++ b/Tests/OptimizelyTests-MultiClients/AtomicPropertyTests.swift
@@ -20,7 +20,7 @@ import XCTest
 class AtomicPropertyTests: XCTestCase {
     private var subject = AtomicProperty<Int>()
     
-    func test_atomicPropertyDeadlocks() async {
+    func test_atomicPropertyDeadlocks() {
         let operationQueue = OperationQueue()
         let expectations = (0..<80).map { id in
             let expectation = expectation(description: "Queue Test \(id)")
@@ -37,8 +37,8 @@ class AtomicPropertyTests: XCTestCase {
         operationQueue.addBarrierBlock {
             finalExpectation.fulfill()
         }
-
-        await fulfillment(of: expectations + CollectionOfOne(finalExpectation), timeout: 10.0)
+        
+        wait(for:  expectations + CollectionOfOne(finalExpectation), timeout: 10.0)
 
         self.subject.property = 0
     }

--- a/Tests/OptimizelyTests-MultiClients/AtomicPropertyTests.swift
+++ b/Tests/OptimizelyTests-MultiClients/AtomicPropertyTests.swift
@@ -1,0 +1,17 @@
+//
+// Copyright 2022, Optimizely, Inc. and contributors 
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");  
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at   
+// 
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation

--- a/Tests/OptimizelyTests-MultiClients/AtomicPropertyTests.swift
+++ b/Tests/OptimizelyTests-MultiClients/AtomicPropertyTests.swift
@@ -22,7 +22,7 @@ class AtomicPropertyTests: XCTestCase {
     
     func test_atomicPropertyDeadlocks() {
         let operationQueue = OperationQueue()
-        let expectations = (0..<80).map { id in
+        let expectations = (0..<80).map { id -> XCTestExpectation in
             let expectation = expectation(description: "Queue Test \(id)")
             operationQueue.addOperation {
                 self.subject.property = (self.subject.property ?? 0) + 1


### PR DESCRIPTION
## Summary
- Implemented RecurrsiveLock instead of DispatchQueue for AtomicProperty 

## Test plan
 - New test case added
 - The previous test should pass

## Issues
https://jira.sso.episerver.net/browse/FSSDK-9600
