### PR TITLE
[FSSDK-9952] chore: prepare for release 3.10.5

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -17,7 +17,7 @@ on:
         description: release
 
 env:
-  VERSION: 3.10.4
+  VERSION: 3.10.5
 
 jobs:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Optimizely Swift SDK Changelog
 
+## 3.10.5
+Jan 19, 2024
+
+### Bug Fixes
+* Value for required reason API fixed at privacy manifest file. ([#541](https://github.com/optimizely/swift-sdk/pull/541))
+* Add coccoapods support to bundle privacy manifest file. ([#542](https://github.com/optimizely/swift-sdk/pull/542))
+* Add SPM support to bundle privacy manifest file. ([#544](https://github.com/optimizely/swift-sdk/pull/544))
+
 ## 3.10.4
 December 8, 2023
 

--- a/OptimizelySwiftSDK.podspec
+++ b/OptimizelySwiftSDK.podspec
@@ -15,6 +15,7 @@ Pod::Spec.new do |s|
     :tag => "v"+s.version.to_s
   }
   s.source_files            = "Sources/**/*.swift"
+  s.resource_bundles        = { 'OptimizelySwiftSDK' => ['Sources/Supporting Files/PrivacyInfo.xcprivacy'] }
   s.swift_version           = ["5.0", "5.1"]
   s.framework               = "Foundation"
   s.requires_arc            = true

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,8 @@
-// swift-tools-version:5.0
+// swift-tools-version:5.3
+// The Swift tools version declares the version of the PackageDescription library,
+// the minimum version of the Swift tools and Swift language compatibility version to process the manifest,
+// and the minimum version of the Swift tools that are needed to use the Swift package.
+
 import PackageDescription
 
 let package = Package(
@@ -14,7 +18,11 @@ let package = Package(
                  targets: ["Optimizely"])
     ],
     targets: [
-        .target(name: "Optimizely", path: "Sources")
+        .target(
+            name: "Optimizely",
+            path: "Sources",
+            resources: [.copy("Supporting Files/PrivacyInfo.xcprivacy")]
+        )
     ],
-    swiftLanguageVersions: [.v5]
+    swiftLanguageVersions: [.v5, .version("5.9")]
 )

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Add the dependency on the Optimizely Swift SDK with Swift Package Manager in `Xc
 #### CocoaPods 
 1. Add the following lines to the _Podfile_:<pre>
 ```use_frameworks!```
-```pod 'OptimizelySwiftSDK', '~> 3.10.4'```
+```pod 'OptimizelySwiftSDK', '~> 3.10.5'```
 </pre>
 
 2. Run the following command: <pre>``` pod install ```</pre>
@@ -45,7 +45,7 @@ Add the dependency on the Optimizely Swift SDK with Swift Package Manager in `Xc
 Further installation instructions for Cocoapods: https://guides.cocoapods.org/using/getting-started.html
 
 #### Carthage
-1. Add the following lines to the _Cartfile_:<pre>```github "optimizely/swift-sdk" ~> 3.10.4```</pre>
+1. Add the following lines to the _Cartfile_:<pre>```github "optimizely/swift-sdk" ~> 3.10.5```</pre>
 
 2. Run the following command:<pre>```carthage update```</pre>
 

--- a/Sources/Supporting Files/PrivacyInfo.xcprivacy
+++ b/Sources/Supporting Files/PrivacyInfo.xcprivacy
@@ -20,12 +20,12 @@
 	<key>NSPrivacyAccessedAPITypes</key>
 	<array>
 		<dict>
-			<key>NSPrivacyAccessedAPITypeReasons</key>
-			<array>
-				<string>To store configuration and event data temporarily</string>
-			</array>
 			<key>NSPrivacyAccessedAPIType</key>
 			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
 		</dict>
 	</array>
 </dict>


### PR DESCRIPTION
## Summary
- Value for required reason API fixed at privacy manifest file. ([#541](https://github.com/optimizely/swift-sdk/pull/541))
- Add coccoapods support to bundle privacy manifest file. ([#542](https://github.com/optimizely/swift-sdk/pull/542))
- Add SPM support to bundle privacy manifest file. ([#544](https://github.com/optimizely/swift-sdk/pull/544))

## Test Plan
- All previous test should pass

## Issues
- [FSSDK-9952](https://jira.sso.episerver.net/browse/FSSDK-9952)
