### PR TITLE
[AI-FSSDK] [FSSDK-12418] Remove experiment type validation from config parsing

### DIFF
--- a/Sources/Data Model/Experiment.swift
+++ b/Sources/Data Model/Experiment.swift
@@ -36,9 +36,10 @@ struct Experiment: Codable, ExperimentCore {
     // datafile spec defines this as [String: Any]. Supposed to be [ExperimentKey: VariationKey]
     var forcedVariations: [String: String]
     var cmab: Cmab?
-    
+    var type: String?
+
     enum CodingKeys: String, CodingKey {
-        case id, key, status, layerId, variations, trafficAllocation, audienceIds, audienceConditions, forcedVariations, cmab
+        case id, key, status, layerId, variations, trafficAllocation, audienceIds, audienceConditions, forcedVariations, cmab, type
     }
 
     // MARK: - OptimizelyConfig
@@ -59,7 +60,8 @@ extension Experiment: Equatable {
             lhs.audienceIds == rhs.audienceIds &&
             lhs.audienceConditions == rhs.audienceConditions &&
             lhs.forcedVariations == rhs.forcedVariations &&
-            lhs.cmab == rhs.cmab
+            lhs.cmab == rhs.cmab &&
+            lhs.type == rhs.type
     }
 }
 

--- a/Tests/OptimizelyTests-DataModel/ExperimentTests.swift
+++ b/Tests/OptimizelyTests-DataModel/ExperimentTests.swift
@@ -143,9 +143,33 @@ extension ExperimentTests {
     func testDecodeFailWithMissingForcedVariations() {
         var data: [String: Any] = ExperimentTests.sampleData
         data["forcedVariations"] = nil
-        
+
         let model: Experiment? = try? OTUtils.model(from: data)
         XCTAssertNil(model)
+    }
+
+    func testDecodeSuccessWithUnknownType() {
+        var data: [String: Any] = ExperimentTests.sampleData
+        data["type"] = "new_unknown_type"
+
+        let model: Experiment = try! OTUtils.model(from: data)
+        XCTAssertEqual(model.type, "new_unknown_type")
+        XCTAssertEqual(model.id, "11111")
+        XCTAssertEqual(model.key, "background")
+    }
+
+    func testDecodeSuccessWithKnownType() {
+        var data: [String: Any] = ExperimentTests.sampleData
+        data["type"] = "fr"
+
+        let model: Experiment = try! OTUtils.model(from: data)
+        XCTAssertEqual(model.type, "fr")
+    }
+
+    func testDecodeSuccessWithNilType() {
+        let data: [String: Any] = ExperimentTests.sampleData
+        let model: Experiment = try! OTUtils.model(from: data)
+        XCTAssertNil(model.type)
     }
 
 }


### PR DESCRIPTION
## Summary

Adds experiment type field to the Experiment model for forward compatibility. Previously, the type field was not decoded from the datafile, so unknown types were silently discarded. Now the type field is stored as an optional string, accepting any value without validation.

## Changes

- Added optional type field to the Experiment struct (accepts any string value)
- Updated CodingKeys and Equatable to include the type field
- Added tests verifying unknown, known, and nil experiment types are all accepted

## Jira Ticket
[FSSDK-12418](https://optimizely-ext.atlassian.net/browse/FSSDK-12418)

[FSSDK-12418]: https://optimizely-ext.atlassian.net/browse/FSSDK-12418?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ