### PR TITLE
[FSSDK-9899] fix:  hub, command not found

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -57,17 +57,10 @@ jobs:
     - uses: maxim-lobanov/setup-xcode@v1
       with:
         xcode-version: 14.1.0
-    - name: Install Homebrew
+    - name: Install Hub by Homebrew
       run: |
         /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-
-    - name: Install Hub
-      run: |
         brew install hub
-
-    - name: Verify Hub Installation
-      run: |
-        hub version
     - id: prepare_for_release
       name: Prepare for release
       env:
@@ -92,17 +85,10 @@ jobs:
     - uses: maxim-lobanov/setup-xcode@v1
       with:
         xcode-version: 14.1.0
-    - name: Install Homebrew
+    - name: Install Hub by Homebrew
       run: |
         /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-
-    - name: Install Hub
-      run: |
         brew install hub
-
-    - name: Verify Hub Installation
-      run: |
-        hub version
     - name: Push to cocoapods.org
       env:
         HOME: 'home/runner'

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -57,6 +57,17 @@ jobs:
     - uses: maxim-lobanov/setup-xcode@v1
       with:
         xcode-version: 14.1.0
+    - name: Install Homebrew
+      run: |
+        /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+    - name: Install Hub
+      run: |
+        brew install hub
+
+    - name: Verify Hub Installation
+      run: |
+        hub version
     - id: prepare_for_release
       name: Prepare for release
       env:
@@ -81,6 +92,17 @@ jobs:
     - uses: maxim-lobanov/setup-xcode@v1
       with:
         xcode-version: 14.1.0
+    - name: Install Homebrew
+      run: |
+        /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+    - name: Install Hub
+      run: |
+        brew install hub
+
+    - name: Verify Hub Installation
+      run: |
+        hub version
     - name: Push to cocoapods.org
       env:
         HOME: 'home/runner'


### PR DESCRIPTION
## Summary
- Hub command not found for pre-release workflow. Hub installation task added into swift.yml workflow.
- [Before fix] (https://github.com/optimizely/swift-sdk/actions/runs/7398824524/job/20128860808)
- [After fix] (https://github.com/optimizely/swift-sdk/actions/runs/7399129592/job/20129831283)

## Test plan
- `prepare_for_release` and `release` workflow should pass.

## Issues
- [FSSDK-9899](https://jira.sso.episerver.net/browse/FSSDK-9899)
