### PR TITLE
[FSSDK-12394] Add local holdouts to swift-sdk (ref sdk)

### DIFF
--- a/OptimizelySwiftSDK.xcodeproj/project.pbxproj
+++ b/OptimizelySwiftSDK.xcodeproj/project.pbxproj
@@ -2119,6 +2119,8 @@
 		98AC984B2DB8FFE0001405DD /* DecisionServiceTests_Holdouts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98AC98482DB8FC29001405DD /* DecisionServiceTests_Holdouts.swift */; };
 		98AC985E2DBA6721001405DD /* OptimizelyUserContextTests_Decide_With_Holdouts_Reasons.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98AC985D2DBA6721001405DD /* OptimizelyUserContextTests_Decide_With_Holdouts_Reasons.swift */; };
 		98AC985F2DBA6721001405DD /* OptimizelyUserContextTests_Decide_With_Holdouts_Reasons.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98AC985D2DBA6721001405DD /* OptimizelyUserContextTests_Decide_With_Holdouts_Reasons.swift */; };
+		98C2DF242F900669003F2443 /* DecisionServiceTests_LocalHoldouts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98C2DF232F900669003F2443 /* DecisionServiceTests_LocalHoldouts.swift */; };
+		98C2DF252F900669003F2443 /* DecisionServiceTests_LocalHoldouts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98C2DF232F900669003F2443 /* DecisionServiceTests_LocalHoldouts.swift */; };
 		98D5AE842DBB91C0000D5844 /* OptimizelyUserContextTests_Decide_Holdouts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98D5AE832DBB91C0000D5844 /* OptimizelyUserContextTests_Decide_Holdouts.swift */; };
 		98D5AE852DBB91C0000D5844 /* OptimizelyUserContextTests_Decide_Holdouts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98D5AE832DBB91C0000D5844 /* OptimizelyUserContextTests_Decide_Holdouts.swift */; };
 		98F28A1D2E01940500A86546 /* Cmab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98F28A1C2E01940500A86546 /* Cmab.swift */; };
@@ -2635,6 +2637,7 @@
 		98AC98452DB7B762001405DD /* BucketTests_HoldoutToVariation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BucketTests_HoldoutToVariation.swift; sourceTree = "<group>"; };
 		98AC98482DB8FC29001405DD /* DecisionServiceTests_Holdouts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecisionServiceTests_Holdouts.swift; sourceTree = "<group>"; };
 		98AC985D2DBA6721001405DD /* OptimizelyUserContextTests_Decide_With_Holdouts_Reasons.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptimizelyUserContextTests_Decide_With_Holdouts_Reasons.swift; sourceTree = "<group>"; };
+		98C2DF232F900669003F2443 /* DecisionServiceTests_LocalHoldouts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecisionServiceTests_LocalHoldouts.swift; sourceTree = "<group>"; };
 		98D5AE832DBB91C0000D5844 /* OptimizelyUserContextTests_Decide_Holdouts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptimizelyUserContextTests_Decide_Holdouts.swift; sourceTree = "<group>"; };
 		98F28A1C2E01940500A86546 /* Cmab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Cmab.swift; sourceTree = "<group>"; };
 		98F28A2D2E01968000A86546 /* CmabTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmabTests.swift; sourceTree = "<group>"; };
@@ -3177,6 +3180,7 @@
 				6E0207A7272A11CF008C3711 /* NetworkReachabilityTests.swift */,
 				6E75198B22C5211100B2B157 /* NotificationCenterTests.swift */,
 				84861810286D0B8900B7F41B /* OdpEventManagerTests.swift */,
+				98C2DF232F900669003F2443 /* DecisionServiceTests_LocalHoldouts.swift */,
 				8486180E286D0B8900B7F41B /* OdpManagerTests.swift */,
 				8486180D286D0B8900B7F41B /* OdpSegmentManagerTests.swift */,
 				98F28A512E02E81500A86546 /* CMABClientTests.swift */,
@@ -5191,6 +5195,7 @@
 				6E6522EB278E4F3800954EA1 /* OdpManager.swift in Sources */,
 				6E75187922C520D400B2B157 /* Variation.swift in Sources */,
 				6E75191522C520D500B2B157 /* BackgroundingCallbacks.swift in Sources */,
+				98C2DF242F900669003F2443 /* DecisionServiceTests_LocalHoldouts.swift in Sources */,
 				6E75195D22C520D500B2B157 /* OPTBucketer.swift in Sources */,
 				6E9B117622C5487100C22D81 /* DatafileHandlerTests.swift in Sources */,
 				84E2E97F2855875E001114AB /* OdpEventManager.swift in Sources */,
@@ -5494,6 +5499,7 @@
 				84861813286D0B8900B7F41B /* OdpManagerTests.swift in Sources */,
 				6E7516FD22C520D400B2B157 /* OptimizelyLogLevel.swift in Sources */,
 				6E75187322C520D400B2B157 /* Variation.swift in Sources */,
+				98C2DF252F900669003F2443 /* DecisionServiceTests_LocalHoldouts.swift in Sources */,
 				6E7517E322C520D400B2B157 /* DefaultDecisionService.swift in Sources */,
 				6E75179922C520D400B2B157 /* DataStoreQueueStackImpl+Extension.swift in Sources */,
 				6E9B115C22C5486E00C22D81 /* DatafileHandlerTests.swift in Sources */,

--- a/Sources/Data Model/Holdout.swift
+++ b/Sources/Data Model/Holdout.swift
@@ -31,11 +31,10 @@ struct Holdout: Codable, ExperimentCore {
     var trafficAllocation: [TrafficAllocation]
     var audienceIds: [String]
     var audienceConditions: ConditionHolder?
-    var includedFlags: [String]
-    var excludedFlags: [String]
-    
+    var includedRules: [String]?
+
     enum CodingKeys: String, CodingKey {
-        case id, key, status, variations, trafficAllocation, audienceIds, audienceConditions, includedFlags, excludedFlags
+        case id, key, status, variations, trafficAllocation, audienceIds, audienceConditions, includedRules
     }
     
     var variationsMap: [String: OptimizelyVariation] = [:]
@@ -54,9 +53,8 @@ struct Holdout: Codable, ExperimentCore {
         trafficAllocation = try container.decode([TrafficAllocation].self, forKey: .trafficAllocation)
         audienceIds = try container.decode([String].self, forKey: .audienceIds)
         audienceConditions = try container.decodeIfPresent(ConditionHolder.self, forKey: .audienceConditions)
-        
-        includedFlags = try container.decodeIfPresent([String].self, forKey: .includedFlags) ?? []
-        excludedFlags = try container.decodeIfPresent([String].self, forKey: .excludedFlags) ?? []
+
+        includedRules = try container.decodeIfPresent([String].self, forKey: .includedRules)
     }
 }
 
@@ -69,13 +67,16 @@ extension Holdout: Equatable {
         lhs.trafficAllocation == rhs.trafficAllocation &&
         lhs.audienceIds == rhs.audienceIds &&
         lhs.audienceConditions == rhs.audienceConditions &&
-        lhs.includedFlags == rhs.includedFlags &&
-        lhs.excludedFlags == rhs.excludedFlags
+        lhs.includedRules == rhs.includedRules
     }
 }
 
 extension Holdout {
     var isActivated: Bool {
         return status == .running
+    }
+
+    var isGlobal: Bool {
+        return includedRules == nil
     }
 }

--- a/Sources/Data Model/HoldoutConfig.swift
+++ b/Sources/Data Model/HoldoutConfig.swift
@@ -24,90 +24,48 @@ struct HoldoutConfig {
     }
     private(set) var global: [Holdout] = []
     private(set) var holdoutIdMap: [String: Holdout] = [:]
-    private(set) var flagHoldoutsMap: [String: [Holdout]] = [:]
-    private(set) var includedHoldouts: [String: [Holdout]] = [:]
-    private(set) var excludedHoldouts: [String: [Holdout]] = [:]
+    private(set) var ruleHoldoutsMap: [String: [Holdout]] = [:]
     
     init(allholdouts: [Holdout] = []) {
         self.allHoldouts = allholdouts
         updateHoldoutMapping()
     }
     
-    /// Updates internal mappings of holdouts including the id map, global list, and per-flag inclusion/exclusion maps.
+    /// Updates internal mappings of holdouts including the id map, global list, and per-rule maps.
     mutating func updateHoldoutMapping() {
         holdoutIdMap = {
             var map = [String: Holdout]()
             allHoldouts.forEach { map[$0.id] = $0 }
             return map
         }()
-        
-        flagHoldoutsMap = [:]
+
         global = []
-        includedHoldouts = [:]
-        excludedHoldouts = [:]
-        
+        ruleHoldoutsMap = [:]
+
         for holdout in allHoldouts {
-            switch (holdout.includedFlags.isEmpty, holdout.excludedFlags.isEmpty) {
-                case (true, true):
-                    global.append(holdout)
-                    
-                case (false, _):
-                    holdout.includedFlags.forEach { flagId in
-                        if var existing = includedHoldouts[flagId] {
-                            existing.append(holdout)
-                            includedHoldouts[flagId] = existing
-                        } else {
-                            includedHoldouts[flagId] = [holdout]
-                        }
-                    }
-                    
-                case (true, false):
-                    global.append(holdout)
-                    
-                    holdout.excludedFlags.forEach { flagId in
-                        if var existing = excludedHoldouts[flagId] {
-                            existing.append(holdout)
-                            excludedHoldouts[flagId] = existing
-                        } else {
-                            excludedHoldouts[flagId] = [holdout]
-                        }
-                    }
+            if holdout.isGlobal {
+                // includedRules == nil → global holdout
+                global.append(holdout)
+            } else {
+                // includedRules == [ruleId, ...] → local holdout
+                for ruleId in holdout.includedRules! {
+                    ruleHoldoutsMap[ruleId, default: []].append(holdout)
+                }
             }
         }
     }
     
-    /// Returns the applicable holdouts for the given flag ID by combining global holdouts (excluding any specified) and included holdouts, in that order.
-    /// Caches the result for future calls.
-    /// - Parameter id: The flag identifier.
-    /// - Returns: An array of `Holdout` objects relevant to the given flag.
-    mutating func getHoldoutForFlag(id: String) -> [Holdout] {
-        guard !allHoldouts.isEmpty else { return [] }
-        
-        // Check cache and return persistent holdouts
-        if let holdouts = flagHoldoutsMap[id] {
-            return holdouts
-        }
-        
-        // Prioritize global holdouts first 
-        var activeHoldouts: [Holdout] = []
-        
-        let excluded = excludedHoldouts[id] ?? []
-        
-        if !excluded.isEmpty {
-            activeHoldouts = global.filter { holdout in
-                return !excluded.contains(holdout)
-            }
-        } else {
-            activeHoldouts = global
-        }
-        
-        let includedHoldouts = includedHoldouts[id] ?? []
-        
-        activeHoldouts += includedHoldouts
-        
-        flagHoldoutsMap[id] = activeHoldouts
-        
-        return flagHoldoutsMap[id] ?? []
+    /// Returns local holdouts targeting a specific rule.
+    /// - Parameter ruleId: The rule identifier.
+    /// - Returns: An array of `Holdout` objects targeting the given rule.
+    func getHoldoutsForRule(ruleId: String) -> [Holdout] {
+        return ruleHoldoutsMap[ruleId] ?? []
+    }
+
+    /// Returns all global holdouts.
+    /// - Returns: An array of global `Holdout` objects.
+    func getGlobalHoldouts() -> [Holdout] {
+        return global
     }
     
     /// Get a Holdout object for an Id.

--- a/Sources/Data Model/ProjectConfig.swift
+++ b/Sources/Data Model/ProjectConfig.swift
@@ -170,8 +170,12 @@ class ProjectConfig {
         
     }
     
-    func getHoldoutForFlag(id: String) -> [Holdout] {
-        return holdoutConfig.getHoldoutForFlag(id: id)
+    func getGlobalHoldouts() -> [Holdout] {
+        return holdoutConfig.getGlobalHoldouts()
+    }
+
+    func getHoldoutsForRule(ruleId: String) -> [Holdout] {
+        return holdoutConfig.getHoldoutsForRule(ruleId: ruleId)
     }
         
     func getAllRulesForFlag(_ flag: FeatureFlag) -> [Experiment] {

--- a/Sources/Implementation/DefaultDecisionService.swift
+++ b/Sources/Implementation/DefaultDecisionService.swift
@@ -28,6 +28,13 @@ struct VariationDecision {
     var variation: Variation?
     var cmabError: Bool = false
     var cmabUUID: String?
+    var holdout: ExperimentCore? = nil  // If variation came from a holdout, store the holdout here
+}
+
+struct DeliveryRuleDecision {
+    var variation: Variation?
+    var skipToEveryoneElse: Bool
+    var holdout: ExperimentCore? = nil  // If variation came from a holdout, store the holdout here
 }
 
 typealias UserProfile = OPTUserProfileService.UPProfile
@@ -468,8 +475,14 @@ class DefaultDecisionService: OPTDecisionService {
                         let featureDecision = FeatureDecision(experiment: experiment, variation: nil, source: Constants.DecisionSource.featureTest.rawValue, error: true)
                         return DecisionResponse(result: featureDecision, reasons: reasons)
                     } else if let variation = result.variation {
-                        let featureDecision = FeatureDecision(experiment: experiment, variation: variation, source: Constants.DecisionSource.featureTest.rawValue, cmabUUID: result.cmabUUID)
-                        return DecisionResponse(result: featureDecision, reasons: reasons)
+                        // Check if this variation came from a holdout
+                        if let holdout = result.holdout {
+                            let featureDecision = FeatureDecision(experiment: holdout, variation: variation, source: Constants.DecisionSource.holdout.rawValue, cmabUUID: result.cmabUUID)
+                            return DecisionResponse(result: featureDecision, reasons: reasons)
+                        } else {
+                            let featureDecision = FeatureDecision(experiment: experiment, variation: variation, source: Constants.DecisionSource.featureTest.rawValue, cmabUUID: result.cmabUUID)
+                            return DecisionResponse(result: featureDecision, reasons: reasons)
+                        }
                     }
                 }
             }
@@ -524,16 +537,22 @@ class DefaultDecisionService: OPTDecisionService {
                                                                 user: user,
                                                                 options: options)
             reasons.merge(decisionResponse.reasons)
-            let (variation, skipToEveryoneElse) = decisionResponse.result!
-            
-            if let variation = variation {
+            let result = decisionResponse.result!
+
+            if let variation = result.variation {
                 let rule = rolloutRules[index]
-                let featureDecision = FeatureDecision(experiment: rule, variation: variation, source: Constants.DecisionSource.rollout.rawValue)
-                return DecisionResponse(result: featureDecision, reasons: reasons)
+                // Check if this variation came from a holdout
+                if let holdout = result.holdout {
+                    let featureDecision = FeatureDecision(experiment: holdout, variation: variation, source: Constants.DecisionSource.holdout.rawValue)
+                    return DecisionResponse(result: featureDecision, reasons: reasons)
+                } else {
+                    let featureDecision = FeatureDecision(experiment: rule, variation: variation, source: Constants.DecisionSource.rollout.rawValue)
+                    return DecisionResponse(result: featureDecision, reasons: reasons)
+                }
             }
-            
+
             // the last rule is special for "Everyone Else"
-            index = skipToEveryoneElse ? (rolloutRules.count - 1) : (index + 1)
+            index = result.skipToEveryoneElse ? (rolloutRules.count - 1) : (index + 1)
         }
         
         return DecisionResponse(result: nil, reasons: reasons)
@@ -649,7 +668,7 @@ class DefaultDecisionService: OPTDecisionService {
             reasons.merge(holdoutDecision.reasons)
             if let variation = holdoutDecision.result {
                 // User is in holdout — return holdout variation immediately, skip this rule
-                let variationDecision = VariationDecision(variation: variation)
+                let variationDecision = VariationDecision(variation: variation, holdout: holdout)
                 return DecisionResponse(result: variationDecision, reasons: reasons)
             }
         }
@@ -673,13 +692,13 @@ class DefaultDecisionService: OPTDecisionService {
     ///   - ruleIndex: The index of the rule to evaluate.
     ///   - user: The user context.
     ///   - options: Optional decision options.
-    /// - Returns: A `DecisionResponse` with the variation (if any), a flag indicating whether to skip to the "Everyone Else" rule, and reasons.
+    /// - Returns: A `DecisionResponse` with the delivery rule decision and reasons.
     func getVariationFromDeliveryRule(config: ProjectConfig,
                                       flagKey: String,
                                       rules: [Experiment],
                                       ruleIndex: Int,
                                       user: OptimizelyUserContext,
-                                      options: [OptimizelyDecideOption]? = nil) -> DecisionResponse<(Variation?, Bool)> {
+                                      options: [OptimizelyDecideOption]? = nil) -> DecisionResponse<DeliveryRuleDecision> {
         let reasons = DecisionReasons(options: options)
         var skipToEveryoneElse = false
         
@@ -692,7 +711,8 @@ class DefaultDecisionService: OPTDecisionService {
         reasons.merge(forcedDecisionResponse.reasons)
         
         if let variation = forcedDecisionResponse.result {
-            return DecisionResponse(result: (variation, skipToEveryoneElse), reasons: reasons)
+            let decision = DeliveryRuleDecision(variation: variation, skipToEveryoneElse: skipToEveryoneElse)
+            return DecisionResponse(result: decision, reasons: reasons)
         }
 
         // check local holdouts targeting this delivery rule
@@ -705,8 +725,9 @@ class DefaultDecisionService: OPTDecisionService {
                                                          options: options)
             reasons.merge(holdoutDecision.reasons)
             if let variation = holdoutDecision.result {
-                // User is in holdout — return holdout variation, skip this delivery rule
-                return DecisionResponse(result: (variation, skipToEveryoneElse), reasons: reasons)
+                // User is in holdout — return holdout variation with holdout info
+                let decision = DeliveryRuleDecision(variation: variation, skipToEveryoneElse: skipToEveryoneElse, holdout: holdout)
+                return DecisionResponse(result: decision, reasons: reasons)
             }
         }
 
@@ -756,8 +777,9 @@ class DefaultDecisionService: OPTDecisionService {
             logger.d(info)
             reasons.addInfo(info)
         }
-        
-        return DecisionResponse(result: (bucketedVariation, skipToEveryoneElse), reasons: reasons)
+
+        let decision = DeliveryRuleDecision(variation: bucketedVariation, skipToEveryoneElse: skipToEveryoneElse)
+        return DecisionResponse(result: decision, reasons: reasons)
     }
     
     // MARK: - Audience Evaluation

--- a/Sources/Implementation/DefaultDecisionService.swift
+++ b/Sources/Implementation/DefaultDecisionService.swift
@@ -392,8 +392,8 @@ class DefaultDecisionService: OPTDecisionService {
                             isAsync: Bool,
                             options: [OptimizelyDecideOption]? = nil) -> DecisionResponse<FeatureDecision> {
         let reasons = DecisionReasons(options: options)
-        
-        let holdouts = config.getHoldoutForFlag(id: featureFlag.id)
+
+        let holdouts = config.getGlobalHoldouts()
         for holdout in holdouts {
             let holdoutDecision = getVariationForHoldout(config: config,
                                                          flagKey: featureFlag.key,
@@ -637,7 +637,23 @@ class DefaultDecisionService: OPTDecisionService {
             let variationDecision = VariationDecision(variation: variation)
             return DecisionResponse(result: variationDecision, reasons: reasons)
         }
-        
+
+        // check local holdouts targeting this rule
+        let localHoldouts = config.getHoldoutsForRule(ruleId: rule.id)
+        for holdout in localHoldouts {
+            let holdoutDecision = getVariationForHoldout(config: config,
+                                                         flagKey: flagKey,
+                                                         holdout: holdout,
+                                                         user: user,
+                                                         options: options)
+            reasons.merge(holdoutDecision.reasons)
+            if let variation = holdoutDecision.result {
+                // User is in holdout — return holdout variation immediately, skip this rule
+                let variationDecision = VariationDecision(variation: variation)
+                return DecisionResponse(result: variationDecision, reasons: reasons)
+            }
+        }
+
         let decisionResponse = getVariation(config: config,
                                             experiment: rule,
                                             user: user,
@@ -678,7 +694,22 @@ class DefaultDecisionService: OPTDecisionService {
         if let variation = forcedDecisionResponse.result {
             return DecisionResponse(result: (variation, skipToEveryoneElse), reasons: reasons)
         }
-        
+
+        // check local holdouts targeting this delivery rule
+        let localHoldouts = config.getHoldoutsForRule(ruleId: rule.id)
+        for holdout in localHoldouts {
+            let holdoutDecision = getVariationForHoldout(config: config,
+                                                         flagKey: flagKey,
+                                                         holdout: holdout,
+                                                         user: user,
+                                                         options: options)
+            reasons.merge(holdoutDecision.reasons)
+            if let variation = holdoutDecision.result {
+                // User is in holdout — return holdout variation, skip this delivery rule
+                return DecisionResponse(result: (variation, skipToEveryoneElse), reasons: reasons)
+            }
+        }
+
         // regular decision
         
         let userId = user.userId

--- a/Tests/OptimizelyTests-Common/BatchEventBuilderTests_Events.swift
+++ b/Tests/OptimizelyTests-Common/BatchEventBuilderTests_Events.swift
@@ -498,6 +498,7 @@ extension BatchEventBuilderTests_Events {
         
         let holdout: Holdout = try! OTUtils.model(from: sampleHoldout)
         optimizely.config?.project.holdouts = [holdout]
+        optimizely.config?.holdoutConfig.allHoldouts = [holdout]
         
         let exp = expectation(description: "Wait for event to dispatch")
         let user = optimizely.createUserContext(userId: userId)
@@ -535,6 +536,7 @@ extension BatchEventBuilderTests_Events {
         var holdout: Holdout = try! OTUtils.model(from: sampleHoldout)
         holdout.includedRules = ["10390977673"]  // exp_no_audience rule in feature_1
         optimizely.config?.project.holdouts = [holdout]
+        optimizely.config?.holdoutConfig.allHoldouts = [holdout]
         
         let exp = expectation(description: "Wait for event to dispatch")
         
@@ -576,6 +578,7 @@ extension BatchEventBuilderTests_Events {
         var holdout: Holdout = try! OTUtils.model(from: sampleHoldout)
         holdout.includedRules = []  // Empty array = local holdout targeting no rules (excludes feature_1)
         optimizely.config?.project.holdouts = [holdout]
+        optimizely.config?.holdoutConfig.allHoldouts = [holdout]
         
         let exp = expectation(description: "Wait for event to dispatch")
         
@@ -616,6 +619,7 @@ extension BatchEventBuilderTests_Events {
         holdout.trafficAllocation[0].endOfRange = 0
         holdout.includedRules = ["10390977673"]  // exp_with_audience rule in feature_1
         optimizely.config?.project.holdouts = [holdout]
+        optimizely.config?.holdoutConfig.allHoldouts = [holdout]
         
         let exp = expectation(description: "Wait for event to dispatch")
         

--- a/Tests/OptimizelyTests-Common/BatchEventBuilderTests_Events.swift
+++ b/Tests/OptimizelyTests-Common/BatchEventBuilderTests_Events.swift
@@ -533,7 +533,7 @@ extension BatchEventBuilderTests_Events {
         try! optimizely.start(datafile: datafile)
         
         var holdout: Holdout = try! OTUtils.model(from: sampleHoldout)
-        holdout.includedFlags = ["4482920077"]
+        holdout.includedRules = ["10390977673"]  // exp_no_audience rule in feature_1
         optimizely.config?.project.holdouts = [holdout]
         
         let exp = expectation(description: "Wait for event to dispatch")
@@ -574,7 +574,7 @@ extension BatchEventBuilderTests_Events {
         try! optimizely.start(datafile: datafile)
         
         var holdout: Holdout = try! OTUtils.model(from: sampleHoldout)
-        holdout.excludedFlags = ["4482920077"]
+        holdout.includedRules = []  // Empty array = local holdout targeting no rules (excludes feature_1)
         optimizely.config?.project.holdouts = [holdout]
         
         let exp = expectation(description: "Wait for event to dispatch")
@@ -614,7 +614,7 @@ extension BatchEventBuilderTests_Events {
         var holdout: Holdout = try! OTUtils.model(from: sampleHoldout)
         /// Set traffic allocation to gero
         holdout.trafficAllocation[0].endOfRange = 0
-        holdout.includedFlags = ["4482920077"]
+        holdout.includedRules = ["10390977673"]  // exp_with_audience rule in feature_1
         optimizely.config?.project.holdouts = [holdout]
         
         let exp = expectation(description: "Wait for event to dispatch")

--- a/Tests/OptimizelyTests-Common/DecisionListenerTest_Holdouts.swift
+++ b/Tests/OptimizelyTests-Common/DecisionListenerTest_Holdouts.swift
@@ -55,9 +55,7 @@ class DecisionListenerTests_Holdouts: XCTestCase {
                     "id": "id_holdout_variation",
                     "key": "key_holdout_variation"
                 ]
-            ],
-            "includedFlags": [],
-            "excludedFlags": []
+            ]
         ]
     }
     
@@ -118,7 +116,8 @@ class DecisionListenerTests_Holdouts: XCTestCase {
     
     func testDecisionListenerDecideWithIncludedFlags() {
         var holdout = try! OTUtils.model(from: sampleHoldout) as Holdout
-        holdout.includedFlags = [kFeatureId]
+        // Include all rules in feature_1: experiment + delivery rules
+        holdout.includedRules = ["10390977673", "3332020515", "3332020494", "18322080788"]
         optimizely.config!.project.holdouts = [holdout]
         
         let exp = expectation(description: "x")
@@ -140,7 +139,7 @@ class DecisionListenerTests_Holdouts: XCTestCase {
     
     func testDecisionListenerDecideWithExcludedFlags() {
         var holdout = try! OTUtils.model(from: sampleHoldout) as Holdout
-        holdout.excludedFlags = [kFeatureId]
+        holdout.includedRules = []  // Empty array = local holdout targeting no rules (excludes feature_1)
         optimizely.config!.project.holdouts = [holdout]
         
         let exp = expectation(description: "x")
@@ -162,13 +161,14 @@ class DecisionListenerTests_Holdouts: XCTestCase {
     
     func testDecisionListenerDecideWithMultipleHoldouts() {
         var holdout = try! OTUtils.model(from: sampleHoldout) as Holdout
-        holdout.excludedFlags = [kFeatureId]
-        
+        holdout.includedRules = []  // Empty array = local holdout targeting no rules (excludes feature_1)
+
         var holdout_2 = holdout
         holdout_2.key = "holdout_key_2"
         holdout_2.id = "holdout_id_2"
-        holdout_2.includedFlags = [kFeatureId]
-        
+        // Include all rules in feature_1: experiment + delivery rules
+        holdout_2.includedRules = ["10390977673", "3332020515", "3332020494", "18322080788"]
+
         optimizely.config!.project.holdouts = [holdout, holdout_2]
         
         let exp = expectation(description: "x")

--- a/Tests/OptimizelyTests-Common/DecisionListenerTest_Holdouts.swift
+++ b/Tests/OptimizelyTests-Common/DecisionListenerTest_Holdouts.swift
@@ -71,11 +71,12 @@ class DecisionListenerTests_Holdouts: XCTestCase {
         var holdout = try! OTUtils.model(from: sampleHoldout) as Holdout
         //  Audience "13389130056" requires "country" = "US"
         holdout.audienceIds = ["13389130056"]
-        
+
         let mockDecisionService = DefaultDecisionService(userProfileService: OTUtils.createClearUserProfileService(), bucketer: MockBucketer(mockBucketValue: 400))
         optimizely.decisionService = mockDecisionService
         optimizely.config!.project.holdouts = [holdout]
-        
+        optimizely.config!.holdoutConfig.allHoldouts = [holdout]
+
         self.notificationCenter = self.optimizely.notificationCenter!
     }
     

--- a/Tests/OptimizelyTests-Common/DecisionListenerTest_Holdouts.swift
+++ b/Tests/OptimizelyTests-Common/DecisionListenerTest_Holdouts.swift
@@ -119,6 +119,7 @@ class DecisionListenerTests_Holdouts: XCTestCase {
         // Include all rules in feature_1: experiment + delivery rules
         holdout.includedRules = ["10390977673", "3332020515", "3332020494", "18322080788"]
         optimizely.config!.project.holdouts = [holdout]
+        optimizely.config!.holdoutConfig.allHoldouts = [holdout]
         
         let exp = expectation(description: "x")
         let user = optimizely.createUserContext(userId: kUserId, attributes: kAttributesCountryMatch)
@@ -141,6 +142,7 @@ class DecisionListenerTests_Holdouts: XCTestCase {
         var holdout = try! OTUtils.model(from: sampleHoldout) as Holdout
         holdout.includedRules = []  // Empty array = local holdout targeting no rules (excludes feature_1)
         optimizely.config!.project.holdouts = [holdout]
+        optimizely.config!.holdoutConfig.allHoldouts = [holdout]
         
         let exp = expectation(description: "x")
         let user = optimizely.createUserContext(userId: kUserId, attributes: kAttributesCountryMatch)
@@ -170,7 +172,8 @@ class DecisionListenerTests_Holdouts: XCTestCase {
         holdout_2.includedRules = ["10390977673", "3332020515", "3332020494", "18322080788"]
 
         optimizely.config!.project.holdouts = [holdout, holdout_2]
-        
+        optimizely.config!.holdoutConfig.allHoldouts = [holdout, holdout_2]
+
         let exp = expectation(description: "x")
         let user = optimizely.createUserContext(userId: kUserId, attributes: kAttributesCountryMatch)
         

--- a/Tests/OptimizelyTests-Common/DecisionServiceTests_Holdouts.swift
+++ b/Tests/OptimizelyTests-Common/DecisionServiceTests_Holdouts.swift
@@ -444,17 +444,22 @@ extension DecisionServiceTests_Holdouts {
         modifiedFeatureFlagData["experimentIds"] = []
         featureFlag = try! OTUtils.model(from: modifiedFeatureFlagData)
         self.config.project.featureFlags = [featureFlag]
-        
+
+        // Use global holdout since there are no valid experiments
+        let globalHoldout = try! OTUtils.model(from: sampleHoldoutGlobal) as Holdout
+        self.config.project.holdouts = [globalHoldout]
+        self.config.holdoutConfig.allHoldouts = [globalHoldout]
+
         let decision = mockDecisionService.getVariationForFeature(
             config: config,
             featureFlag: featureFlag,
             user: optimizely.createUserContext(userId: kUserId, attributes: kAttributesCountryMatch)
         ).result
-        
+
         // Should return holdout decision
         XCTAssertNotNil(decision, "Decision should not be nil")
-        XCTAssertEqual(decision?.experiment?.id, holdout.id, "Should return holdout experiment")
-        XCTAssertEqual(decision?.variation?.key, "holdout_a", "Should return holdout variation")
+        XCTAssertEqual(decision?.experiment?.id, globalHoldout.id, "Should return holdout experiment")
+        XCTAssertEqual(decision?.variation?.key, "global_variation", "Should return holdout variation")
         XCTAssertEqual(decision?.source, Constants.DecisionSource.holdout.rawValue, "Source should be holdout")
     }
     
@@ -464,17 +469,22 @@ extension DecisionServiceTests_Holdouts {
         modifiedFeatureFlagData["experimentIds"] = ["invalid_experiment_id"]
         featureFlag = try! OTUtils.model(from: modifiedFeatureFlagData)
         self.config.project.featureFlags = [featureFlag]
-        
+
+        // Use global holdout since there are no valid experiments
+        let globalHoldout = try! OTUtils.model(from: sampleHoldoutGlobal) as Holdout
+        self.config.project.holdouts = [globalHoldout]
+        self.config.holdoutConfig.allHoldouts = [globalHoldout]
+
         let decision = mockDecisionService.getVariationForFeature(
             config: config,
             featureFlag: featureFlag,
             user: optimizely.createUserContext(userId: kUserId, attributes: kAttributesCountryMatch)
         ).result
-        
+
         // Should return holdout decision
         XCTAssertNotNil(decision, "Decision should not be nil")
-        XCTAssertEqual(decision?.experiment?.id, holdout.id, "Should return holdout experiment")
-        XCTAssertEqual(decision?.variation?.key, "holdout_a", "Should return holdout variation")
+        XCTAssertEqual(decision?.experiment?.id, globalHoldout.id, "Should return holdout experiment")
+        XCTAssertEqual(decision?.variation?.key, "global_variation", "Should return holdout variation")
         XCTAssertEqual(decision?.source, Constants.DecisionSource.holdout.rawValue, "Source should be holdout")
     }
     

--- a/Tests/OptimizelyTests-Common/DecisionServiceTests_Holdouts.swift
+++ b/Tests/OptimizelyTests-Common/DecisionServiceTests_Holdouts.swift
@@ -450,7 +450,11 @@ extension DecisionServiceTests_Holdouts {
         self.config.project.holdouts = [globalHoldout]
         self.config.holdoutConfig.allHoldouts = [globalHoldout]
 
-        let decision = mockDecisionService.getVariationForFeature(
+        // Use bucket value 400 which is within globalHoldout range (0-500)
+        let mockBucketer = MockBucketer(mockBucketValue: 400)
+        let testDecisionService = MockDecisionService(bucketer: mockBucketer)
+
+        let decision = testDecisionService.getVariationForFeature(
             config: config,
             featureFlag: featureFlag,
             user: optimizely.createUserContext(userId: kUserId, attributes: kAttributesCountryMatch)
@@ -475,7 +479,11 @@ extension DecisionServiceTests_Holdouts {
         self.config.project.holdouts = [globalHoldout]
         self.config.holdoutConfig.allHoldouts = [globalHoldout]
 
-        let decision = mockDecisionService.getVariationForFeature(
+        // Use bucket value 400 which is within globalHoldout range (0-500)
+        let mockBucketer = MockBucketer(mockBucketValue: 400)
+        let testDecisionService = MockDecisionService(bucketer: mockBucketer)
+
+        let decision = testDecisionService.getVariationForFeature(
             config: config,
             featureFlag: featureFlag,
             user: optimizely.createUserContext(userId: kUserId, attributes: kAttributesCountryMatch)

--- a/Tests/OptimizelyTests-Common/DecisionServiceTests_Holdouts.swift
+++ b/Tests/OptimizelyTests-Common/DecisionServiceTests_Holdouts.swift
@@ -122,8 +122,7 @@ class DecisionServiceTests_Holdouts: XCTestCase {
                     "key": "holdout_a"
                 ]
             ],
-            "includedFlags": ["flag_id_1234"],
-            "excludedFlags": []
+            "includedRules": ["country11"]  // Target the experiment rule in flag_id_1234
         ]
     }
     
@@ -142,12 +141,10 @@ class DecisionServiceTests_Holdouts: XCTestCase {
                     "id": "holdout_global_variation",
                     "key": "global_variation"
                 ]
-            ],
-            "includedFlags": [],
-            "excludedFlags": []
+            ]
         ]
     }
-    
+
     var sampleHoldoutIncluded: [String: Any] {
         return [
             "status": "Running",
@@ -164,11 +161,10 @@ class DecisionServiceTests_Holdouts: XCTestCase {
                     "key": "included_variation"
                 ]
             ],
-            "includedFlags": ["flag_id_1234"],
-            "excludedFlags": []
+            "includedRules": ["country11"]  // Target the experiment rule in flag_id_1234
         ]
     }
-    
+
     var sampleHoldoutExcluded: [String: Any] {
         return [
             "status": "Running",
@@ -185,8 +181,7 @@ class DecisionServiceTests_Holdouts: XCTestCase {
                     "key": "excluded_variation"
                 ]
             ],
-            "includedFlags": [],
-            "excludedFlags": ["flag_id_1234"]
+            "includedRules": []  // Empty array = local holdout targeting no rules (excludes flag_id_1234)
         ]
     }
     
@@ -476,8 +471,7 @@ extension DecisionServiceTests_Holdouts {
     func testGetVariationForFeatureExperiment_HoldoutExcludedFlag() {
         // Modify holdout to exclude the feature flag
         var modifiedHoldoutData = sampleHoldout
-        modifiedHoldoutData["includedFlags"] = []
-        modifiedHoldoutData["excludedFlags"] = ["flag_id_1234"]
+        modifiedHoldoutData["includedRules"] = []  // Empty array = local holdout targeting no rules (excludes flag_id_1234)
         let excludedHoldout = try! OTUtils.model(from: modifiedHoldoutData) as Holdout
         self.config.project.holdouts = [excludedHoldout]
         

--- a/Tests/OptimizelyTests-Common/DecisionServiceTests_Holdouts.swift
+++ b/Tests/OptimizelyTests-Common/DecisionServiceTests_Holdouts.swift
@@ -209,6 +209,7 @@ class DecisionServiceTests_Holdouts: XCTestCase {
         featureFlag = try! OTUtils.model(from: sampleFeatureFlagData)
         self.config.project.featureFlags = [featureFlag]
         self.config.project.holdouts = [holdout]
+        self.config.holdoutConfig.allHoldouts = [holdout]
     }
     
 }
@@ -226,6 +227,7 @@ extension DecisionServiceTests_Holdouts {
         holdout.audienceConditions = try! OTUtils.model(from: ["or", kAudienceIdCountry])
         holdout.audienceIds = [kAudienceIdAge]
         self.config.project.holdouts = [holdout]
+        self.config.holdoutConfig.allHoldouts = [holdout]
         
         var result: Bool! = mockDecisionService.doesMeetAudienceConditions(config: config,
                                                                            experiment: holdout,
@@ -254,6 +256,7 @@ extension DecisionServiceTests_Holdouts {
         holdout.audienceConditions = nil
         holdout.audienceIds = [kAudienceIdCountry]
         self.config.project.holdouts = [holdout]
+        self.config.holdoutConfig.allHoldouts = [holdout]
         
         var result: Bool! = mockDecisionService.doesMeetAudienceConditions(config: config,
                                                                            experiment: holdout,
@@ -279,6 +282,7 @@ extension DecisionServiceTests_Holdouts {
         holdout.audienceConditions = try! OTUtils.model(from: [])
         holdout.audienceIds = [kAudienceIdAge]
         self.config.project.holdouts = [holdout]
+        self.config.holdoutConfig.allHoldouts = [holdout]
         
         let result: Bool! = self.mockDecisionService.doesMeetAudienceConditions(config: config,
                                                                                 experiment: holdout,
@@ -292,6 +296,7 @@ extension DecisionServiceTests_Holdouts {
         holdout.audienceConditions = nil
         holdout.audienceIds = []
         self.config.project.holdouts = [holdout]
+        self.config.holdoutConfig.allHoldouts = [holdout]
         
         let result: Bool! = mockDecisionService.doesMeetAudienceConditions(config: config,
                                                                            experiment: holdout,
@@ -310,6 +315,7 @@ extension DecisionServiceTests_Holdouts {
         holdout.audienceConditions = array[0]
         holdout.audienceIds = [kAudienceIdAge]
         self.config.project.holdouts = [holdout]
+        self.config.holdoutConfig.allHoldouts = [holdout]
         
         var result: Bool! = mockDecisionService.doesMeetAudienceConditions(config: config,
                                                                            experiment: holdout,
@@ -325,6 +331,7 @@ extension DecisionServiceTests_Holdouts {
         array = try! OTUtils.model(from: ["and"])
         holdout.audienceConditions = array[0]
         self.config.project.holdouts = [holdout]
+        self.config.holdoutConfig.allHoldouts = [holdout]
         
         result = self.mockDecisionService.doesMeetAudienceConditions(config: config,
                                                                      experiment: holdout,
@@ -335,6 +342,7 @@ extension DecisionServiceTests_Holdouts {
         holdout.audienceConditions = nil
         holdout.audienceIds = []
         self.config.project.holdouts = [holdout]
+        self.config.holdoutConfig.allHoldouts = [holdout]
         
         result = self.mockDecisionService.doesMeetAudienceConditions(config: config,
                                                                      experiment: holdout,
@@ -396,6 +404,7 @@ extension DecisionServiceTests_Holdouts {
         modifiedHoldoutData["status"] = "Draft"
         let inactiveHoldout = try! OTUtils.model(from: modifiedHoldoutData) as Holdout
         self.config.project.holdouts = [inactiveHoldout]
+        self.config.holdoutConfig.allHoldouts = [inactiveHoldout]
         
         let decision = mockDecisionService.getVariationForFeature(
             config: config,
@@ -414,6 +423,7 @@ extension DecisionServiceTests_Holdouts {
     func testGetVariationForFeatureExperiment_NoHoldouts() {
         // Remove holdouts
         self.config.project.holdouts = []
+        self.config.holdoutConfig.allHoldouts = []
         
         let decision = mockDecisionService.getVariationForFeature(
             config: config,
@@ -474,6 +484,7 @@ extension DecisionServiceTests_Holdouts {
         modifiedHoldoutData["includedRules"] = []  // Empty array = local holdout targeting no rules (excludes flag_id_1234)
         let excludedHoldout = try! OTUtils.model(from: modifiedHoldoutData) as Holdout
         self.config.project.holdouts = [excludedHoldout]
+        self.config.holdoutConfig.allHoldouts = [excludedHoldout]
         
         let decision = mockDecisionService.getVariationForFeature(
             config: config,
@@ -500,6 +511,7 @@ extension DecisionServiceTests_Holdouts {
         excludedHoldout.trafficAllocation[0].endOfRange = tfAllocationRange
         
         self.config.project.holdouts = [globalHoldout, includedHoldout, excludedHoldout]
+        self.config.holdoutConfig.allHoldouts = [globalHoldout, includedHoldout, excludedHoldout]
         
         // Mock bucketer to bucket into the first valid holdout (global)
         let mockBucketer = MockBucketer(mockBucketValue: 1000) // Within all holdout ranges
@@ -524,6 +536,7 @@ extension DecisionServiceTests_Holdouts {
         let globalHoldout = try! OTUtils.model(from: sampleHoldoutGlobal) as Holdout
         let includedHoldout = try! OTUtils.model(from: sampleHoldoutIncluded) as Holdout
         self.config.project.holdouts = [globalHoldout, includedHoldout]
+        self.config.holdoutConfig.allHoldouts = [globalHoldout, includedHoldout]
         
         // Mock bucketer to fail global holdout bucketing, succeed for included
         let mockBucketer = MockBucketer(mockBucketValue: 700) // Outside global range, within included range
@@ -548,6 +561,7 @@ extension DecisionServiceTests_Holdouts {
         let includedHoldout = try! OTUtils.model(from: sampleHoldoutIncluded) as Holdout
         let excludedHoldout = try! OTUtils.model(from: sampleHoldoutExcluded) as Holdout
         self.config.project.holdouts = [globalHoldout, includedHoldout, excludedHoldout]
+        self.config.holdoutConfig.allHoldouts = [globalHoldout, includedHoldout, excludedHoldout]
         
         // Mock bucketer to fail all holdout bucketing
         let mockBucketer = MockBucketer(mockBucketValue: 1500) // Outside all holdout ranges
@@ -572,6 +586,7 @@ extension DecisionServiceTests_Holdouts {
         modifiedHoldoutData["trafficAllocation"] = []
         let noTrafficHoldout = try! OTUtils.model(from: modifiedHoldoutData) as Holdout
         self.config.project.holdouts = [noTrafficHoldout]
+        self.config.holdoutConfig.allHoldouts = [noTrafficHoldout]
         
         let decision = mockDecisionService.getVariationForFeature(
             config: config,
@@ -595,6 +610,7 @@ extension DecisionServiceTests_Holdouts {
         let includedHoldout = try! OTUtils.model(from: sampleHoldoutIncluded) as Holdout // Requires country: "us"
         
         self.config.project.holdouts = [globalHoldout, includedHoldout]
+        self.config.holdoutConfig.allHoldouts = [globalHoldout, includedHoldout]
         
         // Mock bucketer to fail included holdout bucketing
         let mockBucketer = MockBucketer(mockBucketValue: 1500) // Outside included holdout range
@@ -618,6 +634,7 @@ extension DecisionServiceTests_Holdouts {
         modifiedHoldoutData["variations"] = []
         let noVariationsHoldout = try! OTUtils.model(from: modifiedHoldoutData) as Holdout
         self.config.project.holdouts = [noVariationsHoldout]
+        self.config.holdoutConfig.allHoldouts = [noVariationsHoldout]
         
         let decision = mockDecisionService.getVariationForFeature(
             config: config,
@@ -637,6 +654,7 @@ extension DecisionServiceTests_Holdouts {
         let globalHoldout = try! OTUtils.model(from: sampleHoldoutGlobal) as Holdout
         let includedHoldout = try! OTUtils.model(from: sampleHoldoutIncluded) as Holdout
         self.config.project.holdouts = [globalHoldout, includedHoldout]
+        self.config.holdoutConfig.allHoldouts = [globalHoldout, includedHoldout]
         
         // First call
         let decision1 = mockDecisionService.getVariationForFeature(

--- a/Tests/OptimizelyTests-Common/DecisionServiceTests_LocalHoldouts.swift
+++ b/Tests/OptimizelyTests-Common/DecisionServiceTests_LocalHoldouts.swift
@@ -26,56 +26,38 @@ class DecisionServiceTests_LocalHoldouts: XCTestCase {
     var decisionService: DefaultDecisionService!
 
     let userId = "test_user"
-    let flagKey = "test_flag"
-    let flagId = "flag_123"
+    let flagKey = "feature_1"
+    let experimentRuleId = "10390977673"  // From decide_datafile
+    let deliveryRuleId = "3332020515"     // From decide_datafile rollout
 
-    let experimentRuleId = "exp_rule_456"
-    let experimentRuleKey = "exp_rule"
-
-    let deliveryRuleId = "delivery_rule_789"
-    let deliveryRuleKey = "delivery_rule"
-
-    let globalHoldoutId = "global_holdout_1"
-    let localHoldoutId = "local_holdout_1"
-
-    let holdoutVariationId = "holdout_var_1"
-    let holdoutVariationKey = "holdout_off"
-
-    let ruleVariationId = "rule_var_1"
-    let ruleVariationKey = "rule_var"
+    var sampleHoldout: [String: Any] {
+        return [
+            "status": "Running",
+            "id": "holdout_test_id",
+            "key": "holdout_test_key",
+            "trafficAllocation": [
+                ["entityId": "holdout_variation_id", "endOfRange": 5000] // 50% traffic
+            ],
+            "audienceIds": [],
+            "variations": [
+                [
+                    "variables": [],
+                    "id": "holdout_variation_id",
+                    "key": "holdout_variation_key",
+                    "featureEnabled": false
+                ]
+            ]
+        ]
+    }
 
     override func setUp() {
         super.setUp()
 
-        // Create base variations
-        let holdoutVariation = Variation(id: holdoutVariationId, key: holdoutVariationKey, featureEnabled: false, variablesMap: [:])
-        let ruleVariation = Variation(id: ruleVariationId, key: ruleVariationKey, featureEnabled: true, variablesMap: [:])
-
-        // Create traffic allocation (100% to variation)
-        let trafficAllocation = [TrafficAllocation(entityId: holdoutVariationId, endOfRange: 10000)]
-
-        // Create global holdout (includedRules: nil means global)
-        var globalHoldout = Holdout(id: globalHoldoutId,
-                                    key: "global_holdout",
-                                    status: .running,
-                                    variations: [holdoutVariation],
-                                    trafficAllocation: trafficAllocation,
-                                    audienceIds: [],
-                                    audienceConditions: nil,
-                                    includedRules: nil)
-
-        // Create local holdout targeting experiment rule
-        var localHoldout = Holdout(id: localHoldoutId,
-                                   key: "local_holdout",
-                                   status: .running,
-                                   variations: [holdoutVariation],
-                                   trafficAllocation: trafficAllocation,
-                                   audienceIds: [],
-                                   audienceConditions: nil,
-                                   includedRules: [experimentRuleId])
-
-        // Note: In real tests, we'd load from a proper datafile
-        // This is a simplified setup for illustration
+        // Load a real datafile for testing
+        optimizely = OTUtils.createOptimizely(datafileName: "decide_datafile",
+                                             clearUserProfileService: true)
+        config = optimizely.config!
+        decisionService = optimizely.decisionService as? DefaultDecisionService
     }
 
     // MARK: - Global Holdouts Tests
@@ -84,19 +66,45 @@ class DecisionServiceTests_LocalHoldouts: XCTestCase {
         // Test that global holdouts are checked at flag level before any experiment or delivery rules
         // Expected: User bucketed into global holdout, no rules evaluated
 
-        // This test would verify:
-        // 1. getDecisionForFlag() calls getGlobalHoldouts()
-        // 2. Global holdout match returns immediately
-        // 3. No experiment or delivery rules are evaluated
+        // Create global holdout (includedRules: nil)
+        var holdout = try! OTUtils.model(from: sampleHoldout) as Holdout
+        holdout.includedRules = nil  // Global holdout
+        config.project.holdouts = [holdout]
+        config.holdoutConfig.allHoldouts = [holdout]
 
-        XCTFail("Test not implemented - requires proper datafile setup and assertion logic")
+        // Mock bucketer to ensure user buckets into holdout (50% traffic = endOfRange 5000)
+        let mockBucketer = MockBucketer(mockBucketValue: 2500)
+        let mockDecisionService = DefaultDecisionService(userProfileService: OTUtils.createClearUserProfileService(), bucketer: mockBucketer)
+        optimizely.decisionService = mockDecisionService
+
+        let user = optimizely.createUserContext(userId: userId)
+        let decision = user.decide(key: flagKey)
+
+        // Assert user got the holdout variation
+        XCTAssertEqual(decision.variationKey, "holdout_variation_key", "User should be bucketed into global holdout")
+        XCTAssertFalse(decision.enabled, "Holdout variation should have featureEnabled: false")
     }
 
     func testGlobalHoldout_MissAllowsRuleEvaluation() {
         // Test that when user misses global holdout bucket, rule evaluation continues
         // Expected: Global holdout checked, user not bucketed, experiment rule evaluated
 
-        XCTFail("Test not implemented - requires proper datafile setup and assertion logic")
+        // Create global holdout
+        var holdout = try! OTUtils.model(from: sampleHoldout) as Holdout
+        holdout.includedRules = nil  // Global holdout
+        config.project.holdouts = [holdout]
+        config.holdoutConfig.allHoldouts = [holdout]
+
+        // Mock bucketer to ensure user MISSES holdout (50% traffic = endOfRange 5000)
+        let mockBucketer = MockBucketer(mockBucketValue: 7000)
+        let mockDecisionService = DefaultDecisionService(userProfileService: OTUtils.createClearUserProfileService(), bucketer: mockBucketer)
+        optimizely.decisionService = mockDecisionService
+
+        let user = optimizely.createUserContext(userId: userId)
+        let decision = user.decide(key: flagKey)
+
+        // Assert user did NOT get holdout variation (got normal experiment/rollout decision)
+        XCTAssertNotEqual(decision.variationKey, "holdout_variation_key", "User should NOT be in holdout")
     }
 
     // MARK: - Local Holdouts - Experiment Rules
@@ -105,26 +113,69 @@ class DecisionServiceTests_LocalHoldouts: XCTestCase {
         // Test that local holdout targeting an experiment rule is evaluated
         // Expected: User bucketed into local holdout, experiment rule skipped
 
-        // This test would verify:
-        // 1. getVariationFromExperimentRule() calls getHoldoutsForRule(ruleId)
-        // 2. Local holdout match returns immediately
-        // 3. Normal experiment bucketing is skipped
+        // Create local holdout targeting specific experiment rule
+        var holdout = try! OTUtils.model(from: sampleHoldout) as Holdout
+        holdout.includedRules = [experimentRuleId]  // Target the experiment rule
+        config.project.holdouts = [holdout]
+        config.holdoutConfig.allHoldouts = [holdout]
 
-        XCTFail("Test not implemented - requires proper datafile setup and assertion logic")
+        // Mock bucketer to ensure user buckets into holdout
+        let mockBucketer = MockBucketer(mockBucketValue: 2500)
+        let mockDecisionService = DefaultDecisionService(userProfileService: OTUtils.createClearUserProfileService(), bucketer: mockBucketer)
+        optimizely.decisionService = mockDecisionService
+
+        let user = optimizely.createUserContext(userId: userId)
+        let decision = user.decide(key: flagKey)
+
+        // Assert user got the holdout variation
+        XCTAssertEqual(decision.variationKey, "holdout_variation_key", "User should be bucketed into local holdout")
+        XCTAssertFalse(decision.enabled, "Holdout variation should have featureEnabled: false")
     }
 
     func testLocalHoldout_ExperimentRule_UserNotBucketed() {
         // Test that when user misses local holdout, normal experiment evaluation continues
         // Expected: Local holdout checked, user not bucketed, normal experiment logic runs
 
-        XCTFail("Test not implemented - requires proper datafile setup and assertion logic")
+        // Create local holdout targeting experiment rule
+        var holdout = try! OTUtils.model(from: sampleHoldout) as Holdout
+        holdout.includedRules = [experimentRuleId]
+        config.project.holdouts = [holdout]
+        config.holdoutConfig.allHoldouts = [holdout]
+
+        // Mock bucketer to ensure user MISSES holdout
+        let mockBucketer = MockBucketer(mockBucketValue: 7000)
+        let mockDecisionService = DefaultDecisionService(userProfileService: OTUtils.createClearUserProfileService(), bucketer: mockBucketer)
+        optimizely.decisionService = mockDecisionService
+
+        let user = optimizely.createUserContext(userId: userId)
+        let decision = user.decide(key: flagKey)
+
+        // Assert user did NOT get holdout variation
+        XCTAssertNotEqual(decision.variationKey, "holdout_variation_key", "User should NOT be in holdout")
     }
 
     func testLocalHoldout_ExperimentRule_AudienceMismatch() {
         // Test that local holdout with audience condition skips users not matching audience
         // Expected: User doesn't match audience, holdout skipped, normal experiment runs
 
-        XCTFail("Test not implemented - requires proper datafile setup and assertion logic")
+        // Create local holdout with audience targeting
+        var holdout = try! OTUtils.model(from: sampleHoldout) as Holdout
+        holdout.includedRules = [experimentRuleId]
+        holdout.audienceIds = ["13389130056"]  // Audience from decide_datafile
+        config.project.holdouts = [holdout]
+        config.holdoutConfig.allHoldouts = [holdout]
+
+        // Mock bucketer to ensure would bucket IF audience matched
+        let mockBucketer = MockBucketer(mockBucketValue: 2500)
+        let mockDecisionService = DefaultDecisionService(userProfileService: OTUtils.createClearUserProfileService(), bucketer: mockBucketer)
+        optimizely.decisionService = mockDecisionService
+
+        // User without matching attributes
+        let user = optimizely.createUserContext(userId: userId)
+        let decision = user.decide(key: flagKey)
+
+        // Assert user did NOT get holdout (audience mismatch)
+        XCTAssertNotEqual(decision.variationKey, "holdout_variation_key", "User should NOT be in holdout due to audience mismatch")
     }
 
     // MARK: - Local Holdouts - Delivery Rules
@@ -133,19 +184,45 @@ class DecisionServiceTests_LocalHoldouts: XCTestCase {
         // Test that local holdout targeting a delivery rule is evaluated
         // Expected: User bucketed into local holdout, delivery rule skipped
 
-        // This test would verify:
-        // 1. getVariationFromDeliveryRule() calls getHoldoutsForRule(ruleId)
-        // 2. Local holdout match returns immediately
-        // 3. Normal delivery rule bucketing is skipped
+        // Create local holdout targeting delivery rule
+        var holdout = try! OTUtils.model(from: sampleHoldout) as Holdout
+        holdout.includedRules = [deliveryRuleId]  // Target delivery rule from rollout
+        config.project.holdouts = [holdout]
+        config.holdoutConfig.allHoldouts = [holdout]
 
-        XCTFail("Test not implemented - requires proper datafile setup and assertion logic")
+        // Mock bucketer to ensure user buckets into holdout
+        let mockBucketer = MockBucketer(mockBucketValue: 2500)
+        let mockDecisionService = DefaultDecisionService(userProfileService: OTUtils.createClearUserProfileService(), bucketer: mockBucketer)
+        optimizely.decisionService = mockDecisionService
+
+        let user = optimizely.createUserContext(userId: userId)
+        let decision = user.decide(key: flagKey)
+
+        // Assert user got the holdout variation
+        XCTAssertEqual(decision.variationKey, "holdout_variation_key", "User should be bucketed into local holdout for delivery rule")
+        XCTAssertFalse(decision.enabled, "Holdout variation should have featureEnabled: false")
     }
 
     func testLocalHoldout_DeliveryRule_UserNotBucketed() {
         // Test that when user misses local holdout, normal delivery rule evaluation continues
         // Expected: Local holdout checked, user not bucketed, normal delivery logic runs
 
-        XCTFail("Test not implemented - requires proper datafile setup and assertion logic")
+        // Create local holdout targeting delivery rule
+        var holdout = try! OTUtils.model(from: sampleHoldout) as Holdout
+        holdout.includedRules = [deliveryRuleId]
+        config.project.holdouts = [holdout]
+        config.holdoutConfig.allHoldouts = [holdout]
+
+        // Mock bucketer to ensure user MISSES holdout
+        let mockBucketer = MockBucketer(mockBucketValue: 7000)
+        let mockDecisionService = DefaultDecisionService(userProfileService: OTUtils.createClearUserProfileService(), bucketer: mockBucketer)
+        optimizely.decisionService = mockDecisionService
+
+        let user = optimizely.createUserContext(userId: userId)
+        let decision = user.decide(key: flagKey)
+
+        // Assert user did NOT get holdout variation
+        XCTAssertNotEqual(decision.variationKey, "holdout_variation_key", "User should NOT be in holdout")
     }
 
     // MARK: - Multiple Local Holdouts
@@ -154,14 +231,61 @@ class DecisionServiceTests_LocalHoldouts: XCTestCase {
         // Test that when multiple local holdouts target the same rule, first match wins
         // Expected: User bucketed into first matching holdout, second holdout not evaluated
 
-        XCTFail("Test not implemented - requires proper datafile setup and assertion logic")
+        // Create two local holdouts targeting the same rule
+        var holdout1 = try! OTUtils.model(from: sampleHoldout) as Holdout
+        holdout1.id = "holdout_1"
+        holdout1.key = "holdout_1"
+        holdout1.includedRules = [experimentRuleId]
+        holdout1.variations[0].key = "holdout_1_variation"
+
+        var holdout2 = try! OTUtils.model(from: sampleHoldout) as Holdout
+        holdout2.id = "holdout_2"
+        holdout2.key = "holdout_2"
+        holdout2.includedRules = [experimentRuleId]
+        holdout2.variations[0].id = "holdout_2_var_id"
+        holdout2.variations[0].key = "holdout_2_variation"
+
+        config.project.holdouts = [holdout1, holdout2]
+        config.holdoutConfig.allHoldouts = [holdout1, holdout2]
+
+        // Mock bucketer to ensure user buckets into both
+        let mockBucketer = MockBucketer(mockBucketValue: 2500)
+        let mockDecisionService = DefaultDecisionService(userProfileService: OTUtils.createClearUserProfileService(), bucketer: mockBucketer)
+        optimizely.decisionService = mockDecisionService
+
+        let user = optimizely.createUserContext(userId: userId)
+        let decision = user.decide(key: flagKey)
+
+        // Assert user got the FIRST holdout variation
+        XCTAssertEqual(decision.variationKey, "holdout_1_variation", "User should be in first matching holdout only")
     }
 
     func testMultipleLocalHoldouts_DifferentRules_EachEvaluated() {
         // Test that local holdouts targeting different rules are each evaluated independently
         // Expected: Each rule checks its own local holdouts
 
-        XCTFail("Test not implemented - requires proper datafile setup and assertion logic")
+        // Create two holdouts targeting different rules
+        var holdout1 = try! OTUtils.model(from: sampleHoldout) as Holdout
+        holdout1.includedRules = [experimentRuleId]
+
+        var holdout2 = try! OTUtils.model(from: sampleHoldout) as Holdout
+        holdout2.id = "holdout_2"
+        holdout2.includedRules = [deliveryRuleId]
+        holdout2.variations[0].id = "holdout_2_var_id"
+
+        config.project.holdouts = [holdout1, holdout2]
+        config.holdoutConfig.allHoldouts = [holdout1, holdout2]
+
+        // Mock bucketer
+        let mockBucketer = MockBucketer(mockBucketValue: 2500)
+        let mockDecisionService = DefaultDecisionService(userProfileService: OTUtils.createClearUserProfileService(), bucketer: mockBucketer)
+        optimizely.decisionService = mockDecisionService
+
+        let user = optimizely.createUserContext(userId: userId)
+        let decision = user.decide(key: flagKey)
+
+        // Assert that one of the holdouts was evaluated (which one depends on rule evaluation order)
+        XCTAssertEqual(decision.variationKey, "holdout_variation_key", "User should be in one of the holdouts")
     }
 
     // MARK: - Cross-Flag Local Holdouts
@@ -170,7 +294,26 @@ class DecisionServiceTests_LocalHoldouts: XCTestCase {
         // Test that a local holdout targeting rules from multiple flags only affects those specific rules
         // Expected: Only the targeted rule in this flag is affected, other rules work normally
 
-        XCTFail("Test not implemented - requires proper datafile setup and assertion logic")
+        // Create local holdout targeting specific rule in feature_1
+        var holdout = try! OTUtils.model(from: sampleHoldout) as Holdout
+        holdout.includedRules = [experimentRuleId]  // Only targets experiment in feature_1
+        config.project.holdouts = [holdout]
+        config.holdoutConfig.allHoldouts = [holdout]
+
+        // Mock bucketer
+        let mockBucketer = MockBucketer(mockBucketValue: 2500)
+        let mockDecisionService = DefaultDecisionService(userProfileService: OTUtils.createClearUserProfileService(), bucketer: mockBucketer)
+        optimizely.decisionService = mockDecisionService
+
+        let user = optimizely.createUserContext(userId: userId)
+
+        // Test feature_1 (should be affected)
+        let decision1 = user.decide(key: "feature_1")
+        XCTAssertEqual(decision1.variationKey, "holdout_variation_key", "feature_1 should be in holdout")
+
+        // Test feature_2 (should NOT be affected - no rules targeted)
+        let decision2 = user.decide(key: "feature_2")
+        XCTAssertNotEqual(decision2.variationKey, "holdout_variation_key", "feature_2 should NOT be in holdout")
     }
 
     // MARK: - Global + Local Interaction
@@ -179,20 +322,60 @@ class DecisionServiceTests_LocalHoldouts: XCTestCase {
         // Test precedence: global holdouts evaluated before local holdouts
         // Expected: If user in global holdout, local holdout never evaluated
 
-        // Decision flow should be:
-        // 1. Check global holdouts (flag level)
-        // 2. If no match, evaluate experiment rules
-        //    a. Check local holdouts for this rule
-        //    b. If no match, normal rule evaluation
+        // Create global and local holdouts
+        var globalHoldout = try! OTUtils.model(from: sampleHoldout) as Holdout
+        globalHoldout.id = "global_holdout"
+        globalHoldout.key = "global_holdout"
+        globalHoldout.includedRules = nil  // Global
+        globalHoldout.variations[0].key = "global_variation"
 
-        XCTFail("Test not implemented - requires proper datafile setup and assertion logic")
+        var localHoldout = try! OTUtils.model(from: sampleHoldout) as Holdout
+        localHoldout.id = "local_holdout"
+        localHoldout.includedRules = [experimentRuleId]  // Local
+        localHoldout.variations[0].id = "local_var_id"
+        localHoldout.variations[0].key = "local_variation"
+
+        config.project.holdouts = [globalHoldout, localHoldout]
+        config.holdoutConfig.allHoldouts = [globalHoldout, localHoldout]
+
+        // Mock bucketer to ensure user buckets into both
+        let mockBucketer = MockBucketer(mockBucketValue: 2500)
+        let mockDecisionService = DefaultDecisionService(userProfileService: OTUtils.createClearUserProfileService(), bucketer: mockBucketer)
+        optimizely.decisionService = mockDecisionService
+
+        let user = optimizely.createUserContext(userId: userId)
+        let decision = user.decide(key: flagKey)
+
+        // Assert user got GLOBAL holdout (evaluated first)
+        XCTAssertEqual(decision.variationKey, "global_variation", "Global holdout should be evaluated first")
     }
 
     func testLocalHoldout_EvaluatedAfterForcedDecision() {
         // Test that forced decisions take precedence over local holdouts
         // Expected: Forced decision checked first, if no match then local holdout
 
-        XCTFail("Test not implemented - requires proper datafile setup and assertion logic")
+        // Create local holdout
+        var holdout = try! OTUtils.model(from: sampleHoldout) as Holdout
+        holdout.includedRules = [experimentRuleId]
+        config.project.holdouts = [holdout]
+        config.holdoutConfig.allHoldouts = [holdout]
+
+        // Mock bucketer to ensure would bucket into holdout
+        let mockBucketer = MockBucketer(mockBucketValue: 2500)
+        let mockDecisionService = DefaultDecisionService(userProfileService: OTUtils.createClearUserProfileService(), bucketer: mockBucketer)
+        optimizely.decisionService = mockDecisionService
+
+        let user = optimizely.createUserContext(userId: userId)
+
+        // Set forced decision (should override holdout)
+        let context = OptimizelyDecisionContext(flagKey: flagKey, ruleKey: nil)
+        let forcedDecision = OptimizelyForcedDecision(variationKey: "a")
+        user.setForcedDecision(context: context, decision: forcedDecision)
+
+        let decision = user.decide(key: flagKey)
+
+        // Assert user got forced decision, NOT holdout
+        XCTAssertEqual(decision.variationKey, "a", "Forced decision should take precedence over holdout")
     }
 
     // MARK: - Edge Cases
@@ -211,7 +394,23 @@ class DecisionServiceTests_LocalHoldouts: XCTestCase {
         // Test that local holdouts with status != running are not evaluated
         // Expected: Only running holdouts are checked
 
-        XCTFail("Test not implemented - requires proper datafile setup and assertion logic")
+        // Create inactive holdout
+        var holdout = try! OTUtils.model(from: sampleHoldout) as Holdout
+        holdout.status = .paused  // Not running
+        holdout.includedRules = [experimentRuleId]
+        config.project.holdouts = [holdout]
+        config.holdoutConfig.allHoldouts = [holdout]
+
+        // Mock bucketer to ensure would bucket IF holdout was active
+        let mockBucketer = MockBucketer(mockBucketValue: 2500)
+        let mockDecisionService = DefaultDecisionService(userProfileService: OTUtils.createClearUserProfileService(), bucketer: mockBucketer)
+        optimizely.decisionService = mockDecisionService
+
+        let user = optimizely.createUserContext(userId: userId)
+        let decision = user.decide(key: flagKey)
+
+        // Assert user did NOT get holdout (status not running)
+        XCTAssertNotEqual(decision.variationKey, "holdout_variation_key", "Inactive holdout should not be evaluated")
     }
 
     func testLocalHoldout_EmptyIncludedRules_TreatedAsGlobal() {

--- a/Tests/OptimizelyTests-Common/DecisionServiceTests_LocalHoldouts.swift
+++ b/Tests/OptimizelyTests-Common/DecisionServiceTests_LocalHoldouts.swift
@@ -89,14 +89,14 @@ class DecisionServiceTests_LocalHoldouts: XCTestCase {
         // 2. Global holdout match returns immediately
         // 3. No experiment or delivery rules are evaluated
 
-        XCTAssertTrue(true, "Test implementation requires proper datafile setup")
+        XCTFail("Test not implemented - requires proper datafile setup and assertion logic")
     }
 
     func testGlobalHoldout_MissAllowsRuleEvaluation() {
         // Test that when user misses global holdout bucket, rule evaluation continues
         // Expected: Global holdout checked, user not bucketed, experiment rule evaluated
 
-        XCTAssertTrue(true, "Test implementation requires proper datafile setup")
+        XCTFail("Test not implemented - requires proper datafile setup and assertion logic")
     }
 
     // MARK: - Local Holdouts - Experiment Rules
@@ -110,21 +110,21 @@ class DecisionServiceTests_LocalHoldouts: XCTestCase {
         // 2. Local holdout match returns immediately
         // 3. Normal experiment bucketing is skipped
 
-        XCTAssertTrue(true, "Test implementation requires proper datafile setup")
+        XCTFail("Test not implemented - requires proper datafile setup and assertion logic")
     }
 
     func testLocalHoldout_ExperimentRule_UserNotBucketed() {
         // Test that when user misses local holdout, normal experiment evaluation continues
         // Expected: Local holdout checked, user not bucketed, normal experiment logic runs
 
-        XCTAssertTrue(true, "Test implementation requires proper datafile setup")
+        XCTFail("Test not implemented - requires proper datafile setup and assertion logic")
     }
 
     func testLocalHoldout_ExperimentRule_AudienceMismatch() {
         // Test that local holdout with audience condition skips users not matching audience
         // Expected: User doesn't match audience, holdout skipped, normal experiment runs
 
-        XCTAssertTrue(true, "Test implementation requires proper datafile setup")
+        XCTFail("Test not implemented - requires proper datafile setup and assertion logic")
     }
 
     // MARK: - Local Holdouts - Delivery Rules
@@ -138,14 +138,14 @@ class DecisionServiceTests_LocalHoldouts: XCTestCase {
         // 2. Local holdout match returns immediately
         // 3. Normal delivery rule bucketing is skipped
 
-        XCTAssertTrue(true, "Test implementation requires proper datafile setup")
+        XCTFail("Test not implemented - requires proper datafile setup and assertion logic")
     }
 
     func testLocalHoldout_DeliveryRule_UserNotBucketed() {
         // Test that when user misses local holdout, normal delivery rule evaluation continues
         // Expected: Local holdout checked, user not bucketed, normal delivery logic runs
 
-        XCTAssertTrue(true, "Test implementation requires proper datafile setup")
+        XCTFail("Test not implemented - requires proper datafile setup and assertion logic")
     }
 
     // MARK: - Multiple Local Holdouts
@@ -154,14 +154,14 @@ class DecisionServiceTests_LocalHoldouts: XCTestCase {
         // Test that when multiple local holdouts target the same rule, first match wins
         // Expected: User bucketed into first matching holdout, second holdout not evaluated
 
-        XCTAssertTrue(true, "Test implementation requires proper datafile setup")
+        XCTFail("Test not implemented - requires proper datafile setup and assertion logic")
     }
 
     func testMultipleLocalHoldouts_DifferentRules_EachEvaluated() {
         // Test that local holdouts targeting different rules are each evaluated independently
         // Expected: Each rule checks its own local holdouts
 
-        XCTAssertTrue(true, "Test implementation requires proper datafile setup")
+        XCTFail("Test not implemented - requires proper datafile setup and assertion logic")
     }
 
     // MARK: - Cross-Flag Local Holdouts
@@ -170,7 +170,7 @@ class DecisionServiceTests_LocalHoldouts: XCTestCase {
         // Test that a local holdout targeting rules from multiple flags only affects those specific rules
         // Expected: Only the targeted rule in this flag is affected, other rules work normally
 
-        XCTAssertTrue(true, "Test implementation requires proper datafile setup")
+        XCTFail("Test not implemented - requires proper datafile setup and assertion logic")
     }
 
     // MARK: - Global + Local Interaction
@@ -185,14 +185,14 @@ class DecisionServiceTests_LocalHoldouts: XCTestCase {
         //    a. Check local holdouts for this rule
         //    b. If no match, normal rule evaluation
 
-        XCTAssertTrue(true, "Test implementation requires proper datafile setup")
+        XCTFail("Test not implemented - requires proper datafile setup and assertion logic")
     }
 
     func testLocalHoldout_EvaluatedAfterForcedDecision() {
         // Test that forced decisions take precedence over local holdouts
         // Expected: Forced decision checked first, if no match then local holdout
 
-        XCTAssertTrue(true, "Test implementation requires proper datafile setup")
+        XCTFail("Test not implemented - requires proper datafile setup and assertion logic")
     }
 
     // MARK: - Edge Cases
@@ -211,7 +211,7 @@ class DecisionServiceTests_LocalHoldouts: XCTestCase {
         // Test that local holdouts with status != running are not evaluated
         // Expected: Only running holdouts are checked
 
-        XCTAssertTrue(true, "Test implementation requires proper datafile setup")
+        XCTFail("Test not implemented - requires proper datafile setup and assertion logic")
     }
 
     func testLocalHoldout_EmptyIncludedRules_TreatedAsGlobal() {

--- a/Tests/OptimizelyTests-Common/DecisionServiceTests_LocalHoldouts.swift
+++ b/Tests/OptimizelyTests-Common/DecisionServiceTests_LocalHoldouts.swift
@@ -1,0 +1,237 @@
+//
+// Copyright 2026, Optimizely, Inc. and contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import XCTest
+
+/// Integration tests for Local Holdouts functionality
+/// Tests that local holdouts are correctly evaluated at the rule level
+/// and global holdouts are evaluated at the flag level before any rules
+class DecisionServiceTests_LocalHoldouts: XCTestCase {
+
+    var optimizely: OptimizelyClient!
+    var config: ProjectConfig!
+    var decisionService: DefaultDecisionService!
+
+    let userId = "test_user"
+    let flagKey = "test_flag"
+    let flagId = "flag_123"
+
+    let experimentRuleId = "exp_rule_456"
+    let experimentRuleKey = "exp_rule"
+
+    let deliveryRuleId = "delivery_rule_789"
+    let deliveryRuleKey = "delivery_rule"
+
+    let globalHoldoutId = "global_holdout_1"
+    let localHoldoutId = "local_holdout_1"
+
+    let holdoutVariationId = "holdout_var_1"
+    let holdoutVariationKey = "holdout_off"
+
+    let ruleVariationId = "rule_var_1"
+    let ruleVariationKey = "rule_var"
+
+    override func setUp() {
+        super.setUp()
+
+        // Create base variations
+        let holdoutVariation = Variation(id: holdoutVariationId, key: holdoutVariationKey, featureEnabled: false, variablesMap: [:])
+        let ruleVariation = Variation(id: ruleVariationId, key: ruleVariationKey, featureEnabled: true, variablesMap: [:])
+
+        // Create traffic allocation (100% to variation)
+        let trafficAllocation = [TrafficAllocation(entityId: holdoutVariationId, endOfRange: 10000)]
+
+        // Create global holdout (includedRules: nil means global)
+        var globalHoldout = Holdout(id: globalHoldoutId,
+                                    key: "global_holdout",
+                                    status: .running,
+                                    variations: [holdoutVariation],
+                                    trafficAllocation: trafficAllocation,
+                                    audienceIds: [],
+                                    audienceConditions: nil,
+                                    includedRules: nil)
+
+        // Create local holdout targeting experiment rule
+        var localHoldout = Holdout(id: localHoldoutId,
+                                   key: "local_holdout",
+                                   status: .running,
+                                   variations: [holdoutVariation],
+                                   trafficAllocation: trafficAllocation,
+                                   audienceIds: [],
+                                   audienceConditions: nil,
+                                   includedRules: [experimentRuleId])
+
+        // Note: In real tests, we'd load from a proper datafile
+        // This is a simplified setup for illustration
+    }
+
+    // MARK: - Global Holdouts Tests
+
+    func testGlobalHoldout_EvaluatedBeforeAllRules() {
+        // Test that global holdouts are checked at flag level before any experiment or delivery rules
+        // Expected: User bucketed into global holdout, no rules evaluated
+
+        // This test would verify:
+        // 1. getDecisionForFlag() calls getGlobalHoldouts()
+        // 2. Global holdout match returns immediately
+        // 3. No experiment or delivery rules are evaluated
+
+        XCTAssertTrue(true, "Test implementation requires proper datafile setup")
+    }
+
+    func testGlobalHoldout_MissAllowsRuleEvaluation() {
+        // Test that when user misses global holdout bucket, rule evaluation continues
+        // Expected: Global holdout checked, user not bucketed, experiment rule evaluated
+
+        XCTAssertTrue(true, "Test implementation requires proper datafile setup")
+    }
+
+    // MARK: - Local Holdouts - Experiment Rules
+
+    func testLocalHoldout_ExperimentRule_UserBucketed() {
+        // Test that local holdout targeting an experiment rule is evaluated
+        // Expected: User bucketed into local holdout, experiment rule skipped
+
+        // This test would verify:
+        // 1. getVariationFromExperimentRule() calls getHoldoutsForRule(ruleId)
+        // 2. Local holdout match returns immediately
+        // 3. Normal experiment bucketing is skipped
+
+        XCTAssertTrue(true, "Test implementation requires proper datafile setup")
+    }
+
+    func testLocalHoldout_ExperimentRule_UserNotBucketed() {
+        // Test that when user misses local holdout, normal experiment evaluation continues
+        // Expected: Local holdout checked, user not bucketed, normal experiment logic runs
+
+        XCTAssertTrue(true, "Test implementation requires proper datafile setup")
+    }
+
+    func testLocalHoldout_ExperimentRule_AudienceMismatch() {
+        // Test that local holdout with audience condition skips users not matching audience
+        // Expected: User doesn't match audience, holdout skipped, normal experiment runs
+
+        XCTAssertTrue(true, "Test implementation requires proper datafile setup")
+    }
+
+    // MARK: - Local Holdouts - Delivery Rules
+
+    func testLocalHoldout_DeliveryRule_UserBucketed() {
+        // Test that local holdout targeting a delivery rule is evaluated
+        // Expected: User bucketed into local holdout, delivery rule skipped
+
+        // This test would verify:
+        // 1. getVariationFromDeliveryRule() calls getHoldoutsForRule(ruleId)
+        // 2. Local holdout match returns immediately
+        // 3. Normal delivery rule bucketing is skipped
+
+        XCTAssertTrue(true, "Test implementation requires proper datafile setup")
+    }
+
+    func testLocalHoldout_DeliveryRule_UserNotBucketed() {
+        // Test that when user misses local holdout, normal delivery rule evaluation continues
+        // Expected: Local holdout checked, user not bucketed, normal delivery logic runs
+
+        XCTAssertTrue(true, "Test implementation requires proper datafile setup")
+    }
+
+    // MARK: - Multiple Local Holdouts
+
+    func testMultipleLocalHoldouts_SameRule_FirstMatchWins() {
+        // Test that when multiple local holdouts target the same rule, first match wins
+        // Expected: User bucketed into first matching holdout, second holdout not evaluated
+
+        XCTAssertTrue(true, "Test implementation requires proper datafile setup")
+    }
+
+    func testMultipleLocalHoldouts_DifferentRules_EachEvaluated() {
+        // Test that local holdouts targeting different rules are each evaluated independently
+        // Expected: Each rule checks its own local holdouts
+
+        XCTAssertTrue(true, "Test implementation requires proper datafile setup")
+    }
+
+    // MARK: - Cross-Flag Local Holdouts
+
+    func testLocalHoldout_CrossFlag_OnlyTargetedRulesAffected() {
+        // Test that a local holdout targeting rules from multiple flags only affects those specific rules
+        // Expected: Only the targeted rule in this flag is affected, other rules work normally
+
+        XCTAssertTrue(true, "Test implementation requires proper datafile setup")
+    }
+
+    // MARK: - Global + Local Interaction
+
+    func testGlobalAndLocalHoldouts_GlobalEvaluatedFirst() {
+        // Test precedence: global holdouts evaluated before local holdouts
+        // Expected: If user in global holdout, local holdout never evaluated
+
+        // Decision flow should be:
+        // 1. Check global holdouts (flag level)
+        // 2. If no match, evaluate experiment rules
+        //    a. Check local holdouts for this rule
+        //    b. If no match, normal rule evaluation
+
+        XCTAssertTrue(true, "Test implementation requires proper datafile setup")
+    }
+
+    func testLocalHoldout_EvaluatedAfterForcedDecision() {
+        // Test that forced decisions take precedence over local holdouts
+        // Expected: Forced decision checked first, if no match then local holdout
+
+        XCTAssertTrue(true, "Test implementation requires proper datafile setup")
+    }
+
+    // MARK: - Edge Cases
+
+    func testLocalHoldout_RuleNotFound_NoError() {
+        // Test that local holdout targeting non-existent rule doesn't break evaluation
+        // Expected: Empty array returned from getHoldoutsForRule(), normal evaluation continues
+
+        let config = HoldoutConfig(allholdouts: [])
+        let result = config.getHoldoutsForRule(ruleId: "nonexistent_rule")
+
+        XCTAssertTrue(result.isEmpty, "Non-existent rule should return empty array")
+    }
+
+    func testLocalHoldout_InactiveStatus_NotEvaluated() {
+        // Test that local holdouts with status != running are not evaluated
+        // Expected: Only running holdouts are checked
+
+        XCTAssertTrue(true, "Test implementation requires proper datafile setup")
+    }
+
+    func testLocalHoldout_EmptyIncludedRules_TreatedAsGlobal() {
+        // Test that holdout with empty includedRules array is NOT treated as global
+        // Only includedRules == nil should be global
+
+        var holdout = Holdout(id: "test_holdout",
+                             key: "test",
+                             status: .running,
+                             variations: [],
+                             trafficAllocation: [],
+                             audienceIds: [],
+                             audienceConditions: nil,
+                             includedRules: [])  // Empty array, NOT nil
+
+        // Empty array means local holdout with no rules targeted (effectively inactive)
+        XCTAssertFalse(holdout.isGlobal, "Empty includedRules array should NOT be global")
+
+        // Set to nil
+        holdout.includedRules = nil
+        XCTAssertTrue(holdout.isGlobal, "Nil includedRules should be global")
+    }
+}

--- a/Tests/OptimizelyTests-Common/DecisionServiceTests_LocalHoldouts.swift
+++ b/Tests/OptimizelyTests-Common/DecisionServiceTests_LocalHoldouts.swift
@@ -396,7 +396,7 @@ class DecisionServiceTests_LocalHoldouts: XCTestCase {
 
         // Create inactive holdout
         var holdout = try! OTUtils.model(from: sampleHoldout) as Holdout
-        holdout.status = .paused  // Not running
+        holdout.status = .draft  // Not running
         holdout.includedRules = [experimentRuleId]
         config.project.holdouts = [holdout]
         config.holdoutConfig.allHoldouts = [holdout]
@@ -417,14 +417,10 @@ class DecisionServiceTests_LocalHoldouts: XCTestCase {
         // Test that holdout with empty includedRules array is NOT treated as global
         // Only includedRules == nil should be global
 
-        var holdout = Holdout(id: "test_holdout",
-                             key: "test",
-                             status: .running,
-                             variations: [],
-                             trafficAllocation: [],
-                             audienceIds: [],
-                             audienceConditions: nil,
-                             includedRules: [])  // Empty array, NOT nil
+        // Create holdout with empty array
+        var holdoutData = sampleHoldout
+        holdoutData["includedRules"] = []  // Empty array, NOT nil
+        var holdout = try! OTUtils.model(from: holdoutData) as Holdout
 
         // Empty array means local holdout with no rules targeted (effectively inactive)
         XCTAssertFalse(holdout.isGlobal, "Empty includedRules array should NOT be global")

--- a/Tests/OptimizelyTests-Common/OptimizelyUserContextTests_Decide_Holdouts.swift
+++ b/Tests/OptimizelyTests-Common/OptimizelyUserContextTests_Decide_Holdouts.swift
@@ -39,9 +39,7 @@ class OptimizelyUserContextTests_Decide_Holdouts: XCTestCase {
                     "id": "id_holdout_variation",
                     "key": "key_holdout_variation"
                 ]
-            ],
-            "includedFlags": [],
-            "excludedFlags": []
+            ]
         ]
     }
     
@@ -161,9 +159,9 @@ class OptimizelyUserContextTests_Decide_Holdouts: XCTestCase {
     func testDecide_defaultDecideOption() {
         let featureKey = "feature_2"
         let feature_id = "4482920078"
-        
+
         var holdout = try! OTUtils.model(from: sampleHoldout) as Holdout
-        holdout.includedFlags = [feature_id]
+        holdout.includedRules = ["10420810910"]  // Experiment rule in feature_2
         optimizely.config!.project.holdouts = [holdout]
         
         let mockDecisionService = DefaultDecisionService(userProfileService: OTUtils.createClearUserProfileService(), bucketer: MockBucketer(mockBucketValue: 400))
@@ -200,7 +198,8 @@ class OptimizelyUserContextTests_Decide_Holdouts: XCTestCase {
         let feature1_Id = "4482920077"
         
         var holdout = try! OTUtils.model(from: sampleHoldout) as Holdout
-        holdout.includedFlags = [feature1_Id]
+        // Include all rules in feature_1: experiment + delivery rules
+        holdout.includedRules = ["10390977673", "3332020515", "3332020494", "18322080788"]
         optimizely.config!.project.holdouts = [holdout]
         
         let mockDecisionService = DefaultDecisionService(userProfileService: OTUtils.createClearUserProfileService(), bucketer: MockBucketer(mockBucketValue: 400))
@@ -226,7 +225,8 @@ class OptimizelyUserContextTests_Decide_Holdouts: XCTestCase {
         let featureKey2 = "feature_2"
         
         var holdout = try! OTUtils.model(from: sampleHoldout) as Holdout
-        holdout.includedFlags = [feature1_Id]
+        // Include all rules in feature_1: experiment + delivery rules
+        holdout.includedRules = ["10390977673", "3332020515", "3332020494", "18322080788"]
         optimizely.config!.project.holdouts = [holdout]
         
         let mockDecisionService = DefaultDecisionService(userProfileService: OTUtils.createClearUserProfileService(), bucketer: MockBucketer(mockBucketValue: 400))
@@ -311,7 +311,7 @@ extension OptimizelyUserContextTests_Decide_Holdouts {
         let featureKey3 = "feature_3"
         
         var holdout = try! OTUtils.model(from: sampleHoldout) as Holdout
-        holdout.includedFlags = [feature2_id]
+        holdout.includedRules = ["10420810910"]  // Experiment rule in feature_2
         optimizely.config!.project.holdouts = [holdout]
         
         let mockDecisionService = DefaultDecisionService(userProfileService: OTUtils.createClearUserProfileService(), bucketer: MockBucketer(mockBucketValue: 400))
@@ -356,7 +356,7 @@ extension OptimizelyUserContextTests_Decide_Holdouts {
         let featureKey3 = "feature_3"
         
         var holdout = try! OTUtils.model(from: sampleHoldout) as Holdout
-        holdout.excludedFlags = [feature2_id]
+        holdout.includedRules = []  // Empty array = local holdout targeting no rules (excludes feature_2)
         optimizely.config!.project.holdouts = [holdout]
         
         let mockDecisionService = DefaultDecisionService(userProfileService: OTUtils.createClearUserProfileService(), bucketer: MockBucketer(mockBucketValue: 400))
@@ -407,13 +407,13 @@ extension OptimizelyUserContextTests_Decide_Holdouts {
         includedHoldout.key = "holdout_key_included"
         includedHoldout.trafficAllocation[0].endOfRange = 2000
         /// Applicable to feature 2
-        includedHoldout.includedFlags = [feature2.id]
+        includedHoldout.includedRules = ["10420810910"]  // Experiment rule in feature_2
         
         var excludedHoldout = gHoldout
         excludedHoldout.id = "holdout_id_excluded"
         excludedHoldout.key = "holdout_key_excluded"
         /// Applicable to feature 3
-        excludedHoldout.excludedFlags = [feature1.id, feature2.id]
+        excludedHoldout.includedRules = []  // Empty array = local holdout targeting no rules (excludes all features)
         excludedHoldout.trafficAllocation[0].endOfRange = 2000
         
         optimizely.config!.project.holdouts = [gHoldout, includedHoldout, excludedHoldout]

--- a/Tests/OptimizelyTests-Common/OptimizelyUserContextTests_Decide_Holdouts.swift
+++ b/Tests/OptimizelyTests-Common/OptimizelyUserContextTests_Decide_Holdouts.swift
@@ -364,24 +364,25 @@ extension OptimizelyUserContextTests_Decide_Holdouts {
         let featureKey2 = "feature_2"
         let feature2_id = "4482920078"
         let featureKey3 = "feature_3"
-        
+
         var holdout = try! OTUtils.model(from: sampleHoldout) as Holdout
-        holdout.includedRules = []  // Empty array = local holdout targeting no rules (excludes feature_2)
+        // Local holdout targeting all feature_1 rules (experiment + delivery rules), excludes feature_2
+        holdout.includedRules = ["10390977673", "3332020515", "3332020494", "18322080788"]
         optimizely.config!.project.holdouts = [holdout]
         optimizely.config!.holdoutConfig.allHoldouts = [holdout]
-        
+
         let mockDecisionService = DefaultDecisionService(userProfileService: OTUtils.createClearUserProfileService(), bucketer: MockBucketer(mockBucketValue: 400))
         optimizely.decisionService = mockDecisionService
-        
+
         let variablesExpected1 = try! optimizely.getAllFeatureVariables(featureKey: featureKey1, userId: kUserId)
         let variablesExpected2 = try! optimizely.getAllFeatureVariables(featureKey: featureKey2, userId: kUserId)
         let variablesExpected3 = OptimizelyJSON.createEmpty()
-        
+
         let user = optimizely.createUserContext(userId: kUserId, attributes: ["gender": "f"])
         let decisions = user.decideAll()
-        
+
         XCTAssert(decisions.count == 3)
-        
+
         XCTAssert(decisions[featureKey1]! == OptimizelyDecision(variationKey: "key_holdout_variation",
                                                                 enabled: false,
                                                                 variables: variablesExpected1,
@@ -396,10 +397,11 @@ extension OptimizelyUserContextTests_Decide_Holdouts {
                                                                 flagKey: featureKey2,
                                                                 userContext: user,
                                                                 reasons: []))
-        XCTAssert(decisions[featureKey3]! == OptimizelyDecision(variationKey: "key_holdout_variation",
+        // feature_3 has no rules, so local holdout cannot apply - it should return nil variation
+        XCTAssert(decisions[featureKey3]! == OptimizelyDecision(variationKey: nil,
                                                                 enabled: false,
                                                                 variables: variablesExpected3,
-                                                                ruleKey: "key_holdout",
+                                                                ruleKey: nil,
                                                                 flagKey: featureKey3,
                                                                 userContext: user,
                                                                 reasons: []))
@@ -409,39 +411,32 @@ extension OptimizelyUserContextTests_Decide_Holdouts {
         let feature1 = (key: "feature_1", id: "4482920077")
         let feature2 = (key: "feature_2", id: "4482920078")
         let feature3 = (key: "feature_3", id: "44829230000")
-        
-        /// Applicable to feature (1, 2, 3)
+
+        /// Global holdout (applies to all features)
         let gHoldout = try! OTUtils.model(from: sampleHoldout) as Holdout
-        
+
         var includedHoldout = gHoldout
         includedHoldout.id = "holdout_id_included"
         includedHoldout.key = "holdout_key_included"
         includedHoldout.trafficAllocation[0].endOfRange = 2000
-        /// Applicable to feature 2
+        /// Local holdout applicable to feature_2 experiment rule
         includedHoldout.includedRules = ["10420810910"]  // Experiment rule in feature_2
-        
-        var excludedHoldout = gHoldout
-        excludedHoldout.id = "holdout_id_excluded"
-        excludedHoldout.key = "holdout_key_excluded"
-        /// Applicable to feature 3
-        excludedHoldout.includedRules = []  // Empty array = local holdout targeting no rules (excludes all features)
-        excludedHoldout.trafficAllocation[0].endOfRange = 2000
-        
-        optimizely.config!.project.holdouts = [gHoldout, includedHoldout, excludedHoldout]
-        optimizely.config!.holdoutConfig.allHoldouts = [gHoldout, includedHoldout, excludedHoldout]
-        
+
+        optimizely.config!.project.holdouts = [gHoldout, includedHoldout]
+        optimizely.config!.holdoutConfig.allHoldouts = [gHoldout, includedHoldout]
+
         let mockDecisionService = DefaultDecisionService(userProfileService: OTUtils.createClearUserProfileService(), bucketer: MockBucketer(mockBucketValue: 1000))
         optimizely.decisionService = mockDecisionService
-        
+
         let variablesExpected1 = try! optimizely.getAllFeatureVariables(featureKey: feature1.key, userId: kUserId)
         let variablesExpected2 = try! optimizely.getAllFeatureVariables(featureKey: feature2.key, userId: kUserId)
         let variablesExpected3 = OptimizelyJSON.createEmpty()
-        
+
         let user = optimizely.createUserContext(userId: kUserId, attributes: ["gender": "f"])
         let decisions = user.decideAll()
-        
+
         XCTAssert(decisions.count == 3)
-        
+
         XCTAssert(decisions[feature1.key]! == OptimizelyDecision(variationKey: "a",
                                                                  enabled: true,
                                                                  variables: variablesExpected1,
@@ -456,10 +451,11 @@ extension OptimizelyUserContextTests_Decide_Holdouts {
                                                                  flagKey: feature2.key,
                                                                  userContext: user,
                                                                  reasons: []))
-        XCTAssert(decisions[feature3.key]! == OptimizelyDecision(variationKey: "key_holdout_variation",
+        // feature_3 has no rules, so only global holdouts can apply, but gHoldout fails bucketing at 1000 > 500
+        XCTAssert(decisions[feature3.key]! == OptimizelyDecision(variationKey: nil,
                                                                  enabled: false,
                                                                  variables: variablesExpected3,
-                                                                 ruleKey: "holdout_key_excluded",
+                                                                 ruleKey: nil,
                                                                  flagKey: feature3.key,
                                                                  userContext: user,
                                                                  reasons: []))

--- a/Tests/OptimizelyTests-Common/OptimizelyUserContextTests_Decide_Holdouts.swift
+++ b/Tests/OptimizelyTests-Common/OptimizelyUserContextTests_Decide_Holdouts.swift
@@ -62,6 +62,7 @@ class OptimizelyUserContextTests_Decide_Holdouts: XCTestCase {
         let mockDecisionService = DefaultDecisionService(userProfileService: OTUtils.createClearUserProfileService(), bucketer: MockBucketer(mockBucketValue: 400))
         optimizely.decisionService = mockDecisionService
         optimizely.config!.project.holdouts = [holdout]
+        optimizely.config!.holdoutConfig.allHoldouts = [holdout]
         
         let variablesExpected = try! optimizely.getAllFeatureVariables(featureKey: featureKey, userId: kUserId)
         let user = optimizely.createUserContext(userId: kUserId, attributes: kAttributesCountryMatch)
@@ -90,6 +91,7 @@ class OptimizelyUserContextTests_Decide_Holdouts: XCTestCase {
         let mockDecisionService = DefaultDecisionService(userProfileService: OTUtils.createClearUserProfileService(), bucketer: MockBucketer(mockBucketValue: 400))
         optimizely.decisionService = mockDecisionService
         optimizely.config!.project.holdouts = [holdout]
+        optimizely.config!.holdoutConfig.allHoldouts = [holdout]
         
         
         let variablesExpected = try! optimizely.getAllFeatureVariables(featureKey: featureKey, userId: kUserId)
@@ -120,6 +122,7 @@ class OptimizelyUserContextTests_Decide_Holdouts: XCTestCase {
         let mockDecisionService = DefaultDecisionService(userProfileService: OTUtils.createClearUserProfileService(), bucketer: MockBucketer(mockBucketValue: 400))
         optimizely.decisionService = mockDecisionService
         optimizely.config!.project.holdouts = [holdout]
+        optimizely.config!.holdoutConfig.allHoldouts = [holdout]
         
         let variablesExpected = try! optimizely.getAllFeatureVariables(featureKey: featureKey, userId: kUserId)
         let user = optimizely.createUserContext(userId: kUserId, attributes: kAttributesCountryNotMatch)
@@ -142,6 +145,7 @@ class OptimizelyUserContextTests_Decide_Holdouts: XCTestCase {
     func testDecide_with_holdout_options_excludeVariables() {
         let holdout = try! OTUtils.model(from: sampleHoldout) as Holdout
         optimizely.config!.project.holdouts = [holdout]
+        optimizely.config!.holdoutConfig.allHoldouts = [holdout]
         
         let mockDecisionService = DefaultDecisionService(userProfileService: OTUtils.createClearUserProfileService(), bucketer: MockBucketer(mockBucketValue: 400))
         optimizely.decisionService = mockDecisionService
@@ -163,6 +167,7 @@ class OptimizelyUserContextTests_Decide_Holdouts: XCTestCase {
         var holdout = try! OTUtils.model(from: sampleHoldout) as Holdout
         holdout.includedRules = ["10420810910"]  // Experiment rule in feature_2
         optimizely.config!.project.holdouts = [holdout]
+        optimizely.config!.holdoutConfig.allHoldouts = [holdout]
         
         let mockDecisionService = DefaultDecisionService(userProfileService: OTUtils.createClearUserProfileService(), bucketer: MockBucketer(mockBucketValue: 400))
         optimizely.decisionService = mockDecisionService
@@ -185,6 +190,7 @@ class OptimizelyUserContextTests_Decide_Holdouts: XCTestCase {
         
         try! optimizely.start(datafile: OTUtils.loadJSONDatafile("decide_datafile")!)
         optimizely.config!.project.holdouts = [holdout]
+        optimizely.config!.holdoutConfig.allHoldouts = [holdout]
         
         user = optimizely.createUserContext(userId: kUserId)
         decision = user.decide(key: featureKey)
@@ -201,6 +207,7 @@ class OptimizelyUserContextTests_Decide_Holdouts: XCTestCase {
         // Include all rules in feature_1: experiment + delivery rules
         holdout.includedRules = ["10390977673", "3332020515", "3332020494", "18322080788"]
         optimizely.config!.project.holdouts = [holdout]
+        optimizely.config!.holdoutConfig.allHoldouts = [holdout]
         
         let mockDecisionService = DefaultDecisionService(userProfileService: OTUtils.createClearUserProfileService(), bucketer: MockBucketer(mockBucketValue: 400))
         optimizely.decisionService = mockDecisionService
@@ -228,6 +235,7 @@ class OptimizelyUserContextTests_Decide_Holdouts: XCTestCase {
         // Include all rules in feature_1: experiment + delivery rules
         holdout.includedRules = ["10390977673", "3332020515", "3332020494", "18322080788"]
         optimizely.config!.project.holdouts = [holdout]
+        optimizely.config!.holdoutConfig.allHoldouts = [holdout]
         
         let mockDecisionService = DefaultDecisionService(userProfileService: OTUtils.createClearUserProfileService(), bucketer: MockBucketer(mockBucketValue: 400))
         optimizely.decisionService = mockDecisionService
@@ -268,6 +276,7 @@ extension OptimizelyUserContextTests_Decide_Holdouts {
         
         let holdout = try! OTUtils.model(from: sampleHoldout) as Holdout
         optimizely.config!.project.holdouts = [holdout]
+        optimizely.config!.holdoutConfig.allHoldouts = [holdout]
         
         let mockDecisionService = DefaultDecisionService(userProfileService: OTUtils.createClearUserProfileService(), bucketer: MockBucketer(mockBucketValue: 400))
         optimizely.decisionService = mockDecisionService
@@ -313,6 +322,7 @@ extension OptimizelyUserContextTests_Decide_Holdouts {
         var holdout = try! OTUtils.model(from: sampleHoldout) as Holdout
         holdout.includedRules = ["10420810910"]  // Experiment rule in feature_2
         optimizely.config!.project.holdouts = [holdout]
+        optimizely.config!.holdoutConfig.allHoldouts = [holdout]
         
         let mockDecisionService = DefaultDecisionService(userProfileService: OTUtils.createClearUserProfileService(), bucketer: MockBucketer(mockBucketValue: 400))
         optimizely.decisionService = mockDecisionService
@@ -358,6 +368,7 @@ extension OptimizelyUserContextTests_Decide_Holdouts {
         var holdout = try! OTUtils.model(from: sampleHoldout) as Holdout
         holdout.includedRules = []  // Empty array = local holdout targeting no rules (excludes feature_2)
         optimizely.config!.project.holdouts = [holdout]
+        optimizely.config!.holdoutConfig.allHoldouts = [holdout]
         
         let mockDecisionService = DefaultDecisionService(userProfileService: OTUtils.createClearUserProfileService(), bucketer: MockBucketer(mockBucketValue: 400))
         optimizely.decisionService = mockDecisionService
@@ -417,6 +428,7 @@ extension OptimizelyUserContextTests_Decide_Holdouts {
         excludedHoldout.trafficAllocation[0].endOfRange = 2000
         
         optimizely.config!.project.holdouts = [gHoldout, includedHoldout, excludedHoldout]
+        optimizely.config!.holdoutConfig.allHoldouts = [gHoldout, includedHoldout, excludedHoldout]
         
         let mockDecisionService = DefaultDecisionService(userProfileService: OTUtils.createClearUserProfileService(), bucketer: MockBucketer(mockBucketValue: 1000))
         optimizely.decisionService = mockDecisionService
@@ -456,6 +468,7 @@ extension OptimizelyUserContextTests_Decide_Holdouts {
     func testDecideAll_with_holdouts_options_enabledFlagsOnly() {
         let holdout = try! OTUtils.model(from: sampleHoldout) as Holdout
         optimizely.config!.project.holdouts = [holdout]
+        optimizely.config!.holdoutConfig.allHoldouts = [holdout]
         
         let mockDecisionService = DefaultDecisionService(userProfileService: OTUtils.createClearUserProfileService(), bucketer: MockBucketer(mockBucketValue: 400))
         optimizely.decisionService = mockDecisionService
@@ -475,6 +488,7 @@ extension OptimizelyUserContextTests_Decide_Holdouts {
         
         let holdout = try! OTUtils.model(from: sampleHoldout) as Holdout
         optimizely.config!.project.holdouts = [holdout]
+        optimizely.config!.holdoutConfig.allHoldouts = [holdout]
         
         let mockDecisionService = DefaultDecisionService(userProfileService: OTUtils.createClearUserProfileService(), bucketer: MockBucketer(mockBucketValue: 400))
         optimizely.decisionService = mockDecisionService
@@ -511,6 +525,7 @@ extension OptimizelyUserContextTests_Decide_Holdouts {
         
         let holdout = try! OTUtils.model(from: sampleHoldout) as Holdout
         optimizely.config!.project.holdouts = [holdout]
+        optimizely.config!.holdoutConfig.allHoldouts = [holdout]
         
         let mockDecisionService = DefaultDecisionService(userProfileService: OTUtils.createClearUserProfileService(), bucketer: MockBucketer(mockBucketValue: 400))
         optimizely.decisionService = mockDecisionService
@@ -528,6 +543,7 @@ extension OptimizelyUserContextTests_Decide_Holdouts {
     func testDecide_sendImpression_with_disable_tracking() {
         let holdout = try! OTUtils.model(from: sampleHoldout) as Holdout
         optimizely.config!.project.holdouts = [holdout]
+        optimizely.config!.holdoutConfig.allHoldouts = [holdout]
         
         let mockDecisionService = DefaultDecisionService(userProfileService: OTUtils.createClearUserProfileService(), bucketer: MockBucketer(mockBucketValue: 400))
         optimizely.decisionService = mockDecisionService
@@ -545,6 +561,7 @@ extension OptimizelyUserContextTests_Decide_Holdouts {
     func testDecide_sendImpression_withSendFlagDecisionsOff() {
         let holdout = try! OTUtils.model(from: sampleHoldout) as Holdout
         optimizely.config!.project.holdouts = [holdout]
+        optimizely.config!.holdoutConfig.allHoldouts = [holdout]
         
         let mockDecisionService = DefaultDecisionService(userProfileService: OTUtils.createClearUserProfileService(), bucketer: MockBucketer(mockBucketValue: 400))
         optimizely.decisionService = mockDecisionService

--- a/Tests/OptimizelyTests-Common/OptimizelyUserContextTests_Decide_With_Holdouts_Reasons.swift
+++ b/Tests/OptimizelyTests-Common/OptimizelyUserContextTests_Decide_With_Holdouts_Reasons.swift
@@ -57,6 +57,7 @@ class OptimizelyUserContextTests_Decide_With_Holdouts_Reasons: XCTestCase {
         
         let holdout = try! OTUtils.model(from: sampleHoldout) as Holdout
         optimizely.config!.project.holdouts = [holdout]
+        optimizely.config!.holdoutConfig.allHoldouts = [holdout]
         
         let mockDecisionService = DefaultDecisionService(userProfileService: OTUtils.createClearUserProfileService(), bucketer: MockBucketer(mockBucketValue: 400))
         optimizely.decisionService = mockDecisionService
@@ -80,6 +81,7 @@ class OptimizelyUserContextTests_Decide_With_Holdouts_Reasons: XCTestCase {
         // Include all rules in feature_1: experiment + delivery rules
         holdout.includedRules = ["10390977673", "3332020515", "3332020494", "18322080788"]
         optimizely.config!.project.holdouts = [holdout]
+        optimizely.config!.holdoutConfig.allHoldouts = [holdout]
         
         let mockDecisionService = DefaultDecisionService(userProfileService: OTUtils.createClearUserProfileService(), bucketer: MockBucketer(mockBucketValue: 400))
         optimizely.decisionService = mockDecisionService
@@ -114,6 +116,7 @@ class OptimizelyUserContextTests_Decide_With_Holdouts_Reasons: XCTestCase {
         let mockDecisionService = DefaultDecisionService(userProfileService: OTUtils.createClearUserProfileService(), bucketer: MockBucketer(mockBucketValue: 600))
         optimizely.decisionService = mockDecisionService
         optimizely.config!.project.holdouts = [holdout1, holdout2]
+        optimizely.config!.holdoutConfig.allHoldouts = [holdout1, holdout2]
         
         let user = optimizely.createUserContext(userId: kUserId)
         // Call decide with reasons
@@ -131,6 +134,7 @@ class OptimizelyUserContextTests_Decide_With_Holdouts_Reasons: XCTestCase {
         var holdout = try! OTUtils.model(from: sampleHoldout) as Holdout
         holdout.status = .draft
         optimizely.config!.project.holdouts = [holdout]
+        optimizely.config!.holdoutConfig.allHoldouts = [holdout]
         
         let mockDecisionService = DefaultDecisionService(userProfileService: OTUtils.createClearUserProfileService(), bucketer: MockBucketer(mockBucketValue: 400))
         optimizely.decisionService = mockDecisionService
@@ -160,6 +164,7 @@ class OptimizelyUserContextTests_Decide_With_Holdouts_Reasons: XCTestCase {
         let mockDecisionService = DefaultDecisionService(userProfileService: OTUtils.createClearUserProfileService(), bucketer: MockBucketer(mockBucketValue: 400))
         optimizely.decisionService = mockDecisionService
         optimizely.config!.project.holdouts = [holdout]
+        optimizely.config!.holdoutConfig.allHoldouts = [holdout]
         
         
         let user = optimizely.createUserContext(userId: kUserId, attributes: kAttributesCountryMatch)
@@ -184,6 +189,7 @@ class OptimizelyUserContextTests_Decide_With_Holdouts_Reasons: XCTestCase {
         let mockDecisionService = DefaultDecisionService(userProfileService: OTUtils.createClearUserProfileService(), bucketer: MockBucketer(mockBucketValue: 400))
         optimizely.decisionService = mockDecisionService
         optimizely.config!.project.holdouts = [holdout]
+        optimizely.config!.holdoutConfig.allHoldouts = [holdout]
         
         let user = optimizely.createUserContext(userId: kUserId, attributes: kAttributesCountryNotMatch)
         // Call decide with reasons

--- a/Tests/OptimizelyTests-Common/OptimizelyUserContextTests_Decide_With_Holdouts_Reasons.swift
+++ b/Tests/OptimizelyTests-Common/OptimizelyUserContextTests_Decide_With_Holdouts_Reasons.swift
@@ -38,9 +38,7 @@ class OptimizelyUserContextTests_Decide_With_Holdouts_Reasons: XCTestCase {
                     "id": "id_holdout_variation",
                     "key": "key_holdout_variation"
                 ]
-            ],
-            "includedFlags": [],
-            "excludedFlags": []
+            ]
         ]
     }
     
@@ -77,9 +75,10 @@ class OptimizelyUserContextTests_Decide_With_Holdouts_Reasons: XCTestCase {
     func testDecideReasons_userBucketedIntoIncludedHoldout() {
         let featureKey = "feature_1"
         let featureId = "4482920077"
-        
+
         var holdout = try! OTUtils.model(from: sampleHoldout) as Holdout
-        holdout.includedFlags = [featureId]
+        // Include all rules in feature_1: experiment + delivery rules
+        holdout.includedRules = ["10390977673", "3332020515", "3332020494", "18322080788"]
         optimizely.config!.project.holdouts = [holdout]
         
         let mockDecisionService = DefaultDecisionService(userProfileService: OTUtils.createClearUserProfileService(), bucketer: MockBucketer(mockBucketValue: 400))
@@ -107,9 +106,9 @@ class OptimizelyUserContextTests_Decide_With_Holdouts_Reasons: XCTestCase {
         holdout2.id = "id_holdout_2"
         holdout2.key = "key_holdout_2"
         
-        // Global holdout with 10% traffice (featureId_2 excluded)
+        // Local holdout with 10% traffic (excludes feature_2 by targeting no rules)
         holdout2.trafficAllocation[0].endOfRange = 1000
-        holdout2.excludedFlags = [featureId_2]
+        holdout2.includedRules = []  // Empty array = local holdout targeting no rules (excludes feature_2)
         
         // Bucket valud outside global holdout range but inside second holdout range
         let mockDecisionService = DefaultDecisionService(userProfileService: OTUtils.createClearUserProfileService(), bucketer: MockBucketer(mockBucketValue: 600))

--- a/Tests/OptimizelyTests-DataModel/HoldoutConfigTests.swift
+++ b/Tests/OptimizelyTests-DataModel/HoldoutConfigTests.swift
@@ -1,10 +1,10 @@
 //
-// Copyright 2022, Optimizely, Inc. and contributors 
-// 
-// Licensed under the Apache License, Version 2.0 (the "License");  
+// Copyright 2022, Optimizely, Inc. and contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at   
-// 
+// You may obtain a copy of the License at
+//
 //    http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
@@ -19,137 +19,150 @@ import XCTest
 class HoldoutConfigTests: XCTestCase {
     func testEmptyHoldouts_shouldHaveEmptyMaps() {
         let config = HoldoutConfig(allholdouts: [])
-        
+
         XCTAssertTrue(config.holdoutIdMap.isEmpty)
         XCTAssertTrue(config.global.isEmpty)
-        XCTAssertTrue(config.includedHoldouts.isEmpty)
-        XCTAssertTrue(config.excludedHoldouts.isEmpty)
+        XCTAssertTrue(config.ruleHoldoutsMap.isEmpty)
     }
-    
+
     func testHoldoutMap() {
-        let holdout0: Holdout = try! OTUtils.model(from: HoldoutTests.sampleData)
-        let holdout1: Holdout = try! OTUtils.model(from: HoldoutTests.sampleDataWithIncludedFlags)
-        let holdout2: Holdout = try! OTUtils.model(from: HoldoutTests.sampleDataWithExcludedFlags)
-        
-        let allHoldouts =  [holdout0, holdout1, holdout2]
+        let globalHoldout: Holdout = try! OTUtils.model(from: HoldoutTests.sampleData)
+        let localHoldout1: Holdout = try! OTUtils.model(from: HoldoutTests.sampleDataWithIncludedRules)
+        let localHoldout2: Holdout = try! OTUtils.model(from: HoldoutTests.sampleDataWithDifferentRules)
+
+        let allHoldouts = [globalHoldout, localHoldout1, localHoldout2]
         let holdoutConfig = HoldoutConfig(allholdouts: allHoldouts)
-        
-        XCTAssertEqual(holdoutConfig.holdoutIdMap["11111"]?.includedFlags, [])
-        XCTAssertEqual(holdoutConfig.holdoutIdMap["11111"]?.excludedFlags, [])
-        
-        XCTAssertEqual(holdoutConfig.holdoutIdMap["55555"]?.includedFlags, ["4444", "5555"])
-        XCTAssertEqual(holdoutConfig.holdoutIdMap["55555"]?.excludedFlags, [])
-        
-        XCTAssertEqual(holdoutConfig.holdoutIdMap["3333"]?.includedFlags, [])
-        XCTAssertEqual(holdoutConfig.holdoutIdMap["3333"]?.excludedFlags, ["8888", "9999"])
-        
-        XCTAssertEqual(holdoutConfig.global, [holdout0, holdout2])
-        
-        XCTAssertEqual(holdoutConfig.includedHoldouts["4444"], [holdout1])
-        XCTAssertEqual(holdoutConfig.excludedHoldouts["8888"], [holdout2])
-        
+
+        // Verify holdoutIdMap
+        XCTAssertEqual(holdoutConfig.holdoutIdMap["11111"]?.includedRules, nil)
+        XCTAssertEqual(holdoutConfig.holdoutIdMap["55555"]?.includedRules, ["4444", "5555"])
+        XCTAssertEqual(holdoutConfig.holdoutIdMap["3333"]?.includedRules, ["8888", "9999"])
+
+        // Verify global holdouts
+        XCTAssertEqual(holdoutConfig.global, [globalHoldout])
+
+        // Verify ruleHoldoutsMap
+        XCTAssertEqual(holdoutConfig.ruleHoldoutsMap["4444"], [localHoldout1])
+        XCTAssertEqual(holdoutConfig.ruleHoldoutsMap["5555"], [localHoldout1])
+        XCTAssertEqual(holdoutConfig.ruleHoldoutsMap["8888"], [localHoldout2])
+        XCTAssertEqual(holdoutConfig.ruleHoldoutsMap["9999"], [localHoldout2])
     }
-    
+
     func testGetHoldoutById() {
         var holdout0: Holdout = try! OTUtils.model(from: HoldoutTests.sampleData)
         holdout0.id = "00000"
-        var holdout1: Holdout = try! OTUtils.model(from: HoldoutTests.sampleDataWithIncludedFlags)
+        var holdout1: Holdout = try! OTUtils.model(from: HoldoutTests.sampleDataWithIncludedRules)
         holdout1.id = "11111"
-        var holdout2: Holdout = try! OTUtils.model(from: HoldoutTests.sampleDataWithExcludedFlags)
+        var holdout2: Holdout = try! OTUtils.model(from: HoldoutTests.sampleDataWithDifferentRules)
         holdout2.id = "22222"
-        
-        let allHoldouts =  [holdout0, holdout1, holdout2]
+
+        let allHoldouts = [holdout0, holdout1, holdout2]
         let holdoutConfig = HoldoutConfig(allholdouts: allHoldouts)
-        
+
         XCTAssertEqual(holdoutConfig.getHoldout(id: "00000"), holdout0)
         XCTAssertEqual(holdoutConfig.getHoldout(id: "11111"), holdout1)
         XCTAssertEqual(holdoutConfig.getHoldout(id: "22222"), holdout2)
-        
     }
-    
-    func testHoldoutOrdering_globalThenIncluded() {
+
+    func testGetGlobalHoldouts() {
         var global1: Holdout = try! OTUtils.model(from: HoldoutTests.sampleData)
         global1.id = "g1"
-        
+
         var global2: Holdout = try! OTUtils.model(from: HoldoutTests.sampleData)
         global2.id = "g2"
-        
-        var included: Holdout = try! OTUtils.model(from: HoldoutTests.sampleData)
-        included.id = "i1"
-        included.includedFlags = ["f"]
-        
-        var config = HoldoutConfig(allholdouts: [included, global1, global2])
-        
-        let result = config.getHoldoutForFlag(id: "f").map(\.id)
-        XCTAssertEqual(result, ["g1", "g2", "i1"])
+
+        var local: Holdout = try! OTUtils.model(from: HoldoutTests.sampleDataWithIncludedRules)
+        local.id = "l1"
+
+        let config = HoldoutConfig(allholdouts: [local, global1, global2])
+
+        let result = config.getGlobalHoldouts()
+        XCTAssertEqual(result.count, 2)
+        XCTAssertTrue(result.contains(global1))
+        XCTAssertTrue(result.contains(global2))
+        XCTAssertFalse(result.contains(local))
     }
-    
-    func testHoldoutOrdering_with_Both_IncludedAndExcludedFlags() {
-        let flag1 = "11111"
-        let flag2 = "22222"
-        let flag3 = "33333"
-        let flag4 = "44444"
-        
-        var inc: Holdout = try! OTUtils.model(from: HoldoutTests.sampleData)
-        inc.id = "i1"
-        inc.includedFlags = [flag1]
-        
-        var exc: Holdout = try! OTUtils.model(from: HoldoutTests.sampleData)
-        exc.id = "e1"
-        exc.excludedFlags = [flag2]
-        
-        var gh1: Holdout = try! OTUtils.model(from: HoldoutTests.sampleData)
-        gh1.id = "gh1"
-        gh1.includedFlags = []
-        gh1.excludedFlags = []
-        
-        var gh2: Holdout = try! OTUtils.model(from: HoldoutTests.sampleData)
-        gh2.id = "gh2"
-        gh2.includedFlags = []
-        gh2.excludedFlags = []
-        
-        
-        let allHoldouts =  [inc, exc, gh1, gh2]
-        var holdoutConfig = HoldoutConfig(allholdouts: allHoldouts)
-        
-        XCTAssertEqual(holdoutConfig.getHoldoutForFlag(id: flag1), [exc, gh1, gh2, inc])
-        XCTAssertEqual(holdoutConfig.getHoldoutForFlag(id: flag2), [gh1, gh2])
-        
-        XCTAssertEqual(holdoutConfig.getHoldoutForFlag(id: flag3), [exc, gh1, gh2])
-        XCTAssertEqual(holdoutConfig.getHoldoutForFlag(id: flag4), [exc, gh1, gh2])
-        
-    }
-    
-    func testExcludedHoldout_shouldNotAppearInGlobalForFlag() {
+
+    func testGetHoldoutsForRule() {
+        var local1: Holdout = try! OTUtils.model(from: HoldoutTests.sampleDataWithIncludedRules)
+        local1.id = "l1"
+        local1.includedRules = ["rule1", "rule2"]
+
+        var local2: Holdout = try! OTUtils.model(from: HoldoutTests.sampleDataWithIncludedRules)
+        local2.id = "l2"
+        local2.includedRules = ["rule2", "rule3"]
+
         var global: Holdout = try! OTUtils.model(from: HoldoutTests.sampleData)
-        global.id = "global"
-        
-        var excluded: Holdout = try! OTUtils.model(from: HoldoutTests.sampleData)
-        excluded.id = "excluded"
-        excluded.excludedFlags = ["f"]
-        
-        var config = HoldoutConfig(allholdouts: [global, excluded])
-        
-        let result = config.getHoldoutForFlag(id: "f").map(\.id)
-        XCTAssertEqual(result, ["global"]) // excluded should not appear
+        global.id = "g1"
+
+        let config = HoldoutConfig(allholdouts: [local1, local2, global])
+
+        // Rule1 should only have local1
+        XCTAssertEqual(config.getHoldoutsForRule(ruleId: "rule1"), [local1])
+
+        // Rule2 should have both local1 and local2
+        let rule2Holdouts = config.getHoldoutsForRule(ruleId: "rule2")
+        XCTAssertEqual(rule2Holdouts.count, 2)
+        XCTAssertTrue(rule2Holdouts.contains(local1))
+        XCTAssertTrue(rule2Holdouts.contains(local2))
+
+        // Rule3 should only have local2
+        XCTAssertEqual(config.getHoldoutsForRule(ruleId: "rule3"), [local2])
+
+        // Rule4 (not targeted by any holdout) should return empty
+        XCTAssertTrue(config.getHoldoutsForRule(ruleId: "rule4").isEmpty)
+
+        // Global holdouts should NOT appear in rule-specific lookups
+        XCTAssertFalse(config.getHoldoutsForRule(ruleId: "rule1").contains(global))
     }
-    
-    func testGetHoldoutForFlag_shouldUseCacheOnSecondCall() {
-        var ho1: Holdout = try! OTUtils.model(from: HoldoutTests.sampleData)
-        ho1.id = "h1"
-        ho1.includedFlags = ["f1"]
-        
-        var config = HoldoutConfig(allholdouts: [ho1])
-        
-        // Initially no cache
-        XCTAssertEqual(config.flagHoldoutsMap.count, 0)
-        
-        let _ = config.getHoldoutForFlag(id: "f1")
-        XCTAssertEqual(config.flagHoldoutsMap.count, 1)
-        
-        let cache_v = config.getHoldoutForFlag(id: "f1")
-        XCTAssertEqual(config.flagHoldoutsMap.count, 1)
-        XCTAssertEqual(cache_v, config.flagHoldoutsMap["f1"])
+
+    func testIsGlobalProperty() {
+        let globalHoldout: Holdout = try! OTUtils.model(from: HoldoutTests.sampleData)
+        XCTAssertTrue(globalHoldout.isGlobal)
+
+        let localHoldout: Holdout = try! OTUtils.model(from: HoldoutTests.sampleDataWithIncludedRules)
+        XCTAssertFalse(localHoldout.isGlobal)
     }
-    
+
+    func testMultipleHoldoutsTargetingSameRule() {
+        var local1: Holdout = try! OTUtils.model(from: HoldoutTests.sampleDataWithIncludedRules)
+        local1.id = "l1"
+        local1.includedRules = ["shared_rule"]
+
+        var local2: Holdout = try! OTUtils.model(from: HoldoutTests.sampleDataWithIncludedRules)
+        local2.id = "l2"
+        local2.includedRules = ["shared_rule"]
+
+        var local3: Holdout = try! OTUtils.model(from: HoldoutTests.sampleDataWithIncludedRules)
+        local3.id = "l3"
+        local3.includedRules = ["shared_rule", "other_rule"]
+
+        let config = HoldoutConfig(allholdouts: [local1, local2, local3])
+
+        let sharedRuleHoldouts = config.getHoldoutsForRule(ruleId: "shared_rule")
+        XCTAssertEqual(sharedRuleHoldouts.count, 3)
+        XCTAssertTrue(sharedRuleHoldouts.contains(local1))
+        XCTAssertTrue(sharedRuleHoldouts.contains(local2))
+        XCTAssertTrue(sharedRuleHoldouts.contains(local3))
+    }
+
+    func testUpdateHoldoutMappingTriggeredOnAllHoldoutsChange() {
+        var config = HoldoutConfig(allholdouts: [])
+        XCTAssertTrue(config.global.isEmpty)
+        XCTAssertTrue(config.ruleHoldoutsMap.isEmpty)
+
+        // When allHoldouts changes, updateHoldoutMapping() should be called automatically
+        var global: Holdout = try! OTUtils.model(from: HoldoutTests.sampleData)
+        global.id = "g1"
+
+        var local: Holdout = try! OTUtils.model(from: HoldoutTests.sampleDataWithIncludedRules)
+        local.id = "l1"
+        local.includedRules = ["rule1"]
+
+        config.allHoldouts = [global, local]
+
+        // Verify maps were updated
+        XCTAssertEqual(config.global.count, 1)
+        XCTAssertEqual(config.ruleHoldoutsMap["rule1"]?.count, 1)
+    }
 }

--- a/Tests/OptimizelyTests-DataModel/HoldoutTests.swift
+++ b/Tests/OptimizelyTests-DataModel/HoldoutTests.swift
@@ -31,7 +31,7 @@ class HoldoutTests: XCTestCase {
                                            "match": "exact",
                                            "value": 30]]
     
-    /// Global holoout without  included and excluded key
+    /// Global holdout without includedRules (nil means global)
     static var sampleData: [String: Any] = ["id": "11111",
                                             "key": "background",
                                             "status": "Running",
@@ -39,24 +39,26 @@ class HoldoutTests: XCTestCase {
                                             "trafficAllocation": [HoldoutTests.trafficAllocationData],
                                             "audienceIds": ["33333"],
                                             "audienceConditions": HoldoutTests.conditionHolderData]
-    
-    static var sampleDataWithIncludedFlags: [String: Any] = ["id": "55555",
+
+    /// Local holdout with specific rules
+    static var sampleDataWithIncludedRules: [String: Any] = ["id": "55555",
                                             "key": "background",
                                             "status": "Running",
                                             "variations": [HoldoutTests.variationData],
                                             "trafficAllocation": [HoldoutTests.trafficAllocationData],
                                             "audienceIds": ["33333"],
                                             "audienceConditions": HoldoutTests.conditionHolderData,
-                                            "includedFlags": ["4444", "5555"]]
-    
-    static var sampleDataWithExcludedFlags: [String: Any] = ["id": "3333",
+                                            "includedRules": ["4444", "5555"]]
+
+    /// Another local holdout with different rules
+    static var sampleDataWithDifferentRules: [String: Any] = ["id": "3333",
                                                              "key": "background",
                                                              "status": "Running",
                                                              "variations": [HoldoutTests.variationData],
                                                              "trafficAllocation": [HoldoutTests.trafficAllocationData],
                                                              "audienceIds": ["33333"],
                                                              "audienceConditions": HoldoutTests.conditionHolderData,
-                                                             "excludedFlags": ["8888", "9999"]]
+                                                             "includedRules": ["8888", "9999"]]
     
     
     
@@ -79,11 +81,11 @@ extension HoldoutTests {
         XCTAssert(model.audienceConditions == (try! OTUtils.model(from: HoldoutTests.conditionHolderData)))
     }
     
-    func testDecodeSuccessWithIncludedFlags() {
-        let data: [String: Any] = HoldoutTests.sampleDataWithIncludedFlags
-        
+    func testDecodeSuccessWithIncludedRules() {
+        let data: [String: Any] = HoldoutTests.sampleDataWithIncludedRules
+
         let model: Holdout = try! OTUtils.model(from: data)
-        
+
         XCTAssert(model.id == "55555")
         XCTAssert(model.key == "background")
         XCTAssert(model.status == .running)
@@ -91,23 +93,24 @@ extension HoldoutTests {
         XCTAssert(model.trafficAllocation == [try! OTUtils.model(from: HoldoutTests.trafficAllocationData)])
         XCTAssert(model.audienceIds == ["33333"])
         XCTAssert(model.audienceConditions == (try! OTUtils.model(from: HoldoutTests.conditionHolderData)))
-        XCTAssertEqual(model.includedFlags, ["4444", "5555"])
+        XCTAssertEqual(model.includedRules, ["4444", "5555"])
+        XCTAssertFalse(model.isGlobal)
     }
-    
-    func testDecodeSuccessWithExcludedFlags() {
-        let data: [String: Any] = HoldoutTests.sampleDataWithExcludedFlags
-        
+
+    func testDecodeGlobalHoldout() {
+        let data: [String: Any] = HoldoutTests.sampleData
+
         let model: Holdout = try! OTUtils.model(from: data)
-        
-        XCTAssert(model.id == "3333")
+
+        XCTAssert(model.id == "11111")
         XCTAssert(model.key == "background")
         XCTAssert(model.status == .running)
         XCTAssert(model.variations == [try! OTUtils.model(from: HoldoutTests.variationData)])
         XCTAssert(model.trafficAllocation == [try! OTUtils.model(from: HoldoutTests.trafficAllocationData)])
         XCTAssert(model.audienceIds == ["33333"])
         XCTAssert(model.audienceConditions == (try! OTUtils.model(from: HoldoutTests.conditionHolderData)))
-        XCTAssertEqual(model.includedFlags, [])
-        XCTAssertEqual(model.excludedFlags, ["8888", "9999"])
+        XCTAssertNil(model.includedRules)
+        XCTAssertTrue(model.isGlobal)
     }
     
 

--- a/Tests/OptimizelyTests-DataModel/ProjectConfigTests.swift
+++ b/Tests/OptimizelyTests-DataModel/ProjectConfigTests.swift
@@ -99,14 +99,16 @@ class ProjectConfigTests: XCTestCase {
         var holdout3 = HoldoutTests.sampleData
         var holdout4 = HoldoutTests.sampleData
         
-        holdout0["id"] = "3000" // Global holdout (no included or excluded flags)
-        holdout1["id"] = "3001" // Global holdout (no included or excluded flags)
-        holdout2["id"] = "3002" // Global holdout (no included or excluded flags)
-        holdout3["id"] = "3003" // Included flagids ["2000", "2002"]
-        holdout4["id"] = "3004" // Excluded flagids ["2001"]
-        
-        holdout3["includedFlags"] = ["2000", "2002"]
-        holdout4["excludedFlags"] = ["2001"]
+        holdout0["id"] = "3000" // Global holdout (includedRules == nil)
+        holdout1["id"] = "3001" // Global holdout (includedRules == nil)
+        holdout2["id"] = "3002" // Global holdout (includedRules == nil)
+        holdout3["id"] = "3003" // Local holdout targeting rules in feature 2000 and 2002
+        holdout4["id"] = "3004" // Local holdout targeting rules NOT in feature 2001
+
+        // holdout3 targets all rules in features 2000 and 2002
+        holdout3["includedRules"] = ["1000", "1003", "1004"]  // Rules from features 2000 and 2002
+        // holdout4 targets rules NOT in feature 2001 (i.e., other features)
+        holdout4["includedRules"] = ["1003", "1004"]  // Rules from features 2002 and 2003, NOT 2001
         
         var feature0 = FeatureFlagTests.sampleData
         var feature1 = FeatureFlagTests.sampleData
@@ -142,33 +144,37 @@ class ProjectConfigTests: XCTestCase {
         projectConfig.project = model
         
         let holdoutIdMap = projectConfig.holdoutConfig.holdoutIdMap
-        
-        XCTAssertEqual(holdoutIdMap["3000"]?.includedFlags, [])
-        XCTAssertEqual(holdoutIdMap["3000"]?.excludedFlags, [])
-        
-        XCTAssertEqual(holdoutIdMap["3001"]?.includedFlags, [])
-        XCTAssertEqual(holdoutIdMap["3001"]?.excludedFlags, [])
-        
-        XCTAssertEqual(holdoutIdMap["3002"]?.includedFlags, [])
-        XCTAssertEqual(holdoutIdMap["3002"]?.excludedFlags, [])
-        
-        XCTAssertEqual(holdoutIdMap["3003"]?.includedFlags, ["2000", "2002"])
-        XCTAssertEqual(holdoutIdMap["3003"]?.excludedFlags, [])
-        
-        
-        XCTAssertEqual(holdoutIdMap["3004"]?.includedFlags, [])
-        XCTAssertEqual(holdoutIdMap["3004"]?.excludedFlags, ["2001"])
 
-        /// Test Global holdout + included
-        
-        XCTAssertEqual(projectConfig.holdoutConfig.getHoldoutForFlag(id: "2000").map { $0.id }, ["3000", "3001", "3002", "3004", "3003"])
-        XCTAssertEqual(projectConfig.holdoutConfig.getHoldoutForFlag(id: "2002").map { $0.id }, ["3000", "3001", "3002", "3004","3003"])
-        
-        /// Test Global holdout - excluded
-        XCTAssertEqual(projectConfig.holdoutConfig.getHoldoutForFlag(id: "2001").map { $0.id }, ["3000", "3001", "3002"])
-        
-        /// Test Global holdout + others
-        XCTAssertEqual(projectConfig.holdoutConfig.getHoldoutForFlag(id: "2003").map { $0.id }, ["3000", "3001", "3002", "3004"])
+        // Verify holdouts are correctly stored in holdoutIdMap
+        XCTAssertNotNil(holdoutIdMap["3000"])
+        XCTAssertNotNil(holdoutIdMap["3001"])
+        XCTAssertNotNil(holdoutIdMap["3002"])
+        XCTAssertNotNil(holdoutIdMap["3003"])
+        XCTAssertNotNil(holdoutIdMap["3004"])
+
+        // Verify includedRules values
+        XCTAssertNil(holdoutIdMap["3000"]?.includedRules)  // Global holdout
+        XCTAssertNil(holdoutIdMap["3001"]?.includedRules)  // Global holdout
+        XCTAssertNil(holdoutIdMap["3002"]?.includedRules)  // Global holdout
+        XCTAssertEqual(holdoutIdMap["3003"]?.includedRules, ["1000", "1003", "1004"])
+        XCTAssertEqual(holdoutIdMap["3004"]?.includedRules, ["1003", "1004"])
+
+        /// Test getGlobalHoldouts() - should return holdouts with includedRules == nil
+        let globalHoldouts = projectConfig.holdoutConfig.getGlobalHoldouts()
+        XCTAssertEqual(globalHoldouts.map { $0.id }.sorted(), ["3000", "3001", "3002"])
+
+        /// Test getHoldoutsForRule() for different rules
+        // Rule "1000" (in features 2000, 2001, 2002, 2003) - targeted by holdout3
+        XCTAssertEqual(projectConfig.holdoutConfig.getHoldoutsForRule(ruleId: "1000").map { $0.id }, ["3003"])
+
+        // Rule "1001" (in feature 2001 only) - not targeted by any local holdout
+        XCTAssertTrue(projectConfig.holdoutConfig.getHoldoutsForRule(ruleId: "1001").isEmpty)
+
+        // Rule "1003" (in features 2002, 2003) - targeted by both holdout3 and holdout4
+        XCTAssertEqual(projectConfig.holdoutConfig.getHoldoutsForRule(ruleId: "1003").map { $0.id }.sorted(), ["3003", "3004"])
+
+        // Rule "1004" (in features 2002, 2003) - targeted by both holdout3 and holdout4
+        XCTAssertEqual(projectConfig.holdoutConfig.getHoldoutsForRule(ruleId: "1004").map { $0.id }.sorted(), ["3003", "3004"])
     }
     
     func testFlagVariations() {


### PR DESCRIPTION
## Summary
- add changes to support local holdouts
- Remove all legacy flag-level holdout fields and methods 
- Add includedRules to the Holdout model and update HoldoutConfig and ProjectConfig to build and expose a rule-level holdout lookup map.

## Test plan
- add unit tests

## Issues
https://optimizely-ext.atlassian.net/browse/FSSDK-12368 
