### PR TITLE
[FSSDK-10876] chore: migrate artifact to v4 

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -93,7 +93,7 @@ jobs:
           Scripts/prepare_simulator.sh
           Scripts/run_unit_tests.sh
       - name: Check on failures (Archive Test Results)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: steps.unit_tests.outcome != 'success'
         with:
           name: build-logs-${{ matrix.device }}-${{ matrix.os }}


### PR DESCRIPTION
## Summary
- Artifact actions v3 will be deprecated by December 5



## Test plan
- All testcases should be passed

## Issues
- [FSSDK-10876](https://jira.sso.episerver.net/browse/FSSDK-10876)
