### PR TITLE
[FSSDK-11449] chore: add experiment id and variation id added into decision notification payload

### DIFF
--- a/Sources/Implementation/DecisionInfo.swift
+++ b/Sources/Implementation/DecisionInfo.swift
@@ -140,9 +140,17 @@ struct DecisionInfo {
             decisionInfo[Constants.DecisionInfoKeys.variationKey] = variation?.key ?? NSNull()      // keep key in the map even with nil value
             decisionInfo[Constants.DecisionInfoKeys.ruleKey] = ruleKey ?? NSNull()                  //
             decisionInfo[Constants.DecisionInfoKeys.reasons] = reasons
-            decisionInfo[Constants.DecisionInfoKeys.decisionEventDispatched] = decisionEventDispatched
         }
         
+        decisionInfo[Constants.DecisionInfoKeys.decisionEventDispatched] = decisionEventDispatched
+        
+        if let expId = experiment?.id {
+            decisionInfo[Constants.ExperimentDecisionInfoKeys.experimentId] = expId
+        }
+        
+        if let varId = variation?.id {
+            decisionInfo[Constants.ExperimentDecisionInfoKeys.variationId] = varId
+        }
         return decisionInfo
     }
 

--- a/Sources/Utils/Constants.swift
+++ b/Sources/Utils/Constants.swift
@@ -89,7 +89,9 @@ struct Constants {
     }
     
     struct ExperimentDecisionInfoKeys {
+        static let experimentId = "experimentId"
         static let experiment = "experimentKey"
+        static let variationId = "variationId"
         static let variation = "variationKey"
     }
     

--- a/Tests/OptimizelyTests-Common/DecisionListenerTests_Datafile.swift
+++ b/Tests/OptimizelyTests-Common/DecisionListenerTests_Datafile.swift
@@ -37,12 +37,16 @@ class DecisionListenerTests_Datafile: XCTestCase {
         var notificationVariation: String?
         var notificationExperiment: String?
         var notificationType: String?
+        var expId: String?
+        var varId: String?
         
         let exp = expectation(description: "x")
 
         _ = notificationCenter.addDecisionNotificationListener(decisionListener: { (type, _, _, decisionInfo) in
             notificationExperiment = decisionInfo[Constants.ExperimentDecisionInfoKeys.experiment] as? String
             notificationVariation = decisionInfo[Constants.ExperimentDecisionInfoKeys.variation] as? String
+            expId = decisionInfo[Constants.ExperimentDecisionInfoKeys.experimentId] as? String
+            varId = decisionInfo[Constants.ExperimentDecisionInfoKeys.variationId] as? String
             notificationType = type
             exp.fulfill()
         })
@@ -56,6 +60,8 @@ class DecisionListenerTests_Datafile: XCTestCase {
         XCTAssertEqual(variation, "all_traffic_variation")
         XCTAssertEqual(notificationExperiment, "ab_running_exp_audience_combo_empty_conditions")
         XCTAssertEqual(notificationVariation, "all_traffic_variation")
+        XCTAssertEqual(expId, "10390977723")
+        XCTAssertEqual(varId, "10416523170")
         XCTAssertEqual(notificationType, Constants.DecisionType.abTest.rawValue)
     }
     
@@ -63,12 +69,18 @@ class DecisionListenerTests_Datafile: XCTestCase {
         var notificationVariation: String?
         var notificationExperiment: String?
         var notificationType: String?
+        var expId: String?
+        var varId: String?
         
         let exp = expectation(description: "x")
 
         _ = notificationCenter.addDecisionNotificationListener(decisionListener: { (type, _, _, decisionInfo) in
             notificationExperiment = decisionInfo[Constants.ExperimentDecisionInfoKeys.experiment] as? String
             notificationVariation = decisionInfo[Constants.ExperimentDecisionInfoKeys.variation] as? String
+            expId = decisionInfo[Constants.ExperimentDecisionInfoKeys.experimentId] as? String
+            varId = decisionInfo[Constants.ExperimentDecisionInfoKeys.variationId] as? String
+            expId = decisionInfo[Constants.ExperimentDecisionInfoKeys.experimentId] as? String
+            varId = decisionInfo[Constants.ExperimentDecisionInfoKeys.variationId] as? String
             notificationType = type
             exp.fulfill()
         })
@@ -81,6 +93,8 @@ class DecisionListenerTests_Datafile: XCTestCase {
 
         XCTAssertEqual(notificationExperiment, "ab_running_exp_audience_combo_exact_foo_or_true__and__42_or_4_2")
         XCTAssertEqual(notificationVariation, nil)
+        XCTAssertEqual(expId, "10390977714")
+        XCTAssertEqual(varId, nil)
         XCTAssertEqual(notificationType, Constants.DecisionType.abTest.rawValue)
         notificationCenter.clearAllNotificationListeners()
     }
@@ -93,12 +107,16 @@ class DecisionListenerTests_Datafile: XCTestCase {
         var notificationVariation: String?
         var notificationExperiment: String?
         var notificationType: String?
+        var expId: String?
+        var varId: String?
         
         let exp = expectation(description: "x")
 
         _ = notificationCenter.addDecisionNotificationListener(decisionListener: { (type, _, _, decisionInfo) in
             notificationExperiment = decisionInfo[Constants.ExperimentDecisionInfoKeys.experiment] as? String
             notificationVariation = decisionInfo[Constants.ExperimentDecisionInfoKeys.variation] as? String
+            expId = decisionInfo[Constants.ExperimentDecisionInfoKeys.experimentId] as? String
+            varId = decisionInfo[Constants.ExperimentDecisionInfoKeys.variationId] as? String
             notificationType = type
             exp.fulfill()
        })
@@ -111,6 +129,8 @@ class DecisionListenerTests_Datafile: XCTestCase {
         XCTAssertEqual(notificationExperiment, "ab_running_exp_audience_combo_empty_conditions")
         XCTAssertEqual(notificationVariation, "all_traffic_variation")
         XCTAssertEqual(notificationType, Constants.DecisionType.abTest.rawValue)
+        XCTAssertEqual(expId, "10390977723")
+        XCTAssertEqual(varId, "10416523170")
         notificationCenter.clearAllNotificationListeners()
     }
     
@@ -118,12 +138,15 @@ class DecisionListenerTests_Datafile: XCTestCase {
         var notificationVariation: String?
         var notificationExperiment: String?
         var notificationType: String?
-        
+        var expId: String?
+        var varId: String?
         let exp = expectation(description: "x")
 
         _ = notificationCenter.addDecisionNotificationListener(decisionListener: { (type, _, _, decisionInfo) in
             notificationExperiment = decisionInfo[Constants.ExperimentDecisionInfoKeys.experiment] as? String
             notificationVariation = decisionInfo[Constants.ExperimentDecisionInfoKeys.variation] as? String
+            expId = decisionInfo[Constants.ExperimentDecisionInfoKeys.experimentId] as? String
+            varId = decisionInfo[Constants.ExperimentDecisionInfoKeys.variationId] as? String
             notificationType = type
             exp.fulfill()
         })
@@ -133,6 +156,8 @@ class DecisionListenerTests_Datafile: XCTestCase {
 
         XCTAssertEqual(notificationExperiment, "ab_running_exp_audience_combo_exact_foo_or_true__and__42_or_4_2")
         XCTAssertEqual(notificationVariation, nil)
+        XCTAssertEqual(expId, "10390977714")
+        XCTAssertEqual(varId, nil)
         XCTAssertEqual(notificationType, Constants.DecisionType.abTest.rawValue)
         notificationCenter.clearAllNotificationListeners()
     }


### PR DESCRIPTION
## Summary
- add experiment id and variation id added into decision notification payload



## Test plan
- [FSC Check](https://github.com/optimizely/fullstack-sdk-compatibility-suite/actions/runs/15110727259/job/42469422640)

## Issues
- [FSSDK-11449](https://jira.sso.episerver.net/browse/FSSDK-11449)
