### PR TITLE
Add PrivacyInfo inside resources in Swift Package

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,11 @@ let package = Package(
                  targets: ["Optimizely"])
     ],
     targets: [
-        .target(name: "Optimizely", path: "Sources")
+        .target(name: "Optimizely", 
+                path: "Sources",
+                exclude: ["Supporting Files/PrivacyInfo.xcprivacy"],
+                resources: [.copy("Supporting Files/PrivacyInfo.xcprivacy")]
+        )
     ],
     swiftLanguageVersions: [.v5]
 )


### PR DESCRIPTION
## Summary
- As far as I know, PrivacyInfo needs to be as a resource in order to get it in the application. Same as in Cocoapods but for SPM.

## Test plan

## Issues
- Not opened issue
