### PR TITLE
[AI-FSSDK] [FSSDK-12670] Block ODP identify event for single identifier

### DIFF
--- a/Sources/ODP/OdpEventManager.swift
+++ b/Sources/ODP/OdpEventManager.swift
@@ -73,7 +73,7 @@ open class OdpEventManager {
         }
 
         guard identifiers.count >= 2 else {
-            logger.d("ODP identify event is not dispatched (only one identifier provided).")
+            logger.d("ODP identify event is not dispatched (fewer than 2 valid identifiers).")
             return
         }
 

--- a/Sources/ODP/OdpEventManager.swift
+++ b/Sources/ODP/OdpEventManager.swift
@@ -65,13 +65,18 @@ open class OdpEventManager {
     
     func identifyUser(vuid: String?, userId: String?) {
         var identifiers = [String: String]()
-        if let _vuid = vuid {
-            identifiers[Constants.ODP.keyForVuid] = _vuid
+        if let vuid = vuid, !vuid.isEmpty {
+            identifiers[Constants.ODP.keyForVuid] = vuid
         }
-        if let userId = userId {
+        if let userId = userId, !userId.isEmpty {
             identifiers[Constants.ODP.keyForUserId] = userId
         }
-        
+
+        guard identifiers.count >= 2 else {
+            logger.d("ODP identify event is not dispatched (only one identifier provided).")
+            return
+        }
+
         sendEvent(type: Constants.ODP.eventType,
                   action: "identified",
                   identifiers: identifiers,

--- a/Sources/ODP/OdpEventManager.swift
+++ b/Sources/ODP/OdpEventManager.swift
@@ -72,6 +72,8 @@ open class OdpEventManager {
             identifiers[Constants.ODP.keyForUserId] = userId
         }
 
+        // Identify requires 2+ identifiers to link (e.g., vuid + fs_user_id).
+        // A single identifier has no cross-reference value and generates unnecessary traffic.
         guard identifiers.count >= 2 else {
             logger.d("ODP identify event is not dispatched (fewer than 2 valid identifiers).")
             return

--- a/Tests/OptimizelyTests-Common/OdpEventManagerTests.swift
+++ b/Tests/OptimizelyTests-Common/OdpEventManagerTests.swift
@@ -119,15 +119,11 @@ class OdpEventManagerTests: XCTestCase {
         validateData(evt.data, customData: [:])
     }
     
-    func testIdentifyUser_noApiKey_nilUserId() {
+    func testIdentifyUser_noApiKey_nilUserId_singleIdentifier() {
         manager.identifyUser(vuid: "v1", userId: nil)
-        
-        XCTAssertEqual(1, manager.eventQueue.count)
-        let evt = manager.eventQueue.getFirstItem()!
-        XCTAssertEqual("fullstack", evt.type)
-        XCTAssertEqual("identified", evt.action)
-        XCTAssertEqual(["vuid": "v1"], evt.identifiers)
-        validateData(evt.data, customData: [:])
+
+        // single identifier should be skipped (not queued)
+        XCTAssertEqual(0, manager.eventQueue.count)
     }
     
     func testSendEvent_apiKey() {


### PR DESCRIPTION
## Summary

Fixes ODP identify event to only send when multiple valid identifiers exist. Previously, the SDK could send an identify event with just a single VUID when userId was nil, which provides no identity-linking value.

## Changes
- Added identifier count guard in `OdpEventManager.identifyUser` to skip event dispatch when fewer than 2 valid identifiers are present
- Added empty string check for both vuid and userId before adding to identifiers map
- Added debug-level logging when the identify event is skipped due to single identifier
- Updated test for nil userId case to expect no event queued (single identifier is now skipped)

## Jira Ticket
[FSSDK-12670](https://optimizely-ext.atlassian.net/browse/FSSDK-12670)

## Notes
- Reference implementation: Python SDK PR #513
- The count check is placed in OdpEventManager (where identifiers map is constructed) rather than OdpManager (which routes based on VUID detection)

[FSSDK-12670]: https://optimizely-ext.atlassian.net/browse/FSSDK-12670?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ