### PR TITLE
refactor: Added ability to inject custom directory for DataStoreFile

### DIFF
--- a/Sources/Customization/DefaultEventDispatcher.swift
+++ b/Sources/Customization/DefaultEventDispatcher.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 public enum DataStoreType {
-    case file, memory, userDefaults
+    case file(directory: FileManager.SearchPathDirectory? = nil), memory, userDefaults
 }
 
 open class DefaultEventDispatcher: BackgroundingCallbacks, OPTEventDispatcher {
@@ -54,7 +54,7 @@ open class DefaultEventDispatcher: BackgroundingCallbacks, OPTEventDispatcher {
     let reachability = NetworkReachability(maxContiguousFails: 1)
 
     public init(batchSize: Int = DefaultValues.batchSize,
-                backingStore: DataStoreType = .file,
+                backingStore: DataStoreType = .file(directory: nil),
                 dataStoreName: String = "OPTEventQueue",
                 timerInterval: TimeInterval = DefaultValues.timeInterval,
                 maxQueueSize: Int = DefaultValues.maxQueueSize) {
@@ -63,9 +63,14 @@ open class DefaultEventDispatcher: BackgroundingCallbacks, OPTEventDispatcher {
         self.maxQueueSize = maxQueueSize >= 100 ? maxQueueSize : DefaultValues.maxQueueSize
         
         switch backingStore {
-        case .file:
-            self.eventQueue = DataStoreQueueStackImpl<EventForDispatch>(queueStackName: "OPTEventQueue",
-                                                                        dataStore: DataStoreFile<[Data]>(storeName: dataStoreName))
+        case .file(let directory):
+            if let directory {
+                self.eventQueue = DataStoreQueueStackImpl<EventForDispatch>(queueStackName: "OPTEventQueue",
+                                                                            dataStore: DataStoreFile<[Data]>(storeName: dataStoreName, directory: directory))
+            } else {
+                self.eventQueue = DataStoreQueueStackImpl<EventForDispatch>(queueStackName: "OPTEventQueue",
+                                                                            dataStore: DataStoreFile<[Data]>(storeName: dataStoreName))
+            }
         case .memory:
             self.eventQueue = DataStoreQueueStackImpl<EventForDispatch>(queueStackName: "OPTEventQueue",
                                                                         dataStore: DataStoreMemory<[Data]>(storeName: dataStoreName))

--- a/Sources/Implementation/Datastore/DataStoreFile.swift
+++ b/Sources/Implementation/Datastore/DataStoreFile.swift
@@ -46,10 +46,10 @@ open class DataStoreFile<T>: OPTDataStore where T: Codable {
         dataStoreName = storeName
         lock = DispatchQueue(label: storeName)
         
-        url = if let url = FileManager.default.urls(for: directory, in: .userDomainMask).first {
-            url.appendingPathComponent(storeName, isDirectory: false)
+        if let url = FileManager.default.urls(for: directory, in: .userDomainMask).first {
+            self.url = url.appendingPathComponent(storeName, isDirectory: false)
         } else {
-            URL(fileURLWithPath: storeName)
+            self.url = URL(fileURLWithPath: storeName)
         }
     }
     

--- a/Sources/Implementation/Datastore/DataStoreFile.swift
+++ b/Sources/Implementation/Datastore/DataStoreFile.swift
@@ -30,21 +30,27 @@ open class DataStoreFile<T>: OPTDataStore where T: Codable {
         return threadSafeLogger.logger
     }
 
-    public init(storeName: String, async: Bool = true) {
-        self.async = async
-        dataStoreName = storeName
-        lock = DispatchQueue(label: storeName)
+    public convenience init(storeName: String, async: Bool = true) {
         #if os(tvOS) || os(macOS)
         let directory = FileManager.SearchPathDirectory.cachesDirectory
         #else
         let directory = FileManager.SearchPathDirectory.documentDirectory
         #endif
-        if let url = FileManager.default.urls(for: directory, in: .userDomainMask).first {
-            self.url = url.appendingPathComponent(storeName, isDirectory: false)
-        } else {
-            self.url = URL(fileURLWithPath: storeName)
-        }
         
+        self.init(storeName: storeName, directory: directory, async: async)
+    }
+    
+    public init(storeName: String, directory: FileManager.SearchPathDirectory, async: Bool = true) {
+        self.async = async
+        
+        dataStoreName = storeName
+        lock = DispatchQueue(label: storeName)
+        
+        url = if let url = FileManager.default.urls(for: directory, in: .userDomainMask).first {
+            url.appendingPathComponent(storeName, isDirectory: false)
+        } else {
+            URL(fileURLWithPath: storeName)
+        }
     }
     
     func isArray() -> Bool {

--- a/Tests/OptimizelyTests-Common/DataStoreTests.swift
+++ b/Tests/OptimizelyTests-Common/DataStoreTests.swift
@@ -17,10 +17,9 @@
 import XCTest
 
 class DataStoreTests: XCTestCase {
-
-    override func setUp() {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
-        if let url = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first {
+    
+    private func createDirectoryIfNeeded(directory: FileManager.SearchPathDirectory) {
+        if let url = FileManager.default.urls(for: directory, in: .userDomainMask).first {
             if (!FileManager.default.fileExists(atPath: url.path)) {
                 do {
                     try FileManager.default.createDirectory(at: url, withIntermediateDirectories: false, attributes: nil)
@@ -30,7 +29,11 @@ class DataStoreTests: XCTestCase {
                 
             }
         }
+    }
 
+    override func setUp() {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+        createDirectoryIfNeeded(directory: .documentDirectory)
     }
 
     override func tearDown() {
@@ -168,6 +171,19 @@ class DataStoreTests: XCTestCase {
          datastore.removeItem(forKey: key)
      }
 
+    func testFileStoreCustomDirectory() throws {
+        createDirectoryIfNeeded(directory: .applicationSupportDirectory)
+        
+        let datastore = DataStoreFile<[String]>(storeName: "testFileStore")
+        
+        datastore.saveItem(forKey: "testString", value: ["value"])
+        let vj = datastore.getItem(forKey: "testString") as! [String]
+        XCTAssertEqual(vj.first, "value")
+        
+        var url = try XCTUnwrap(FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first)
+            .appendingPathComponent("testFileStore", isDirectory: false)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: url.path()))
+    }
 
     
     func testUserDefaults() {

--- a/Tests/OptimizelyTests-Common/DataStoreTests.swift
+++ b/Tests/OptimizelyTests-Common/DataStoreTests.swift
@@ -174,7 +174,7 @@ class DataStoreTests: XCTestCase {
     func testFileStoreCustomDirectory() throws {
         createDirectoryIfNeeded(directory: .applicationSupportDirectory)
         
-        let datastore = DataStoreFile<[String]>(storeName: "testFileStore")
+        let datastore = DataStoreFile<[String]>(storeName: "testFileStore", directory: .applicationSupportDirectory)
         
         datastore.saveItem(forKey: "testString", value: ["value"])
         let vj = datastore.getItem(forKey: "testString") as! [String]

--- a/Tests/OptimizelyTests-Common/DataStoreTests.swift
+++ b/Tests/OptimizelyTests-Common/DataStoreTests.swift
@@ -182,7 +182,7 @@ class DataStoreTests: XCTestCase {
         
         var url = try XCTUnwrap(FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first)
             .appendingPathComponent("testFileStore", isDirectory: false)
-        XCTAssertTrue(FileManager.default.fileExists(atPath: url.path()))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: url.path))
     }
 
     

--- a/Tests/OptimizelyTests-Common/EventDispatcherTests.swift
+++ b/Tests/OptimizelyTests-Common/EventDispatcherTests.swift
@@ -82,7 +82,7 @@ class EventDispatcherTests: XCTestCase {
     }
 
     func testEventDispatcherFile() {
-        eventDispatcher = DefaultEventDispatcher( backingStore: .file)
+        eventDispatcher = DefaultEventDispatcher( backingStore: .file(directory: nil))
         let pEventD: OPTEventDispatcher = eventDispatcher!
         eventDispatcher?.timerInterval = 1
         let wait = {() in


### PR DESCRIPTION
## Summary
- Extended `DataStoreFile` to allow for injection of custom `FileManager.SearchPathDirectory`
- Extended `DefaultEventDispatcher` to allow for injection of custom `FileManager.SearchPathDirectory` for `DataStoreType.file`

Users have been raising the issue that they see these technical files inside of their `Files` app, because the directory for `DataStoreFile` defaults to `.documentsDirectory`, which is visible to users. This change allows us to update the directory to `.applicationSupportDirectory` in `DefaultEventDispatcher` using `DataStoreType.file(directory: .applicationSupportDirectory)` and in `DefaultDatafileHandler` by overriding `open func createDataStore(sdkKey: String) -> OPTDataStore`.

## Test plan
- Added a new test to verify the custom directory is used by `DataStoreFile`

## Issues
- None
