### PR TITLE
[AI-FSSDK] [FSSDK-12813] Relax campaign_id/entity_id validation to non-empty string per updated spec

### DIFF
--- a/Sources/Implementation/Events/BatchEventBuilder.swift
+++ b/Sources/Implementation/Events/BatchEventBuilder.swift
@@ -68,20 +68,23 @@ class BatchEventBuilder {
     /// event carries pipeline-valid values, regardless of decision type
     /// (experiment, feature test, rollout, or holdout). See spec FR-001–FR-005.
     ///
-    /// - `campaign_id` falls back to `experiment_id` when the raw value is not a
-    ///   non-empty decimal-digit string. For well-formed datafiles this is a
-    ///   no-op for non-holdout decisions; the fallback fires on holdout events
-    ///   (which legitimately may lack `layerId`) and acts as a safety net for
-    ///   any future malformed input.
-    /// - `variation_id` becomes `nil` (emitted as JSON `null`) when the raw
-    ///   value is not a non-empty decimal-digit string.
+    /// - `campaign_id` falls back to `experiment_id` when the raw value is an
+    ///   empty string. Any non-empty string (numeric like `"12345"` or opaque
+    ///   like `"layer_abc"`/`"default-12345"`) is accepted and passes through
+    ///   unchanged. The fallback fires on holdout events (which legitimately
+    ///   may lack `layerId`) and acts as a safety net for any future malformed
+    ///   input. See spec FR-001 / FR-002 (relaxed per 2026-06-24 update).
+    /// - `variation_id` keeps the stricter numeric-string contract: it becomes
+    ///   `nil` (emitted as JSON `null`) when the raw value is not a non-empty
+    ///   decimal-digit string. See spec FR-003 / FR-004.
     static func normalizeDecisionIds(rawCampaignId: String,
                                      rawVariationId: String?,
                                      experimentId: String) -> (campaignId: String, variationId: String?) {
-        // campaign_id must be a numeric string, otherwise fall back to
-        // experiment_id. The upstream experiment_id is passed through unchanged
-        // even if it is itself invalid (FR-006 — never drop the event).
-        let campaignId = isValidNumericIdString(rawCampaignId) ? rawCampaignId : experimentId
+        // campaign_id only needs to be a non-empty string of any character
+        // content. If it is empty, fall back to experiment_id. The upstream
+        // experiment_id is passed through unchanged even if it is itself
+        // invalid (FR-006 — never drop the event).
+        let campaignId = isNonEmptyString(rawCampaignId) ? rawCampaignId : experimentId
 
         // variation_id must be a numeric string or JSON null. Anything else
         // (empty, whitespace, non-numeric) becomes nil so the encoder emits
@@ -96,10 +99,23 @@ class BatchEventBuilder {
         return (campaignId, variationId)
     }
 
+    /// Returns true iff `value` is a non-empty string. Used for the relaxed
+    /// `campaign_id` / `entity_id` validation per spec FR-001 / FR-009 — any
+    /// non-empty string passes regardless of character content (IDs may be
+    /// opaque, e.g. `"default-12345"`, `"layer_abc"`).
+    static func isNonEmptyString(_ value: String) -> Bool {
+        return !value.isEmpty
+    }
+
     /// Returns true iff `value` is a non-empty string consisting entirely of
     /// decimal digits `[0-9]`. Empty strings, whitespace-only strings, and any
     /// string containing non-digit characters return false. Leading zeros are
     /// allowed because Optimizely IDs are opaque identifiers (see spec).
+    ///
+    /// Used only for `variation_id` validation per spec FR-003 — `variation_id`
+    /// retains the stricter numeric-string-only contract even after the
+    /// 2026-06-24 spec relaxation. `campaign_id` and `entity_id` use
+    /// `isNonEmptyString(_:)` instead.
     static func isValidNumericIdString(_ value: String) -> Bool {
         guard !value.isEmpty else { return false }
         // `CharacterSet.decimalDigits` includes non-ASCII digit forms (e.g.

--- a/Tests/OptimizelyTests-Common/BatchEventBuilderTests_HoldoutIds.swift
+++ b/Tests/OptimizelyTests-Common/BatchEventBuilderTests_HoldoutIds.swift
@@ -15,15 +15,40 @@
 //
 
 // Tests for FSSDK-12813: every decision event (experiment, feature test,
-// rollout, or holdout) must carry a valid numeric `campaign_id` (falling back
-// to `experiment_id` if invalid) and either a valid numeric `variation_id` or
-// JSON `null`. The normalization is uniform across decision types per FR-005.
+// rollout, or holdout) must carry a non-empty `campaign_id` (falling back to
+// `experiment_id` only when empty) and either a valid numeric `variation_id`
+// or JSON `null`. The normalization is uniform across decision types per
+// FR-005.
+//
+// Spec note (2026-06-24 relaxation): `campaign_id` and `entity_id` accept any
+// non-empty string content (IDs may be opaque, e.g. `"layer_abc"`). Only
+// `variation_id` keeps the stricter numeric-string-only contract.
 
 import XCTest
 
 class BatchEventBuilderTests_HoldoutIds: XCTestCase {
 
-    // MARK: - isValidNumericIdString
+    // MARK: - isNonEmptyString (campaign_id / entity_id validator)
+
+    func testIsNonEmptyString_acceptsAnyNonEmptyContent() {
+        // Numeric strings.
+        XCTAssertTrue(BatchEventBuilder.isNonEmptyString("12345"))
+        XCTAssertTrue(BatchEventBuilder.isNonEmptyString("0"))
+        // Opaque IDs — the whole point of the FSSDK-12813 spec relaxation:
+        // any non-empty string content is valid for campaign_id / entity_id.
+        XCTAssertTrue(BatchEventBuilder.isNonEmptyString("layer_abc"))
+        XCTAssertTrue(BatchEventBuilder.isNonEmptyString("default-12345"))
+        XCTAssertTrue(BatchEventBuilder.isNonEmptyString("exp_42"))
+        // Whitespace-only is still non-empty per spec FR-001 — only the empty
+        // string triggers the fallback.
+        XCTAssertTrue(BatchEventBuilder.isNonEmptyString(" "))
+    }
+
+    func testIsNonEmptyString_rejectsEmptyOnly() {
+        XCTAssertFalse(BatchEventBuilder.isNonEmptyString(""))
+    }
+
+    // MARK: - isValidNumericIdString (variation_id validator — unchanged)
 
     func testIsValidNumericIdString_validDigits() {
         XCTAssertTrue(BatchEventBuilder.isValidNumericIdString("12345"))
@@ -79,6 +104,8 @@ class BatchEventBuilderTests_HoldoutIds: XCTestCase {
     // MARK: - normalizeDecisionIds — campaign_id (FR-001/FR-002) applied uniformly
 
     func testNormalize_emptyCampaignFallsBackToExperimentId() {
+        // Only the empty string triggers the fallback per spec FR-002
+        // (post-2026-06-24 relaxation).
         let (campaign, _) = BatchEventBuilder.normalizeDecisionIds(
             rawCampaignId: "",
             rawVariationId: "777",
@@ -86,20 +113,35 @@ class BatchEventBuilderTests_HoldoutIds: XCTestCase {
         XCTAssertEqual(campaign, "exp_42")
     }
 
-    func testNormalize_whitespaceCampaignFallsBackToExperimentId() {
+    func testNormalize_whitespaceCampaignPassesThrough() {
+        // Spec FR-001 (relaxed 2026-06-24): any non-empty string is valid for
+        // campaign_id, including whitespace-only. Only empty triggers fallback.
         let (campaign, _) = BatchEventBuilder.normalizeDecisionIds(
             rawCampaignId: "   ",
             rawVariationId: "777",
             experimentId: "exp_42")
-        XCTAssertEqual(campaign, "exp_42")
+        XCTAssertEqual(campaign, "   ")
     }
 
-    func testNormalize_nonNumericCampaignFallsBackToExperimentId() {
+    func testNormalize_nonNumericCampaignPassesThrough() {
+        // Spec FR-001 (relaxed 2026-06-24): non-numeric campaign_id is valid
+        // — IDs may be opaque. No fallback to experiment_id.
         let (campaign, _) = BatchEventBuilder.normalizeDecisionIds(
             rawCampaignId: "not_a_number",
             rawVariationId: "777",
             experimentId: "exp_42")
-        XCTAssertEqual(campaign, "exp_42")
+        XCTAssertEqual(campaign, "not_a_number")
+    }
+
+    func testNormalize_opaqueCampaignPassesThrough_FSSDK12813_relaxation() {
+        // Direct proof of the FSSDK-12813 spec relaxation: an opaque ID such
+        // as "layer_abc" is a valid campaign_id and MUST pass through
+        // unchanged (no fallback to experiment_id).
+        let (campaign, _) = BatchEventBuilder.normalizeDecisionIds(
+            rawCampaignId: "layer_abc",
+            rawVariationId: "777",
+            experimentId: "exp_42")
+        XCTAssertEqual(campaign, "layer_abc")
     }
 
     func testNormalize_validNumericCampaignKept() {


### PR DESCRIPTION
## Summary

Follow-up to the merged [#642](https://github.com/optimizely/swift-sdk/pull/642) (released as **5.4.1**), which normalized `decisions[].campaign_id`, `decisions[].variation_id`, and `events[].entity_id` on outgoing decision impression events.

The [FSSDK-12813](https://optimizely-ext.atlassian.net/browse/FSSDK-12813) spec was updated on **2026-06-24** to **relax** the validation contract for `campaign_id` and `entity_id` only. This PR brings the Swift SDK in line with the relaxed contract.

### What the spec relaxed

- `decisions[].campaign_id` and `events[].entity_id` MUST be **non-empty strings**. IDs may be opaque (e.g. `"layer_abc"`, `"default-12345"`) — any non-empty string is valid regardless of character content.
- The fallback to `experiment_id` now fires **only** when the source value is the empty string `""` (or nil / missing). Previously it fired on any non-numeric input.

### What is unchanged

- `decisions[].variation_id` keeps the **stricter** numeric-string-only contract per spec FR-003. Empty, whitespace, or non-numeric `variation_id` values still normalize to `nil` (JSON `null`).
- No change to `Sources/Data Model/DispatchEvents/BatchEvent.swift` — `Decision.variationID: String?` and its explicit-`null` encoder from #642 remain correct.
- No change to FR-006 (events never dropped) or FR-007 (no warnings on the normalization path).
- No public API change, no datafile schema change, no SDK version bump (5.4.1 already released; this rides the next release ticket).

## Changes

- `Sources/Implementation/Events/BatchEventBuilder.swift`
  - `normalizeDecisionIds(...)` now gates `campaign_id` with a new `isNonEmptyString(_:)` helper instead of `isValidNumericIdString(_:)`. The `variation_id` branch is untouched.
  - Adds `isNonEmptyString(_:) -> Bool` (returns `!value.isEmpty`).
  - Retains `isValidNumericIdString(_:)` — still used by the `variation_id` branch per spec FR-003.
  - Doc comments updated to cite the 2026-06-24 spec relaxation.
- `Tests/OptimizelyTests-Common/BatchEventBuilderTests_HoldoutIds.swift`
  - **Flipped**: `testNormalize_whitespaceCampaignFallsBackToExperimentId` → `testNormalize_whitespaceCampaignPassesThrough` (whitespace is non-empty, so it passes through unchanged).
  - **Flipped**: `testNormalize_nonNumericCampaignFallsBackToExperimentId` → `testNormalize_nonNumericCampaignPassesThrough` (non-numeric is non-empty, so it passes through unchanged).
  - **Added**: `testNormalize_opaqueCampaignPassesThrough_FSSDK12813_relaxation` — direct proof that an opaque ID `"layer_abc"` passes through `campaign_id` unchanged with no fallback to `experiment_id`.
  - **Added**: `testIsNonEmptyString_acceptsAnyNonEmptyContent` and `testIsNonEmptyString_rejectsEmptyOnly` — unit coverage for the new helper.
  - All `variation_id` tests unchanged.
  - All `isValidNumericIdString` tests unchanged (still used by `variation_id`).
  - Header comment updated to describe the relaxed contract.

## Verification

- `xcodebuild -workspace OptimizelySwiftSDK.xcworkspace -scheme OptimizelySwiftSDK-iOS -destination 'platform=iOS Simulator,name=iPhone 17' test` — **not executed in this run**; CoreSimulator was unavailable in the sandboxed environment. Local reviewers should run the command above. The change is mechanical: one validator swap on one branch of `normalizeDecisionIds`, plus tests flipped/added in lockstep.
- Pre-existing impression-event regression suites referenced in #642 (`BatchEventBuilderTests_Events`, `BatchEventBuilderTests_Attributes`, `BatchEventBuilderTests_EventTags`, `BatchEventBuilderTests_Region`, `DecisionServiceTests_Holdouts`) all used non-empty placeholders for `campaign_id` and so are unaffected by this relaxation (FR-011 audit).

## Jira Ticket

[FSSDK-12813](https://optimizely-ext.atlassian.net/browse/FSSDK-12813)

## Related

- Original implementation PR (merged, released as 5.4.1): #642

[FSSDK-12813]: https://optimizely-ext.atlassian.net/browse/FSSDK-12813?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FSSDK-12813]: https://optimizely-ext.atlassian.net/browse/FSSDK-12813?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ