### PR TITLE
[AI-FSSDK] [release] prepare for release swift v5.4.1

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -17,7 +17,7 @@ on:
         description: release
 
 env:
-  VERSION: 5.4.0
+  VERSION: 5.4.1
 
 jobs:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Optimizely Swift SDK Changelog
 
+## 5.4.1
+June 24, 2026
+
+### Fixes
+
+- normalize campaign_id, variation_id, and entity_id on decision events ([#642](https://github.com/optimizely/swift-sdk/pull/642))
+
 ## 5.4.0
 June 22, 2026
 

--- a/OptimizelySwiftSDK.podspec
+++ b/OptimizelySwiftSDK.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name                    = "OptimizelySwiftSDK"
   s.module_name	            = "Optimizely"
-  s.version                 = "5.4.0"
+  s.version                 = "5.4.1"
   s.summary                 = "Optimizely experiment framework for iOS/tvOS/watchOS"
   s.homepage                = "https://docs.developers.optimizely.com/experimentation/v4.0.0-full-stack/docs"
   s.license                 = { :type => "Apache License, Version 2.0", :file => "LICENSE" }

--- a/OptimizelySwiftSDK.podspec
+++ b/OptimizelySwiftSDK.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name                    = "OptimizelySwiftSDK"
   s.module_name	            = "Optimizely"
-  s.version                 = "5.4.1"
+  s.version                 = "5.4.0"
   s.summary                 = "Optimizely experiment framework for iOS/tvOS/watchOS"
   s.homepage                = "https://docs.developers.optimizely.com/experimentation/v4.0.0-full-stack/docs"
   s.license                 = { :type => "Apache License, Version 2.0", :file => "LICENSE" }

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ If you have a name conflict with other swift packages when you add the Optimizel
 #### CocoaPods 
 1. Add the following lines to the _Podfile_:<pre>
 ```use_frameworks!```
-```pod 'OptimizelySwiftSDK', '~> 5.4.0'```
+```pod 'OptimizelySwiftSDK', '~> 5.4.1'```
 </pre>
 
 2. Run the following command: <pre>``` pod install ```</pre>


### PR DESCRIPTION
## Summary

Prepare for releasing swift v5.4.1

## Release Details
- Version Bump: v5.4.0 → v5.4.1 (patch)

## Jira Ticket

[FSSDK-12813](https://optimizely-ext.atlassian.net/browse/FSSDK-12813)

[FSSDK-12813]: https://optimizely-ext.atlassian.net/browse/FSSDK-12813?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ