### PR TITLE
[AI-FSSDK] [FSSDK-12813] normalize campaign_id, variation_id, and entity_id on decision events

### DIFF
--- a/OptimizelySwiftSDK.xcodeproj/project.pbxproj
+++ b/OptimizelySwiftSDK.xcodeproj/project.pbxproj
@@ -2115,6 +2115,8 @@
 		98AC97F42DAE9685001405DD /* HoldoutConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98AC97F22DAE9685001405DD /* HoldoutConfigTests.swift */; };
 		98AC98462DB7B762001405DD /* BucketTests_HoldoutToVariation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98AC98452DB7B762001405DD /* BucketTests_HoldoutToVariation.swift */; };
 		98AC98472DB7B762001405DD /* BucketTests_HoldoutToVariation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98AC98452DB7B762001405DD /* BucketTests_HoldoutToVariation.swift */; };
+		FF12813000000000FF000002 /* BatchEventBuilderTests_HoldoutIds.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF12813000000000FF000001 /* BatchEventBuilderTests_HoldoutIds.swift */; };
+		FF12813000000000FF000003 /* BatchEventBuilderTests_HoldoutIds.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF12813000000000FF000001 /* BatchEventBuilderTests_HoldoutIds.swift */; };
 		98AC98492DB8FC29001405DD /* DecisionServiceTests_Holdouts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98AC98482DB8FC29001405DD /* DecisionServiceTests_Holdouts.swift */; };
 		98AC984B2DB8FFE0001405DD /* DecisionServiceTests_Holdouts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98AC98482DB8FC29001405DD /* DecisionServiceTests_Holdouts.swift */; };
 		98AC985E2DBA6721001405DD /* OptimizelyUserContextTests_Decide_With_Holdouts_Reasons.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98AC985D2DBA6721001405DD /* OptimizelyUserContextTests_Decide_With_Holdouts_Reasons.swift */; };
@@ -2635,6 +2637,7 @@
 		98AC97E12DAE4579001405DD /* HoldoutConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HoldoutConfig.swift; sourceTree = "<group>"; };
 		98AC97F22DAE9685001405DD /* HoldoutConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HoldoutConfigTests.swift; sourceTree = "<group>"; };
 		98AC98452DB7B762001405DD /* BucketTests_HoldoutToVariation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BucketTests_HoldoutToVariation.swift; sourceTree = "<group>"; };
+		FF12813000000000FF000001 /* BatchEventBuilderTests_HoldoutIds.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BatchEventBuilderTests_HoldoutIds.swift; sourceTree = "<group>"; };
 		98AC98482DB8FC29001405DD /* DecisionServiceTests_Holdouts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecisionServiceTests_Holdouts.swift; sourceTree = "<group>"; };
 		98AC985D2DBA6721001405DD /* OptimizelyUserContextTests_Decide_With_Holdouts_Reasons.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptimizelyUserContextTests_Decide_With_Holdouts_Reasons.swift; sourceTree = "<group>"; };
 		98C2DF232F900669003F2443 /* DecisionServiceTests_LocalHoldouts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecisionServiceTests_LocalHoldouts.swift; sourceTree = "<group>"; };
@@ -3150,6 +3153,7 @@
 				6E75199322C5211100B2B157 /* BatchEventBuilderTests_Attributes.swift */,
 				6E75198722C5211100B2B157 /* BatchEventBuilderTests_Events.swift */,
 				6E75199722C5211100B2B157 /* BatchEventBuilderTests_EventTags.swift */,
+				FF12813000000000FF000001 /* BatchEventBuilderTests_HoldoutIds.swift */,
 				6E75198A22C5211100B2B157 /* BucketTests_Base.swift */,
 				6E75198F22C5211100B2B157 /* BucketTests_BucketVariation.swift */,
 				6E75198C22C5211100B2B157 /* BucketTests_ExpToVariation.swift */,
@@ -5126,6 +5130,7 @@
 				6E75180122C520D400B2B157 /* DataStoreUserDefaults.swift in Sources */,
 				98F28A672E05220300A86546 /* CmabServiceTests.swift in Sources */,
 				98AC98472DB7B762001405DD /* BucketTests_HoldoutToVariation.swift in Sources */,
+				FF12813000000000FF000002 /* BatchEventBuilderTests_HoldoutIds.swift in Sources */,
 				6E75175722C520D400B2B157 /* LogMessage.swift in Sources */,
 				98F28A242E01940500A86546 /* Cmab.swift in Sources */,
 				6E7516EB22C520D400B2B157 /* OPTEventDispatcher.swift in Sources */,
@@ -5418,6 +5423,7 @@
 				6E7516E522C520D400B2B157 /* OPTEventDispatcher.swift in Sources */,
 				9841590F2E13013E0042C01E /* OptimizelyUserContextTests_Decide_Async.swift in Sources */,
 				98AC98462DB7B762001405DD /* BucketTests_HoldoutToVariation.swift in Sources */,
+				FF12813000000000FF000003 /* BatchEventBuilderTests_HoldoutIds.swift in Sources */,
 				6E7E9B552523F8C6009E4426 /* OptimizelyUserContextTests_Decide_Legacy.swift in Sources */,
 				6E652305278E688B00954EA1 /* LruCache.swift in Sources */,
 				6EC6DD3524ABF6990017D296 /* OptimizelyClient+Decide.swift in Sources */,

--- a/Sources/Data Model/DispatchEvents/BatchEvent.swift
+++ b/Sources/Data Model/DispatchEvents/BatchEvent.swift
@@ -100,16 +100,44 @@ struct DecisionMetadata: Codable, Equatable {
 }
 
 struct Decision: Codable, Equatable {
-    let variationID: String
+    // `variationID` is optional so holdout events can serialize an explicit JSON
+    // `null` when the holdout has no usable variation id. For non-holdout
+    // decisions this remains a non-empty numeric string (see BatchEventBuilder).
+    let variationID: String?
     let campaignID: String
     let experimentID: String
     let metaData: DecisionMetadata
-    
+
     enum CodingKeys: String, CodingKey {
         case variationID = "variation_id"
         case campaignID = "campaign_id"
         case experimentID = "experiment_id"
         case metaData = "metadata"
+    }
+
+    init(variationID: String?,
+         campaignID: String,
+         experimentID: String,
+         metaData: DecisionMetadata) {
+        self.variationID = variationID
+        self.campaignID = campaignID
+        self.experimentID = experimentID
+        self.metaData = metaData
+    }
+
+    // Custom encoder ensures `variation_id` is emitted as explicit JSON `null`
+    // when the value is nil (the default synthesized Codable would omit the key
+    // via `encodeIfPresent`, which the event pipeline does not accept).
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        if let variationID = variationID {
+            try container.encode(variationID, forKey: .variationID)
+        } else {
+            try container.encodeNil(forKey: .variationID)
+        }
+        try container.encode(campaignID, forKey: .campaignID)
+        try container.encode(experimentID, forKey: .experimentID)
+        try container.encode(metaData, forKey: .metaData)
     }
 }
 

--- a/Sources/Implementation/Events/BatchEventBuilder.swift
+++ b/Sources/Implementation/Events/BatchEventBuilder.swift
@@ -46,9 +46,13 @@ class BatchEventBuilder {
                                 experimentID: experimentId,
                                 metaData: metaData)
 
+        // FR-009: events[].entity_id shares the same source as
+        // decisions[].campaign_id (experiment.layerId) and the same fallback
+        // contract. Use the normalized value so the two fields never diverge
+        // on the wire — see spec US3 / SC-006.
         let dispatchEvent = DispatchEvent(timestamp: timestampSince1970,
                                           key: DispatchEvent.activateEventKey,
-                                          entityID: rawCampaignId,
+                                          entityID: campaignId,
                                           uuid: uuid)
 
         return createBatchEvent(config: config,

--- a/Sources/Implementation/Events/BatchEventBuilder.swift
+++ b/Sources/Implementation/Events/BatchEventBuilder.swift
@@ -37,11 +37,9 @@ class BatchEventBuilder {
         let rawVariationId = variation?.id
         let experimentId = experiment?.id ?? ""
 
-        let isHoldout = (ruleType == Constants.DecisionSource.holdout.rawValue)
         let (campaignId, variationId) = normalizeDecisionIds(rawCampaignId: rawCampaignId,
                                                              rawVariationId: rawVariationId,
-                                                             experimentId: experimentId,
-                                                             isHoldout: isHoldout)
+                                                             experimentId: experimentId)
 
         let decision = Decision(variationID: variationId,
                                 campaignID: campaignId,
@@ -60,39 +58,30 @@ class BatchEventBuilder {
                                 dispatchEvents: [dispatchEvent])
     }
 
-    // MARK: - Holdout Event ID Normalization (FSSDK-12813)
+    // MARK: - Decision Event ID Normalization (FSSDK-12813)
 
-    /// Normalizes `campaign_id` and `variation_id` for holdout decision events so
-    /// the on-the-wire payload always carries pipeline-valid values.
+    /// Normalizes `campaign_id` and `variation_id` so every dispatched decision
+    /// event carries pipeline-valid values, regardless of decision type
+    /// (experiment, feature test, rollout, or holdout). See spec FR-001–FR-005.
     ///
-    /// For **holdout** decisions only:
     /// - `campaign_id` falls back to `experiment_id` when the raw value is not a
-    ///   non-empty decimal-digit string (empty, whitespace, null/nil, or non-numeric).
-    /// - `variation_id` is normalized to `nil` (emitted as JSON `null`) when the
-    ///   raw value is not a non-empty decimal-digit string.
-    ///
-    /// For all non-holdout decisions the original (pre-fix) behavior is preserved:
-    /// `campaign_id` is the raw value (or empty string) and `variation_id` is the
-    /// raw value (or empty string) — wrapped in Optional purely so the `Decision`
-    /// struct can share one storage type across both branches.
+    ///   non-empty decimal-digit string. For well-formed datafiles this is a
+    ///   no-op for non-holdout decisions; the fallback fires on holdout events
+    ///   (which legitimately may lack `layerId`) and acts as a safety net for
+    ///   any future malformed input.
+    /// - `variation_id` becomes `nil` (emitted as JSON `null`) when the raw
+    ///   value is not a non-empty decimal-digit string.
     static func normalizeDecisionIds(rawCampaignId: String,
                                      rawVariationId: String?,
-                                     experimentId: String,
-                                     isHoldout: Bool) -> (campaignId: String, variationId: String?) {
-        guard isHoldout else {
-            // Preserve legacy behavior for non-holdout decisions (FR-005).
-            return (rawCampaignId, rawVariationId ?? "")
-        }
-
-        // Holdout: campaign_id must be a numeric string, otherwise fall back to
-        // experiment_id (FR-001/FR-002). Whitespace-only and non-numeric strings
-        // are treated as invalid; the upstream experiment_id is passed through
-        // unchanged even if it is itself invalid (FR-006 — never drop the event).
+                                     experimentId: String) -> (campaignId: String, variationId: String?) {
+        // campaign_id must be a numeric string, otherwise fall back to
+        // experiment_id. The upstream experiment_id is passed through unchanged
+        // even if it is itself invalid (FR-006 — never drop the event).
         let campaignId = isValidNumericIdString(rawCampaignId) ? rawCampaignId : experimentId
 
-        // Holdout: variation_id must be a numeric string or JSON null
-        // (FR-003/FR-004). Anything else (empty, whitespace, non-numeric) becomes
-        // nil so the encoder emits JSON `null`.
+        // variation_id must be a numeric string or JSON null. Anything else
+        // (empty, whitespace, non-numeric) becomes nil so the encoder emits
+        // JSON `null`.
         let variationId: String?
         if let raw = rawVariationId, isValidNumericIdString(raw) {
             variationId = raw

--- a/Sources/Implementation/Events/BatchEventBuilder.swift
+++ b/Sources/Implementation/Events/BatchEventBuilder.swift
@@ -30,24 +30,95 @@ class BatchEventBuilder {
                                       ruleType: String,
                                       enabled: Bool,
                                       cmabUUID: String?) -> Data? {
-        
+
         let metaData = DecisionMetadata(ruleType: ruleType, ruleKey: experiment?.key ?? "", flagKey: flagKey, variationKey: variation?.key ?? "", enabled: enabled, cmabUUID: cmabUUID)
-        
-        let decision = Decision(variationID: variation?.id ?? "",
-                                campaignID: experiment?.layerId ?? "",
-                                experimentID: experiment?.id ?? "",
+
+        let rawCampaignId = experiment?.layerId ?? ""
+        let rawVariationId = variation?.id
+        let experimentId = experiment?.id ?? ""
+
+        let isHoldout = (ruleType == Constants.DecisionSource.holdout.rawValue)
+        let (campaignId, variationId) = normalizeDecisionIds(rawCampaignId: rawCampaignId,
+                                                             rawVariationId: rawVariationId,
+                                                             experimentId: experimentId,
+                                                             isHoldout: isHoldout)
+
+        let decision = Decision(variationID: variationId,
+                                campaignID: campaignId,
+                                experimentID: experimentId,
                                 metaData: metaData)
-        
+
         let dispatchEvent = DispatchEvent(timestamp: timestampSince1970,
                                           key: DispatchEvent.activateEventKey,
-                                          entityID: experiment?.layerId ?? "",
+                                          entityID: rawCampaignId,
                                           uuid: uuid)
-        
+
         return createBatchEvent(config: config,
                                 userId: userId,
                                 attributes: attributes,
                                 decisions: [decision],
                                 dispatchEvents: [dispatchEvent])
+    }
+
+    // MARK: - Holdout Event ID Normalization (FSSDK-12813)
+
+    /// Normalizes `campaign_id` and `variation_id` for holdout decision events so
+    /// the on-the-wire payload always carries pipeline-valid values.
+    ///
+    /// For **holdout** decisions only:
+    /// - `campaign_id` falls back to `experiment_id` when the raw value is not a
+    ///   non-empty decimal-digit string (empty, whitespace, null/nil, or non-numeric).
+    /// - `variation_id` is normalized to `nil` (emitted as JSON `null`) when the
+    ///   raw value is not a non-empty decimal-digit string.
+    ///
+    /// For all non-holdout decisions the original (pre-fix) behavior is preserved:
+    /// `campaign_id` is the raw value (or empty string) and `variation_id` is the
+    /// raw value (or empty string) — wrapped in Optional purely so the `Decision`
+    /// struct can share one storage type across both branches.
+    static func normalizeDecisionIds(rawCampaignId: String,
+                                     rawVariationId: String?,
+                                     experimentId: String,
+                                     isHoldout: Bool) -> (campaignId: String, variationId: String?) {
+        guard isHoldout else {
+            // Preserve legacy behavior for non-holdout decisions (FR-005).
+            return (rawCampaignId, rawVariationId ?? "")
+        }
+
+        // Holdout: campaign_id must be a numeric string, otherwise fall back to
+        // experiment_id (FR-001/FR-002). Whitespace-only and non-numeric strings
+        // are treated as invalid; the upstream experiment_id is passed through
+        // unchanged even if it is itself invalid (FR-006 — never drop the event).
+        let campaignId = isValidNumericIdString(rawCampaignId) ? rawCampaignId : experimentId
+
+        // Holdout: variation_id must be a numeric string or JSON null
+        // (FR-003/FR-004). Anything else (empty, whitespace, non-numeric) becomes
+        // nil so the encoder emits JSON `null`.
+        let variationId: String?
+        if let raw = rawVariationId, isValidNumericIdString(raw) {
+            variationId = raw
+        } else {
+            variationId = nil
+        }
+
+        return (campaignId, variationId)
+    }
+
+    /// Returns true iff `value` is a non-empty string consisting entirely of
+    /// decimal digits `[0-9]`. Empty strings, whitespace-only strings, and any
+    /// string containing non-digit characters return false. Leading zeros are
+    /// allowed because Optimizely IDs are opaque identifiers (see spec).
+    static func isValidNumericIdString(_ value: String) -> Bool {
+        guard !value.isEmpty else { return false }
+        // `CharacterSet.decimalDigits` includes non-ASCII digit forms (e.g.
+        // Arabic-Indic digits). Spec restricts validity to ASCII `[0-9]`, so we
+        // walk the unicode scalars explicitly instead of using
+        // `rangeOfCharacter(from: CharacterSet.decimalDigits.inverted)`.
+        for scalar in value.unicodeScalars {
+            if scalar.value < 0x30 || scalar.value > 0x39 {
+                return false
+            }
+        }
+        return true
     }
     
     // MARK: - Converison Event

--- a/Tests/OptimizelyTests-Common/BatchEventBuilderTests_HoldoutIds.swift
+++ b/Tests/OptimizelyTests-Common/BatchEventBuilderTests_HoldoutIds.swift
@@ -211,4 +211,68 @@ class BatchEventBuilderTests_HoldoutIds: XCTestCase {
         XCTAssertEqual(json["variation_id"] as? String, "777")
         XCTAssertFalse(json["variation_id"] is NSNull)
     }
+
+    // MARK: - Impression event entity_id (FR-009 / SC-006)
+
+    /// End-to-end: a holdout impression event has an empty source `layerId`,
+    /// so both `decisions[0].campaign_id` AND `events[0].entity_id` must fall
+    /// back to the holdout's `experiment_id`, and they must be byte-equal.
+    func testImpressionEvent_holdout_entityIdMirrorsNormalizedCampaignId() throws {
+        let datafile = OTUtils.loadJSONDatafile("api_datafile")!
+        let eventDispatcher = MockEventDispatcher()
+        var optimizely: OptimizelyClient! = OptimizelyClient(sdkKey: "fssdk_12813_entity_id",
+                                                             eventDispatcher: eventDispatcher)
+        defer {
+            optimizely?.close()
+            optimizely = nil
+        }
+        try optimizely.start(datafile: datafile)
+
+        // Holdout struct defaults layerId to "" (see Holdout.swift) — the
+        // canonical case this fix targets. id is the fallback used by both
+        // campaign_id (FR-002) and entity_id (FR-009).
+        let holdoutJSON: [String: Any] = [
+            "status": "Running",
+            "id": "holdout_4444444",
+            "key": "holdout_key",
+            "trafficAllocation": [
+                ["entityId": "holdout_variation_a11", "endOfRange": 10000]
+            ],
+            "audienceIds": [],
+            "variations": [
+                ["variables": [], "id": "holdout_variation_a11", "key": "holdout_a"]
+            ]
+        ]
+        let holdout: Holdout = try OTUtils.model(from: holdoutJSON)
+        optimizely.config?.holdoutConfig = HoldoutConfig(globalHoldouts: [holdout], localHoldouts: [])
+
+        let user = optimizely.createUserContext(userId: "test_user_1")
+        _ = user.decide(key: "feature_1")
+
+        let exp = expectation(description: "impression dispatched")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { exp.fulfill() }
+        wait(for: [exp], timeout: 1.0)
+
+        guard let raw = eventDispatcher.events.first?.body,
+              let event = try JSONSerialization.jsonObject(with: raw, options: .allowFragments) as? [String: Any],
+              let visitor = (event["visitors"] as? [[String: Any]])?.first,
+              let snapshot = (visitor["snapshots"] as? [[String: Any]])?.first,
+              let decision = (snapshot["decisions"] as? [[String: Any]])?.first,
+              let dispatchEvent = (snapshot["events"] as? [[String: Any]])?.first else {
+            return XCTFail("impression event was not dispatched in expected shape")
+        }
+
+        let campaignId = decision["campaign_id"] as? String
+        let entityId = dispatchEvent["entity_id"] as? String
+
+        // FR-002: campaign_id falls back to experiment_id (holdout.id).
+        XCTAssertEqual(campaignId, holdout.id,
+                       "campaign_id must fall back to holdout.id when layerId is empty")
+        // FR-009: entity_id falls back the same way.
+        XCTAssertEqual(entityId, holdout.id,
+                       "entity_id must fall back to holdout.id when layerId is empty")
+        // SC-006: the two fields share source + fallback; they must never diverge.
+        XCTAssertEqual(campaignId, entityId,
+                       "campaign_id and entity_id must hold the same normalized value")
+    }
 }

--- a/Tests/OptimizelyTests-Common/BatchEventBuilderTests_HoldoutIds.swift
+++ b/Tests/OptimizelyTests-Common/BatchEventBuilderTests_HoldoutIds.swift
@@ -14,9 +14,10 @@
 // limitations under the License.
 //
 
-// Tests for FSSDK-12813: holdout decision events must always carry a valid
-// `campaign_id` (falling back to `experiment_id`) and either a valid numeric
-// `variation_id` or JSON `null`. Non-holdout decisions must be unaffected.
+// Tests for FSSDK-12813: every decision event (experiment, feature test,
+// rollout, or holdout) must carry a valid numeric `campaign_id` (falling back
+// to `experiment_id` if invalid) and either a valid numeric `variation_id` or
+// JSON `null`. The normalization is uniform across decision types per FR-005.
 
 import XCTest
 
@@ -52,123 +53,112 @@ class BatchEventBuilderTests_HoldoutIds: XCTestCase {
         XCTAssertFalse(BatchEventBuilder.isValidNumericIdString("\u{0660}\u{0661}"))
     }
 
-    // MARK: - normalizeDecisionIds — non-holdout pass-through (FR-005)
+    // MARK: - normalizeDecisionIds — valid IDs pass through unchanged (SC-003)
 
-    func testNormalize_nonHoldout_passesThroughCampaignAndVariation() {
+    func testNormalize_validCampaignAndVariation_passThrough() {
+        // The dominant production case: both IDs already valid. No change.
         let (campaign, variation) = BatchEventBuilder.normalizeDecisionIds(
             rawCampaignId: "555",
             rawVariationId: "777",
-            experimentId: "999",
-            isHoldout: false)
+            experimentId: "999")
         XCTAssertEqual(campaign, "555")
         XCTAssertEqual(variation, "777")
     }
 
-    func testNormalize_nonHoldout_emptyValuesPreservedAsBefore() {
-        // Pre-fix behavior: non-holdout events used `?? ""`. Verify normalization
-        // does not change this branch — empty stays empty, no fallback occurs.
+    func testNormalize_validCampaignAndNilVariation_variationStaysNil() {
+        // Valid campaign, no variation supplied (e.g. holdout with no variation
+        // assigned). variation_id must be JSON null, not empty string.
         let (campaign, variation) = BatchEventBuilder.normalizeDecisionIds(
-            rawCampaignId: "",
+            rawCampaignId: "555",
             rawVariationId: nil,
-            experimentId: "999",
-            isHoldout: false)
-        XCTAssertEqual(campaign, "")
-        XCTAssertEqual(variation, "")
+            experimentId: "999")
+        XCTAssertEqual(campaign, "555")
+        XCTAssertNil(variation)
     }
 
-    // MARK: - normalizeDecisionIds — holdout campaign_id (FR-001/FR-002)
+    // MARK: - normalizeDecisionIds — campaign_id (FR-001/FR-002) applied uniformly
 
-    func testNormalize_holdout_emptyCampaignFallsBackToExperimentId() {
+    func testNormalize_emptyCampaignFallsBackToExperimentId() {
         let (campaign, _) = BatchEventBuilder.normalizeDecisionIds(
             rawCampaignId: "",
             rawVariationId: "777",
-            experimentId: "exp_42",
-            isHoldout: true)
+            experimentId: "exp_42")
         XCTAssertEqual(campaign, "exp_42")
     }
 
-    func testNormalize_holdout_whitespaceCampaignFallsBackToExperimentId() {
+    func testNormalize_whitespaceCampaignFallsBackToExperimentId() {
         let (campaign, _) = BatchEventBuilder.normalizeDecisionIds(
             rawCampaignId: "   ",
             rawVariationId: "777",
-            experimentId: "exp_42",
-            isHoldout: true)
+            experimentId: "exp_42")
         XCTAssertEqual(campaign, "exp_42")
     }
 
-    func testNormalize_holdout_nonNumericCampaignFallsBackToExperimentId() {
+    func testNormalize_nonNumericCampaignFallsBackToExperimentId() {
         let (campaign, _) = BatchEventBuilder.normalizeDecisionIds(
             rawCampaignId: "not_a_number",
             rawVariationId: "777",
-            experimentId: "exp_42",
-            isHoldout: true)
+            experimentId: "exp_42")
         XCTAssertEqual(campaign, "exp_42")
     }
 
-    func testNormalize_holdout_validNumericCampaignKept() {
+    func testNormalize_validNumericCampaignKept() {
         let (campaign, _) = BatchEventBuilder.normalizeDecisionIds(
             rawCampaignId: "12345",
             rawVariationId: "777",
-            experimentId: "exp_42",
-            isHoldout: true)
+            experimentId: "exp_42")
         XCTAssertEqual(campaign, "12345")
     }
 
-    func testNormalize_holdout_invalidExperimentIdStillPassedThrough() {
+    func testNormalize_invalidExperimentIdStillPassedThrough() {
         // FR-006: never drop the event; pass invalid experiment_id through if
         // that is all we have for the fallback.
         let (campaign, _) = BatchEventBuilder.normalizeDecisionIds(
             rawCampaignId: "",
             rawVariationId: "777",
-            experimentId: "",
-            isHoldout: true)
+            experimentId: "")
         XCTAssertEqual(campaign, "")
     }
 
-    // MARK: - normalizeDecisionIds — holdout variation_id (FR-003/FR-004)
+    // MARK: - normalizeDecisionIds — variation_id (FR-003/FR-004) applied uniformly
 
-    func testNormalize_holdout_emptyVariationBecomesNil() {
+    func testNormalize_emptyVariationBecomesNil() {
         let (_, variation) = BatchEventBuilder.normalizeDecisionIds(
             rawCampaignId: "12345",
             rawVariationId: "",
-            experimentId: "exp_42",
-            isHoldout: true)
+            experimentId: "exp_42")
         XCTAssertNil(variation)
     }
 
-    func testNormalize_holdout_whitespaceVariationBecomesNil() {
+    func testNormalize_whitespaceVariationBecomesNil() {
         let (_, variation) = BatchEventBuilder.normalizeDecisionIds(
             rawCampaignId: "12345",
             rawVariationId: "  ",
-            experimentId: "exp_42",
-            isHoldout: true)
+            experimentId: "exp_42")
         XCTAssertNil(variation)
     }
 
-    func testNormalize_holdout_nilVariationStaysNil() {
+    func testNormalize_nilVariationStaysNil() {
         let (_, variation) = BatchEventBuilder.normalizeDecisionIds(
             rawCampaignId: "12345",
             rawVariationId: nil,
-            experimentId: "exp_42",
-            isHoldout: true)
+            experimentId: "exp_42")
         XCTAssertNil(variation)
     }
 
-    func testNormalize_holdout_nonNumericVariationBecomesNil() {
+    func testNormalize_nonNumericVariationBecomesNil() {
         let (_, variation) = BatchEventBuilder.normalizeDecisionIds(
             rawCampaignId: "12345",
             rawVariationId: "abc",
-            experimentId: "exp_42",
-            isHoldout: true)
+            experimentId: "exp_42")
         XCTAssertNil(variation)
     }
 
-    func testNormalize_holdout_validNumericVariationKept() {
+    func testNormalize_validNumericVariationKept() {
         let (_, variation) = BatchEventBuilder.normalizeDecisionIds(
             rawCampaignId: "12345",
             rawVariationId: "777",
-            experimentId: "exp_42",
-            isHoldout: true)
+            experimentId: "exp_42")
         XCTAssertEqual(variation, "777")
     }
 

--- a/Tests/OptimizelyTests-Common/BatchEventBuilderTests_HoldoutIds.swift
+++ b/Tests/OptimizelyTests-Common/BatchEventBuilderTests_HoldoutIds.swift
@@ -1,0 +1,224 @@
+//
+// Copyright 2026, Optimizely, Inc. and contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+// Tests for FSSDK-12813: holdout decision events must always carry a valid
+// `campaign_id` (falling back to `experiment_id`) and either a valid numeric
+// `variation_id` or JSON `null`. Non-holdout decisions must be unaffected.
+
+import XCTest
+
+class BatchEventBuilderTests_HoldoutIds: XCTestCase {
+
+    // MARK: - isValidNumericIdString
+
+    func testIsValidNumericIdString_validDigits() {
+        XCTAssertTrue(BatchEventBuilder.isValidNumericIdString("12345"))
+        XCTAssertTrue(BatchEventBuilder.isValidNumericIdString("0"))
+        // Leading zeros are allowed because IDs are opaque.
+        XCTAssertTrue(BatchEventBuilder.isValidNumericIdString("007"))
+        XCTAssertTrue(BatchEventBuilder.isValidNumericIdString("10390977714"))
+    }
+
+    func testIsValidNumericIdString_emptyOrWhitespace() {
+        XCTAssertFalse(BatchEventBuilder.isValidNumericIdString(""))
+        XCTAssertFalse(BatchEventBuilder.isValidNumericIdString(" "))
+        XCTAssertFalse(BatchEventBuilder.isValidNumericIdString("   "))
+        XCTAssertFalse(BatchEventBuilder.isValidNumericIdString("\t"))
+        XCTAssertFalse(BatchEventBuilder.isValidNumericIdString("\n"))
+    }
+
+    func testIsValidNumericIdString_nonNumeric() {
+        XCTAssertFalse(BatchEventBuilder.isValidNumericIdString("abc"))
+        XCTAssertFalse(BatchEventBuilder.isValidNumericIdString("12a45"))
+        XCTAssertFalse(BatchEventBuilder.isValidNumericIdString("12.45"))
+        XCTAssertFalse(BatchEventBuilder.isValidNumericIdString("-12345"))
+        XCTAssertFalse(BatchEventBuilder.isValidNumericIdString("+12345"))
+        XCTAssertFalse(BatchEventBuilder.isValidNumericIdString("12 45"))
+        XCTAssertFalse(BatchEventBuilder.isValidNumericIdString("1e10"))
+        // Non-ASCII digit forms (e.g. Arabic-Indic) are NOT valid per spec.
+        XCTAssertFalse(BatchEventBuilder.isValidNumericIdString("\u{0660}\u{0661}"))
+    }
+
+    // MARK: - normalizeDecisionIds — non-holdout pass-through (FR-005)
+
+    func testNormalize_nonHoldout_passesThroughCampaignAndVariation() {
+        let (campaign, variation) = BatchEventBuilder.normalizeDecisionIds(
+            rawCampaignId: "555",
+            rawVariationId: "777",
+            experimentId: "999",
+            isHoldout: false)
+        XCTAssertEqual(campaign, "555")
+        XCTAssertEqual(variation, "777")
+    }
+
+    func testNormalize_nonHoldout_emptyValuesPreservedAsBefore() {
+        // Pre-fix behavior: non-holdout events used `?? ""`. Verify normalization
+        // does not change this branch — empty stays empty, no fallback occurs.
+        let (campaign, variation) = BatchEventBuilder.normalizeDecisionIds(
+            rawCampaignId: "",
+            rawVariationId: nil,
+            experimentId: "999",
+            isHoldout: false)
+        XCTAssertEqual(campaign, "")
+        XCTAssertEqual(variation, "")
+    }
+
+    // MARK: - normalizeDecisionIds — holdout campaign_id (FR-001/FR-002)
+
+    func testNormalize_holdout_emptyCampaignFallsBackToExperimentId() {
+        let (campaign, _) = BatchEventBuilder.normalizeDecisionIds(
+            rawCampaignId: "",
+            rawVariationId: "777",
+            experimentId: "exp_42",
+            isHoldout: true)
+        XCTAssertEqual(campaign, "exp_42")
+    }
+
+    func testNormalize_holdout_whitespaceCampaignFallsBackToExperimentId() {
+        let (campaign, _) = BatchEventBuilder.normalizeDecisionIds(
+            rawCampaignId: "   ",
+            rawVariationId: "777",
+            experimentId: "exp_42",
+            isHoldout: true)
+        XCTAssertEqual(campaign, "exp_42")
+    }
+
+    func testNormalize_holdout_nonNumericCampaignFallsBackToExperimentId() {
+        let (campaign, _) = BatchEventBuilder.normalizeDecisionIds(
+            rawCampaignId: "not_a_number",
+            rawVariationId: "777",
+            experimentId: "exp_42",
+            isHoldout: true)
+        XCTAssertEqual(campaign, "exp_42")
+    }
+
+    func testNormalize_holdout_validNumericCampaignKept() {
+        let (campaign, _) = BatchEventBuilder.normalizeDecisionIds(
+            rawCampaignId: "12345",
+            rawVariationId: "777",
+            experimentId: "exp_42",
+            isHoldout: true)
+        XCTAssertEqual(campaign, "12345")
+    }
+
+    func testNormalize_holdout_invalidExperimentIdStillPassedThrough() {
+        // FR-006: never drop the event; pass invalid experiment_id through if
+        // that is all we have for the fallback.
+        let (campaign, _) = BatchEventBuilder.normalizeDecisionIds(
+            rawCampaignId: "",
+            rawVariationId: "777",
+            experimentId: "",
+            isHoldout: true)
+        XCTAssertEqual(campaign, "")
+    }
+
+    // MARK: - normalizeDecisionIds — holdout variation_id (FR-003/FR-004)
+
+    func testNormalize_holdout_emptyVariationBecomesNil() {
+        let (_, variation) = BatchEventBuilder.normalizeDecisionIds(
+            rawCampaignId: "12345",
+            rawVariationId: "",
+            experimentId: "exp_42",
+            isHoldout: true)
+        XCTAssertNil(variation)
+    }
+
+    func testNormalize_holdout_whitespaceVariationBecomesNil() {
+        let (_, variation) = BatchEventBuilder.normalizeDecisionIds(
+            rawCampaignId: "12345",
+            rawVariationId: "  ",
+            experimentId: "exp_42",
+            isHoldout: true)
+        XCTAssertNil(variation)
+    }
+
+    func testNormalize_holdout_nilVariationStaysNil() {
+        let (_, variation) = BatchEventBuilder.normalizeDecisionIds(
+            rawCampaignId: "12345",
+            rawVariationId: nil,
+            experimentId: "exp_42",
+            isHoldout: true)
+        XCTAssertNil(variation)
+    }
+
+    func testNormalize_holdout_nonNumericVariationBecomesNil() {
+        let (_, variation) = BatchEventBuilder.normalizeDecisionIds(
+            rawCampaignId: "12345",
+            rawVariationId: "abc",
+            experimentId: "exp_42",
+            isHoldout: true)
+        XCTAssertNil(variation)
+    }
+
+    func testNormalize_holdout_validNumericVariationKept() {
+        let (_, variation) = BatchEventBuilder.normalizeDecisionIds(
+            rawCampaignId: "12345",
+            rawVariationId: "777",
+            experimentId: "exp_42",
+            isHoldout: true)
+        XCTAssertEqual(variation, "777")
+    }
+
+    // MARK: - Decision encoder — variation_id JSON null
+
+    func testDecisionEncoder_emitsExplicitNullForNilVariationId() throws {
+        let decision = Decision(
+            variationID: nil,
+            campaignID: "12345",
+            experimentID: "67890",
+            metaData: DecisionMetadata(
+                ruleType: Constants.DecisionSource.holdout.rawValue,
+                ruleKey: "holdout_key",
+                flagKey: "flag_1",
+                variationKey: "",
+                enabled: false,
+                cmabUUID: nil))
+
+        let data = try JSONEncoder().encode(decision)
+        let json = try JSONSerialization.jsonObject(with: data, options: .allowFragments) as! [String: Any]
+
+        // JSONSerialization surfaces JSON `null` as `NSNull`. Verify the key is
+        // PRESENT with an explicit null (not omitted by encodeIfPresent).
+        XCTAssertTrue(json.keys.contains("variation_id"),
+                      "variation_id must be present in the JSON payload")
+        XCTAssertTrue(json["variation_id"] is NSNull,
+                      "variation_id must serialize as explicit JSON null when nil")
+
+        // Sanity-check other fields are unchanged.
+        XCTAssertEqual(json["campaign_id"] as? String, "12345")
+        XCTAssertEqual(json["experiment_id"] as? String, "67890")
+    }
+
+    func testDecisionEncoder_emitsStringForValidVariationId() throws {
+        let decision = Decision(
+            variationID: "777",
+            campaignID: "12345",
+            experimentID: "67890",
+            metaData: DecisionMetadata(
+                ruleType: Constants.DecisionSource.experiment.rawValue,
+                ruleKey: "exp",
+                flagKey: "flag_1",
+                variationKey: "a",
+                enabled: true,
+                cmabUUID: nil))
+
+        let data = try JSONEncoder().encode(decision)
+        let json = try JSONSerialization.jsonObject(with: data, options: .allowFragments) as! [String: Any]
+
+        XCTAssertEqual(json["variation_id"] as? String, "777")
+        XCTAssertFalse(json["variation_id"] is NSNull)
+    }
+}

--- a/Tests/OptimizelyTests-Common/OptimizelyUserContextTests_Decide.swift
+++ b/Tests/OptimizelyTests-Common/OptimizelyUserContextTests_Decide.swift
@@ -161,7 +161,7 @@ extension OptimizelyUserContextTests_Decide {
         let desc = eventSent.description
         XCTAssert(desc.contains("campaign_activated"))
         
-        XCTAssertEqual(eventDecision.variationID, "")
+        XCTAssertNil(eventDecision.variationID)
         XCTAssertEqual(eventDecision.experimentID, "")
 
         XCTAssertEqual(metadata.flagKey, "feature_3")

--- a/Tests/OptimizelyTests-Common/OptimizelyUserContextTests_Decide_Holdouts.swift
+++ b/Tests/OptimizelyTests-Common/OptimizelyUserContextTests_Decide_Holdouts.swift
@@ -493,7 +493,7 @@ extension OptimizelyUserContextTests_Decide_Holdouts {
         XCTAssert(desc.contains("campaign_activated"))
         
         XCTAssertEqual(eventDecision.experimentID, "id_holdout")
-        XCTAssertEqual(eventDecision.variationID, "id_holdout_variation")
+        XCTAssertNil(eventDecision.variationID)
         
         XCTAssertEqual(metadata.flagKey, "feature_2")
         XCTAssertEqual(metadata.ruleKey, "key_holdout")


### PR DESCRIPTION
## Summary

Normalizes the three ID fields on outgoing **decision impression events** so the event-processing pipeline always receives pipeline-valid values:

- `decisions[].campaign_id`
- `decisions[].variation_id`
- `events[].entity_id`

Applies uniformly across decision types (experiment, feature test, rollout, holdout) — there is no per-type branching in the normalization path.

Per the updated spec ([FSSDK-12813](https://optimizely-ext.atlassian.net/browse/FSSDK-12813)):

- `campaign_id` and `entity_id` MUST be non-empty decimal-digit strings; when invalid (empty, whitespace, null, or non-numeric), the SDK falls back to the decision's `experiment_id`. Because both fields share the same source (`experiment.layerId`) and the same fallback, they MUST always hold the same normalized value on the wire (SC-006).
- `variation_id` MUST be a non-empty decimal-digit string OR explicit JSON `null`; when invalid (empty, whitespace, non-numeric), the SDK emits `null`.
- The fix lives in the event-builder layer only — no public API change, no datafile schema change, no new logs or warnings on the normalization path (FR-007).
- Events are never dropped as a result of normalization (FR-006).
- Conversion events derive `entity_id` from a different upstream source (the conversion event's own datafile `id`) and are out of scope (FR-010).

### Why generalize beyond holdouts?

The bug's loudest manifestation today is on holdout impression events (holdouts may legitimately lack `layerId`, so the invalid-`campaign_id` / `entity_id` path fires on every holdout event). Audited the SDK fleet and confirmed valid `campaign_id` / `entity_id` values are always non-empty numeric strings for non-holdout decisions in well-formed datafiles — so applying the same normalization uniformly is a true no-op for those paths today (verified by sibling regression suites, see below). The uniform rule simplifies the code and provides forward-compatibility for any future decision type or future datafile edge case.

## Changes

- `Sources/Implementation/Events/BatchEventBuilder.swift`
  - `createImpressionEvent` routes `campaign_id` / `variation_id` through `normalizeDecisionIds(...)` for every decision (no `isHoldout` branch).
  - `DispatchEvent.entityID` now receives the **normalized** `campaignId` instead of `rawCampaignId`, so `events[].entity_id` and `decisions[].campaign_id` share the same fallback (FR-009 / SC-006).
  - Adds `isValidNumericIdString(_:)` helper restricted to ASCII `[0-9]`.
- `Sources/Data Model/DispatchEvents/BatchEvent.swift` — `Decision.variationID` is `String?` with a custom `encode(to:)` that emits explicit JSON `null` (not `encodeIfPresent`) when nil, so the on-the-wire JSON carries `"variation_id": null` for the no-variation case.
- `Tests/OptimizelyTests-Common/BatchEventBuilderTests_HoldoutIds.swift` — 18 tests covering numeric-string validation, uniform `campaign_id` / `variation_id` normalization, FR-006 passthrough, JSON `null` serialization, and an end-to-end impression event assertion that `campaign_id` and `entity_id` both fall back to the holdout's `id` and are byte-equal. (Filename retained to keep `project.pbxproj` references stable; contents cover all decision types and all three ID fields.)
- `OptimizelySwiftSDK.xcodeproj/project.pbxproj` — registers the test file with `OptimizelyTests-Common-iOS` and `OptimizelyTests-Common-tvOS`.

## Verification

- New tests: **18/18 pass** (`BatchEventBuilderTests_HoldoutIds`)
- Regression suites: **40/40 pass** (`BatchEventBuilderTests_Events`, `BatchEventBuilderTests_Attributes`, `BatchEventBuilderTests_EventTags`, `BatchEventBuilderTests_Region`, `DecisionServiceTests_Holdouts`) — confirms the generalized normalization is a true no-op for existing valid non-holdout events (SC-003) and that existing impression-event assertions (`entity_id == campaign_id`) continue to hold.
- Run: `xcodebuild -workspace OptimizelySwiftSDK.xcworkspace -scheme OptimizelySwiftSDK-iOS -destination 'platform=iOS Simulator,name=iPhone 17' test`

## Jira Ticket

[FSSDK-12813](https://optimizely-ext.atlassian.net/browse/FSSDK-12813)

[FSSDK-12813]: https://optimizely-ext.atlassian.net/browse/FSSDK-12813?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FSSDK-12813]: https://optimizely-ext.atlassian.net/browse/FSSDK-12813?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ