### PR TITLE
[FSSDK-9776] handle duplicate experiment key

### DIFF
--- a/Sources/Optimizely/OptimizelyClient.swift
+++ b/Sources/Optimizely/OptimizelyClient.swift
@@ -782,7 +782,7 @@ open class OptimizelyClient: NSObject {
     public func getOptimizelyConfig() throws -> OptimizelyConfig {
         guard let config = self.config else { throw OptimizelyError.sdkNotReady }
         
-        return OptimizelyConfigImp(projectConfig: config)
+        return OptimizelyConfigImp(projectConfig: config, logger: logger)
     }
 
 }

--- a/Sources/Optimizely/OptimizelyConfig.swift
+++ b/Sources/Optimizely/OptimizelyConfig.swift
@@ -95,7 +95,7 @@ struct OptimizelyConfigImp: OptimizelyConfig {
     var attributes: [OptimizelyAttribute] = []
     var audiences: [OptimizelyAudience] = []
     var events: [OptimizelyEvent] = []
-	private var logger = OPTLoggerFactory.getLogger()
+	var logger = OPTLoggerFactory.getLogger()
 	
     init(projectConfig: ProjectConfig) {
         guard let project = projectConfig.project else { return }

--- a/Sources/Optimizely/OptimizelyConfig.swift
+++ b/Sources/Optimizely/OptimizelyConfig.swift
@@ -96,7 +96,7 @@ struct OptimizelyConfigImp: OptimizelyConfig {
     var audiences: [OptimizelyAudience] = []
     var events: [OptimizelyEvent] = []
     var logger = OPTLoggerFactory.getLogger()
-	
+
     init(projectConfig: ProjectConfig) {
         guard let project = projectConfig.project else { return }
         
@@ -151,11 +151,10 @@ extension OptimizelyConfigImp {
     
     func makeExperimentsMap(project: Project, experiments: [Experiment]) -> [String: Experiment] {
         var map = [String: Experiment]()
-		
         experiments.forEach {
-			if map.keys.contains($0.key) {
-				logger.w("Duplicate experiment keys found in datafile: \($0.key)")
-			}
+            if map.keys.contains($0.key) {
+                logger.w("Duplicate experiment keys found in datafile: \($0.key)")
+            }
             map[$0.key] = $0
         }
         return map

--- a/Sources/Optimizely/OptimizelyConfig.swift
+++ b/Sources/Optimizely/OptimizelyConfig.swift
@@ -95,7 +95,8 @@ struct OptimizelyConfigImp: OptimizelyConfig {
     var attributes: [OptimizelyAttribute] = []
     var audiences: [OptimizelyAudience] = []
     var events: [OptimizelyEvent] = []
-
+	private var logger = OPTLoggerFactory.getLogger()
+	
     init(projectConfig: ProjectConfig) {
         guard let project = projectConfig.project else { return }
         
@@ -150,7 +151,11 @@ extension OptimizelyConfigImp {
     
     func makeExperimentsMap(project: Project, experiments: [Experiment]) -> [String: Experiment] {
         var map = [String: Experiment]()
+		
         experiments.forEach {
+			if map.keys.contains($0.key) {
+				logger.w("Duplicate experiment keys found in datafile: \($0.key)")
+			}
             map[$0.key] = $0
         }
         return map

--- a/Sources/Optimizely/OptimizelyConfig.swift
+++ b/Sources/Optimizely/OptimizelyConfig.swift
@@ -95,7 +95,7 @@ struct OptimizelyConfigImp: OptimizelyConfig {
     var attributes: [OptimizelyAttribute] = []
     var audiences: [OptimizelyAudience] = []
     var events: [OptimizelyEvent] = []
-	var logger = OPTLoggerFactory.getLogger()
+    var logger = OPTLoggerFactory.getLogger()
 	
     init(projectConfig: ProjectConfig) {
         guard let project = projectConfig.project else { return }

--- a/Sources/Optimizely/OptimizelyConfig.swift
+++ b/Sources/Optimizely/OptimizelyConfig.swift
@@ -95,9 +95,8 @@ struct OptimizelyConfigImp: OptimizelyConfig {
     var attributes: [OptimizelyAttribute] = []
     var audiences: [OptimizelyAudience] = []
     var events: [OptimizelyEvent] = []
-    var logger = OPTLoggerFactory.getLogger()
-
-    init(projectConfig: ProjectConfig) {
+    
+    init(projectConfig: ProjectConfig, logger: OPTLogger = DefaultLogger()) {
         guard let project = projectConfig.project else { return }
         
         self.environmentKey = project.environmentKey ?? ""
@@ -140,7 +139,7 @@ struct OptimizelyConfigImp: OptimizelyConfig {
             return updatedRollout
         }
         
-        self.experimentsMap = makeExperimentsMap(project: project, experiments: updatedExperiments)
+        self.experimentsMap = makeExperimentsMap(project: project, experiments: updatedExperiments, logger: logger)
         self.featuresMap = makeFeaturesMap(project: project, experiments: updatedExperiments, rollouts: updatedRollouts)
     }
 }
@@ -149,7 +148,7 @@ struct OptimizelyConfigImp: OptimizelyConfig {
 
 extension OptimizelyConfigImp {
     
-    func makeExperimentsMap(project: Project, experiments: [Experiment]) -> [String: Experiment] {
+    func makeExperimentsMap(project: Project, experiments: [Experiment], logger: OPTLogger) -> [String: Experiment] {
         var map = [String: Experiment]()
         experiments.forEach {
             if map.keys.contains($0.key) {

--- a/Tests/OptimizelyTests-APIs/OptimizelyClientTests_OptimizelyConfig.swift
+++ b/Tests/OptimizelyTests-APIs/OptimizelyClientTests_OptimizelyConfig.swift
@@ -259,66 +259,66 @@ class OptimizelyClientTests_OptimizelyConfig: XCTestCase {
         XCTAssertNil(result)
     }
 	
-	func testOptimizelyConfigWithDuplicateKeys() {
-		let exp0: [String : Any] = [
-			"id": "10001",
-			"key": "duplicate_key",
-			"status": "Running",
-			"layerId": "22222",
-			"variations": [],
-			"trafficAllocation": [],
-			"audienceIds": ["33333"],
-			"audienceConditions": [],
-			"forcedVariations": ["12345": "1234567890"]
-		]
-		
-		let exp1: [String : Any] = [
-			"id": "10005",
-			"key": "duplicate_key",
-			"status": "Running",
-			"layerId": "22222",
-			"variations": [],
-			"trafficAllocation": [],
-			"audienceIds": ["33333"],
-			"audienceConditions": [],
-			"forcedVariations": ["12345": "1234567890"]
-		]
-		
-		var projectData: [String: Any] = [
-			"version": "4",
-			"projectId": "11111",
-			"experiments": [],
-			"audiences": [],
-			"groups": [],
-			"attributes": [],
-			"accountId": "1234567890",
-			"events": [],
-			"revision": "5",
-			"anonymizeIP": true,
-			"rollouts": [],
-			"typedAudiences": [],
-			"integrations": [],
-			"featureFlags": [],
-			"botFiltering": false,
-			"sendFlagDecisions": true
-		]
-		
-		projectData["experiments"] = [exp0, exp1]
-		let model: Project = try! OTUtils.model(from: projectData)
-		let projectConfig = ProjectConfig()
-		projectConfig.project = model
-		
-		optimizely.config = projectConfig
-		
-		let optiConfig = try! optimizely.getOptimizelyConfig()
-		let optimizelyExpMap: [String: OptimizelyExperiment] = optiConfig.experimentsMap
-		
-		let logger = (optiConfig as! OptimizelyConfigImp).logger as! TestLogger
-		XCTAssertEqual(logger.getMessages(.warning), ["Duplicate experiment keys found in datafile: duplicate_key"])
-		
-		XCTAssertEqual(optimizelyExpMap.count, 1)
-		XCTAssertEqual(optimizelyExpMap["duplicate_key"]?.id, "10005")
-	}
+    func testOptimizelyConfigWithDuplicateKeys() {
+        let exp0: [String : Any] = [
+            "id": "10001",
+            "key": "duplicate_key",
+            "status": "Running",
+            "layerId": "22222",
+            "variations": [],
+            "trafficAllocation": [],
+            "audienceIds": ["33333"],
+            "audienceConditions": [],
+            "forcedVariations": ["12345": "1234567890"]
+        ]
+        
+        let exp1: [String : Any] = [
+            "id": "10005",
+            "key": "duplicate_key",
+            "status": "Running",
+            "layerId": "22222",
+            "variations": [],
+            "trafficAllocation": [],
+            "audienceIds": ["33333"],
+            "audienceConditions": [],
+            "forcedVariations": ["12345": "1234567890"]
+        ]
+        
+        var projectData: [String: Any] = [
+            "version": "4",
+            "projectId": "11111",
+            "experiments": [],
+            "audiences": [],
+            "groups": [],
+            "attributes": [],
+            "accountId": "1234567890",
+            "events": [],
+            "revision": "5",
+            "anonymizeIP": true,
+            "rollouts": [],
+            "typedAudiences": [],
+            "integrations": [],
+            "featureFlags": [],
+            "botFiltering": false,
+            "sendFlagDecisions": true
+        ]
+        
+        projectData["experiments"] = [exp0, exp1]
+        let model: Project = try! OTUtils.model(from: projectData)
+        let projectConfig = ProjectConfig()
+        projectConfig.project = model
+        
+        optimizely.config = projectConfig
+        
+        let optiConfig = try! optimizely.getOptimizelyConfig()
+        let optimizelyExpMap: [String: OptimizelyExperiment] = optiConfig.experimentsMap
+        
+        let logger = (optiConfig as! OptimizelyConfigImp).logger as! TestLogger
+        XCTAssertEqual(logger.getMessages(.warning), ["Duplicate experiment keys found in datafile: duplicate_key"])
+        
+        XCTAssertEqual(optimizelyExpMap.count, 1)
+        XCTAssertEqual(optimizelyExpMap["duplicate_key"]?.id, "10005")
+    }
     
 }
 
@@ -430,38 +430,38 @@ extension OptimizelyEvent {
 // MARK: - Mock Loggers
 
 fileprivate class TestLogger: OPTLogger {
-	private static var _logLevel: OptimizelyLogLevel?
-	public static var logLevel: OptimizelyLogLevel {
-		get {
-			return _logLevel ?? .info
-		}
-		set (newLevel) {
-			_logLevel = newLevel
-		}
-	}
-	
-	required public init() {
-		clearMessages()
-	}
-	
-	func log(level: OptimizelyLogLevel, message: String) {
-		logMessages[level.rawValue].append(message)
-	}
-	
-	// Utils
-	
-	var logMessages = [[String]]()
-	
-	var logCount: Int {
-		return logMessages.reduce(0) { $0 + $1.count }
-	}
-	
-	func getMessages(_ level: OptimizelyLogLevel) -> [String] {
-		return logMessages[level.rawValue]
-	}
-	
-	func clearMessages() {
-		logMessages = [[String]](repeating: [], count: OptimizelyLogLevel.debug.rawValue + 1)
-	}
-	
+    private static var _logLevel: OptimizelyLogLevel?
+    public static var logLevel: OptimizelyLogLevel {
+        get {
+            return _logLevel ?? .info
+        }
+        set (newLevel) {
+            _logLevel = newLevel
+        }
+    }
+    
+    required public init() {
+        clearMessages()
+    }
+    
+    func log(level: OptimizelyLogLevel, message: String) {
+        logMessages[level.rawValue].append(message)
+    }
+    
+    // Utils
+    
+    var logMessages = [[String]]()
+    
+    var logCount: Int {
+        return logMessages.reduce(0) { $0 + $1.count }
+    }
+    
+    func getMessages(_ level: OptimizelyLogLevel) -> [String] {
+        return logMessages[level.rawValue]
+    }
+    
+    func clearMessages() {
+        logMessages = [[String]](repeating: [], count: OptimizelyLogLevel.debug.rawValue + 1)
+    }
+    
 }

--- a/Tests/OptimizelyTests-APIs/OptimizelyClientTests_OptimizelyConfig.swift
+++ b/Tests/OptimizelyTests-APIs/OptimizelyClientTests_OptimizelyConfig.swift
@@ -26,7 +26,6 @@ class OptimizelyClientTests_OptimizelyConfig: XCTestCase {
         let datafile = OTUtils.loadJSONDatafile("optimizely_config_datafile")!
 
         self.optimizely = OptimizelyClient(sdkKey: "12345",
-                                           logger: TestLogger(),
                                            userProfileService: OTUtils.createClearUserProfileService())
         try! self.optimizely.start(datafile: datafile)
     }
@@ -308,12 +307,9 @@ class OptimizelyClientTests_OptimizelyConfig: XCTestCase {
         let projectConfig = ProjectConfig()
         projectConfig.project = model
         
-        optimizely.config = projectConfig
-        
-        let optiConfig = try! optimizely.getOptimizelyConfig()
-        let optimizelyExpMap: [String: OptimizelyExperiment] = optiConfig.experimentsMap
-        
-        let logger = optimizely.logger as! TestLogger
+        let logger = TestLogger()
+        let optiConfigImpl = OptimizelyConfigImp(projectConfig: projectConfig, logger: logger)
+        let optimizelyExpMap: [String: OptimizelyExperiment] = optiConfigImpl.experimentsMap
         XCTAssertEqual(logger.getMessages(.warning), ["Duplicate experiment keys found in datafile: duplicate_key"])
         
         XCTAssertEqual(optimizelyExpMap.count, 1)

--- a/Tests/OptimizelyTests-APIs/OptimizelyClientTests_OptimizelyConfig.swift
+++ b/Tests/OptimizelyTests-APIs/OptimizelyClientTests_OptimizelyConfig.swift
@@ -257,6 +257,67 @@ class OptimizelyClientTests_OptimizelyConfig: XCTestCase {
         let result = try? self.optimizely.getOptimizelyConfig()
         XCTAssertNil(result)
     }
+	
+	func testOptimizelyConfigWithDuplicateKeys() {
+		let exp0: [String : Any] = [
+			"id": "10001",
+			"key": "duplicate_key",
+			"status": "Running",
+			"layerId": "22222",
+			"variations": [],
+			"trafficAllocation": [],
+			"audienceIds": ["33333"],
+			"audienceConditions": [],
+			"forcedVariations": ["12345": "1234567890"]
+		]
+		
+		let exp1: [String : Any] = [
+			"id": "10005",
+			"key": "duplicate_key",
+			"status": "Running",
+			"layerId": "22222",
+			"variations": [],
+			"trafficAllocation": [],
+			"audienceIds": ["33333"],
+			"audienceConditions": [],
+			"forcedVariations": ["12345": "1234567890"]
+		]
+		
+		var projectData: [String: Any] = [
+			"version": "4",
+			"projectId": "11111",
+			"experiments": [],
+			"audiences": [],
+			"groups": [],
+			"attributes": [],
+			"accountId": "1234567890",
+			"events": [],
+			"revision": "5",
+			"anonymizeIP": true,
+			"rollouts": [],
+			"typedAudiences": [],
+			"integrations": [],
+			"featureFlags": [],
+			"botFiltering": false,
+			"sendFlagDecisions": true
+		]
+		
+		projectData["experiments"] = [exp0, exp1]
+		let model: Project = try! OTUtils.model(from: projectData)
+		let projectConfig = ProjectConfig()
+		projectConfig.project = model
+		
+		optimizely = OptimizelyClient(
+			sdkKey: "demo_key"
+		)
+		
+		optimizely.config = projectConfig
+				
+		let optimizelyExpMap: [String: OptimizelyExperiment] = try! optimizely.getOptimizelyConfig().experimentsMap
+		
+		XCTAssertEqual(optimizelyExpMap.count, 1)
+		XCTAssertEqual(optimizelyExpMap["duplicate_key"]?.id, "10005")
+	}
     
 }
 

--- a/Tests/OptimizelyTests-APIs/OptimizelyClientTests_OptimizelyConfig.swift
+++ b/Tests/OptimizelyTests-APIs/OptimizelyClientTests_OptimizelyConfig.swift
@@ -313,7 +313,7 @@ class OptimizelyClientTests_OptimizelyConfig: XCTestCase {
         let optiConfig = try! optimizely.getOptimizelyConfig()
         let optimizelyExpMap: [String: OptimizelyExperiment] = optiConfig.experimentsMap
         
-        let logger = (optiConfig as! OptimizelyConfigImp).logger as! TestLogger
+        let logger = optimizely.logger as! TestLogger
         XCTAssertEqual(logger.getMessages(.warning), ["Duplicate experiment keys found in datafile: duplicate_key"])
         
         XCTAssertEqual(optimizelyExpMap.count, 1)

--- a/Tests/OptimizelyTests-APIs/OptimizelyClientTests_OptimizelyConfig.swift
+++ b/Tests/OptimizelyTests-APIs/OptimizelyClientTests_OptimizelyConfig.swift
@@ -26,7 +26,7 @@ class OptimizelyClientTests_OptimizelyConfig: XCTestCase {
         let datafile = OTUtils.loadJSONDatafile("optimizely_config_datafile")!
 
         self.optimizely = OptimizelyClient(sdkKey: "12345",
-										   logger: TestLogger(),
+                                           logger: TestLogger(),
                                            userProfileService: OTUtils.createClearUserProfileService())
         try! self.optimizely.start(datafile: datafile)
     }

--- a/Tests/OptimizelyTests-DataModel/ProjectConfigTests.swift
+++ b/Tests/OptimizelyTests-DataModel/ProjectConfigTests.swift
@@ -79,69 +79,6 @@ class ProjectConfigTests: XCTestCase {
         XCTAssertEqual(featureMap["1003"], ["2002"])
         XCTAssertEqual(featureMap["1004"], ["2002"])
     }
-
-	func testProjectConfigWithDuplicateKey() {
-		let exp0: [String : Any] = [
-			"id": "10001",
-			"key": "duplicate_key",
-			"status": "Running",
-			"layerId": "22222",
-			"variations": [],
-			"trafficAllocation": [],
-			"audienceIds": ["33333"],
-			"audienceConditions": [],
-			"forcedVariations": ["12345": "1234567890"]
-		]
-		
-		let exp1: [String : Any] = [
-			"id": "10005",
-			"key": "duplicate_key",
-			"status": "Running",
-			"layerId": "22222",
-			"variations": [],
-			"trafficAllocation": [],
-			"audienceIds": ["33333"],
-			"audienceConditions": [],
-			"forcedVariations": ["12345": "1234567890"]
-		]
-		
-		var projectData: [String: Any] = [
-			"version": "4",
-			"projectId": "11111",
-			"experiments": [],
-			"audiences": [],
-			"groups": [],
-			"attributes": [],
-			"accountId": "1234567890",
-			"events": [],
-			"revision": "5",
-			"anonymizeIP": true,
-			"rollouts": [],
-			"typedAudiences": [],
-			"integrations": [],
-			"featureFlags": [],
-			"botFiltering": false,
-			"sendFlagDecisions": true
-		]
-		
-		projectData["experiments"] = [exp0, exp1]
-		let model: Project = try! OTUtils.model(from: projectData)
-		let projectConfig = ProjectConfig()
-		projectConfig.project = model
-		
-		optimizely = OptimizelyClient(
-			sdkKey: "demo_key",
-			logger: _TestLogger()
-		)
-		
-		optimizely.config = projectConfig
-				
-		let optimizelyExpMap: [String: OptimizelyExperiment] = try! optimizely.getOptimizelyConfig().experimentsMap
-		
-		XCTAssertEqual(optimizelyExpMap.count, 1)
-		XCTAssertEqual(optimizelyExpMap["duplicate_key"]?.id, "10005")
-	}
-		
 	
     func testFlagVariations() {
         let datafile = OTUtils.loadJSONDatafile("decide_datafile")!

--- a/Tests/OptimizelyTests-DataModel/ProjectConfigTests.swift
+++ b/Tests/OptimizelyTests-DataModel/ProjectConfigTests.swift
@@ -79,7 +79,7 @@ class ProjectConfigTests: XCTestCase {
         XCTAssertEqual(featureMap["1003"], ["2002"])
         XCTAssertEqual(featureMap["1004"], ["2002"])
     }
-	
+    
     func testFlagVariations() {
         let datafile = OTUtils.loadJSONDatafile("decide_datafile")!
         let optimizely = OptimizelyClient(sdkKey: "12345",

--- a/Tests/OptimizelyTests-DataModel/ProjectConfigTests.swift
+++ b/Tests/OptimizelyTests-DataModel/ProjectConfigTests.swift
@@ -79,7 +79,70 @@ class ProjectConfigTests: XCTestCase {
         XCTAssertEqual(featureMap["1003"], ["2002"])
         XCTAssertEqual(featureMap["1004"], ["2002"])
     }
-    
+
+	func testProjectConfigWithDuplicateKey() {
+		let exp0: [String : Any] = [
+			"id": "10001",
+			"key": "duplicate_key",
+			"status": "Running",
+			"layerId": "22222",
+			"variations": [],
+			"trafficAllocation": [],
+			"audienceIds": ["33333"],
+			"audienceConditions": [],
+			"forcedVariations": ["12345": "1234567890"]
+		]
+		
+		let exp1: [String : Any] = [
+			"id": "10005",
+			"key": "duplicate_key",
+			"status": "Running",
+			"layerId": "22222",
+			"variations": [],
+			"trafficAllocation": [],
+			"audienceIds": ["33333"],
+			"audienceConditions": [],
+			"forcedVariations": ["12345": "1234567890"]
+		]
+		
+		var projectData: [String: Any] = [
+			"version": "4",
+			"projectId": "11111",
+			"experiments": [],
+			"audiences": [],
+			"groups": [],
+			"attributes": [],
+			"accountId": "1234567890",
+			"events": [],
+			"revision": "5",
+			"anonymizeIP": true,
+			"rollouts": [],
+			"typedAudiences": [],
+			"integrations": [],
+			"featureFlags": [],
+			"botFiltering": false,
+			"sendFlagDecisions": true
+		]
+		
+		projectData["experiments"] = [exp0, exp1]
+		let model: Project = try! OTUtils.model(from: projectData)
+		let projectConfig = ProjectConfig()
+		projectConfig.project = model
+		
+		optimizely = OptimizelyClient(
+			sdkKey: "demo_key",
+			logger: _TestLogger()
+		)
+		
+		optimizely.config = projectConfig
+				
+		let optimizelyExpMap: [String: OptimizelyExperiment] = try! optimizely.getOptimizelyConfig().experimentsMap
+		
+		XCTAssertEqual(optimizelyExpMap.count, 1)
+		XCTAssertEqual(optimizelyExpMap["duplicate_key"]?.id, "10005")
+	}
+		
+	
     func testFlagVariations() {
         let datafile = OTUtils.loadJSONDatafile("decide_datafile")!
         let optimizely = OptimizelyClient(sdkKey: "12345",


### PR DESCRIPTION
## Summary
When duplicate experiment key found in the data file, SDK returns correct experiment map in  OptimizelyConfig

- Keep latest experiment key, found in the datafile experiment list
- Add warning log "Duplicate keys found in datafile: {key-name}"

## Test plan
- Add test case for OptimizelyConfig with duplicate key

## Issues
- [FSSDK-9776](https://jira.sso.episerver.net/browse/FSSDK-9776)
