### PR TITLE
[FSSDK-11154] chore: add remove method to LRU Cache for CMAB service

### DIFF
--- a/Sources/ODP/LruCache.swift
+++ b/Sources/ODP/LruCache.swift
@@ -89,6 +89,16 @@ class LruCache<K: Hashable, V> {
         }
     }
     
+    func remove(key: K) {
+        if maxSize <= 0 { return }
+        queue.async(flags: .barrier) {
+            if var item = self.map[key] {
+                self.removeFromLink(item)
+                self.map[key] = nil
+            }
+        }
+    }
+    
     // read cache contents without order update
     func peek(key: K) -> V? {
         if maxSize <= 0 { return nil }


### PR DESCRIPTION
## Summary
- Add remove method to LRU Cache for CMAB service


## Test plan
- All existing testcases should pass

## Issues
- FSSDK-11154
