### PR TITLE
[FSSDK-9946] chore: add coccoapods support to bundle privacy manifest file

### DIFF
--- a/OptimizelySwiftSDK.podspec
+++ b/OptimizelySwiftSDK.podspec
@@ -15,6 +15,7 @@ Pod::Spec.new do |s|
     :tag => "v"+s.version.to_s
   }
   s.source_files            = "Sources/**/*.swift"
+  s.resource_bundles        = { 'OptimizelySwiftSDK' => ['Sources/Supporting Files/PrivacyInfo.xcprivacy'] }
   s.swift_version           = ["5.0", "5.1"]
   s.framework               = "Foundation"
   s.requires_arc            = true


### PR DESCRIPTION
## Summary
- Without the `resource_bundles` specification in podspec, cocoapods doesn't include the `PrivacyInfo.xcprivacy` file into the main app bundle. It causes third party SDK's privacy to be missing in the main app's privacy report.
- Ref [pod#10325](https://github.com/CocoaPods/CocoaPods/issues/10325#issuecomment-1718723762)

## Test plan
- Follow the steps:
   1. Add dependency into a demo app.
   2. Archive the app
   3. Generate privacy report and verify report


## Issues
- [FSSDK-9946](https://jira.sso.episerver.net/browse/FSSDK-9946)
