### PR TITLE
[FSSDK-9950] chore: SPM support added to process privacy manifest

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -24,5 +24,5 @@ let package = Package(
             resources: [.copy("Supporting Files/PrivacyInfo.xcprivacy")]
         )
     ],
-    swiftLanguageVersions: [.v5]
+    swiftLanguageVersions: [.v5, .version("5.9")]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,8 @@
-// swift-tools-version:5.0
+// swift-tools-version:5.3
+// The Swift tools version declares the version of the PackageDescription library,
+// the minimum version of the Swift tools and Swift language compatibility version to process the manifest,
+// and the minimum version of the Swift tools that are needed to use the Swift package.
+
 import PackageDescription
 
 let package = Package(
@@ -14,7 +18,11 @@ let package = Package(
                  targets: ["Optimizely"])
     ],
     targets: [
-        .target(name: "Optimizely", path: "Sources")
+        .target(
+            name: "Optimizely",
+            path: "Sources",
+            resources: [.copy("Supporting Files/PrivacyInfo.xcprivacy")]
+        )
     ],
     swiftLanguageVersions: [.v5]
 )


### PR DESCRIPTION
## Summary
- SPM support added to process the privacy manifest info file. [Resource](https://docs.swift.org/package-manager/PackageDescription/PackageDescription.html#resource)
- Swift tools version updated to 5.4 [About the Swift Tools Version](https://docs.swift.org/package-manager/PackageDescription/PackageDescription.html#)
- Update package compiling swift version. [SwiftVersion](https://docs.swift.org/package-manager/PackageDescription/PackageDescription.html#swiftversion)

## Issues
- [FSSDK-9950](https://jira.sso.episerver.net/browse/FSSDK-9950)