### PR TITLE
[FSSDK-9945] fix: privacy manifest file value for required reason API

### DIFF
--- a/Sources/Supporting Files/PrivacyInfo.xcprivacy
+++ b/Sources/Supporting Files/PrivacyInfo.xcprivacy
@@ -20,12 +20,12 @@
 	<key>NSPrivacyAccessedAPITypes</key>
 	<array>
 		<dict>
-			<key>NSPrivacyAccessedAPITypeReasons</key>
-			<array>
-				<string>To store configuration and event data temporarily</string>
-			</array>
 			<key>NSPrivacyAccessedAPIType</key>
 			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
 		</dict>
 	</array>
 </dict>


### PR DESCRIPTION
## Summary
- Current value was supplied by us, but the value should align with the list [CA92.1, 1C8F.1, C56D.1, AC6B.1] [Ref](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api)

## Test plan
- N/A

## Issues
- [FSSDK-9945](https://jira.sso.episerver.net/browse/FSSDK-9945)
