### PR TITLE
[AI-FSSDK] (DO NOT REVIEW) [FSSDK-12265] Add experiments field to Holdout data model

### DIFF
--- a/Sources/Data Model/Holdout.swift
+++ b/Sources/Data Model/Holdout.swift
@@ -33,9 +33,10 @@ struct Holdout: Codable, ExperimentCore {
     var audienceConditions: ConditionHolder?
     var includedFlags: [String]
     var excludedFlags: [String]
-    
+    var experiments: [String]
+
     enum CodingKeys: String, CodingKey {
-        case id, key, status, variations, trafficAllocation, audienceIds, audienceConditions, includedFlags, excludedFlags
+        case id, key, status, variations, trafficAllocation, audienceIds, audienceConditions, includedFlags, excludedFlags, experiments
     }
     
     var variationsMap: [String: OptimizelyVariation] = [:]
@@ -54,9 +55,10 @@ struct Holdout: Codable, ExperimentCore {
         trafficAllocation = try container.decode([TrafficAllocation].self, forKey: .trafficAllocation)
         audienceIds = try container.decode([String].self, forKey: .audienceIds)
         audienceConditions = try container.decodeIfPresent(ConditionHolder.self, forKey: .audienceConditions)
-        
+
         includedFlags = try container.decodeIfPresent([String].self, forKey: .includedFlags) ?? []
         excludedFlags = try container.decodeIfPresent([String].self, forKey: .excludedFlags) ?? []
+        experiments = try container.decodeIfPresent([String].self, forKey: .experiments) ?? []
     }
 }
 
@@ -70,12 +72,17 @@ extension Holdout: Equatable {
         lhs.audienceIds == rhs.audienceIds &&
         lhs.audienceConditions == rhs.audienceConditions &&
         lhs.includedFlags == rhs.includedFlags &&
-        lhs.excludedFlags == rhs.excludedFlags
+        lhs.excludedFlags == rhs.excludedFlags &&
+        lhs.experiments == rhs.experiments
     }
 }
 
 extension Holdout {
     var isActivated: Bool {
         return status == .running
+    }
+
+    var isLocal: Bool {
+        return !experiments.isEmpty
     }
 }

--- a/Sources/Data Model/HoldoutConfig.swift
+++ b/Sources/Data Model/HoldoutConfig.swift
@@ -49,36 +49,7 @@ struct HoldoutConfig {
         experimentHoldoutsMap = [:]
 
         for holdout in allHoldouts {
-            switch (holdout.includedFlags.isEmpty, holdout.excludedFlags.isEmpty) {
-                case (true, true):
-                    global.append(holdout)
-                    
-                case (false, _):
-                    holdout.includedFlags.forEach { flagId in
-                        if var existing = includedHoldouts[flagId] {
-                            existing.append(holdout)
-                            includedHoldouts[flagId] = existing
-                        } else {
-                            includedHoldouts[flagId] = [holdout]
-                        }
-                    }
-                    
-                case (true, false):
-                    global.append(holdout)
-                    
-                    holdout.excludedFlags.forEach { flagId in
-                        if var existing = excludedHoldouts[flagId] {
-                            existing.append(holdout)
-                            excludedHoldouts[flagId] = existing
-                        } else {
-                            excludedHoldouts[flagId] = [holdout]
-                        }
-                    }
-            }
-        }
-
-        // Build experiment-to-holdouts mapping
-        for holdout in allHoldouts {
+            // Handle experiment-specific holdouts (local holdouts)
             if !holdout.experiments.isEmpty {
                 for experimentId in holdout.experiments {
                     if var existing = experimentHoldoutsMap[experimentId] {
@@ -88,6 +59,35 @@ struct HoldoutConfig {
                         experimentHoldoutsMap[experimentId] = [holdout]
                     }
                 }
+                continue  // Skip flag-level logic for experiment-specific holdouts
+            }
+
+            // Handle flag-level holdouts (global holdouts)
+            switch (holdout.includedFlags.isEmpty, holdout.excludedFlags.isEmpty) {
+                case (true, true):
+                    global.append(holdout)
+
+                case (false, _):
+                    holdout.includedFlags.forEach { flagId in
+                        if var existing = includedHoldouts[flagId] {
+                            existing.append(holdout)
+                            includedHoldouts[flagId] = existing
+                        } else {
+                            includedHoldouts[flagId] = [holdout]
+                        }
+                    }
+
+                case (true, false):
+                    global.append(holdout)
+
+                    holdout.excludedFlags.forEach { flagId in
+                        if var existing = excludedHoldouts[flagId] {
+                            existing.append(holdout)
+                            excludedHoldouts[flagId] = existing
+                        } else {
+                            excludedHoldouts[flagId] = [holdout]
+                        }
+                    }
             }
         }
     }


### PR DESCRIPTION
## Summary
Adds experiments field to Holdout data model to support local holdouts (MVP 3), allowing holdouts to target specific experiments instead of entire flags.

## Changes
- Added experiments field to Holdout struct with backward-compatible decoding
- Added isLocal property to identify local vs global holdouts
- Implemented experiment-to-holdout mapping in HoldoutConfig
- Added getHoldoutsForExperiment() method for O(1) experiment lookups

## Jira Ticket
[FSSDK-12265](https://optimizely-ext.atlassian.net/browse/FSSDK-12265)

## Notes
- Data model layer only - no decision service logic in this ticket
- Fully backward compatible with existing datafiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[FSSDK-12265]: https://optimizely-ext.atlassian.net/browse/FSSDK-12265?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ