### PR TITLE
[AI-FSSDK] [FSSDK-12834] Replace non-numeric holdout placeholder IDs in event-construction tests

### DIFF
--- a/Sources/Implementation/Events/BatchEventBuilder.swift
+++ b/Sources/Implementation/Events/BatchEventBuilder.swift
@@ -62,35 +62,23 @@ class BatchEventBuilder {
                                 dispatchEvents: [dispatchEvent])
     }
 
-    // MARK: - Decision Event ID Normalization (FSSDK-12813, FSSDK-12834)
+    // MARK: - Decision Event ID Normalization
 
-    /// Normalizes `campaign_id` and `variation_id` so every dispatched decision
-    /// event carries pipeline-valid values, regardless of decision type
-    /// (experiment, feature test, rollout, or holdout). See spec FR-001–FR-005.
+    /// Normalizes `campaign_id` and `variation_id` for every dispatched
+    /// decision event (experiment, feature test, rollout, holdout).
     ///
-    /// - `campaign_id` (and the mirrored `events[].entity_id`, FR-009) falls
-    ///   back to `experiment_id` ONLY when the raw value is empty, whitespace-
-    ///   only, null, or missing. Any other non-empty string passes through
-    ///   unchanged — IDs may be opaque (e.g. `"default-12345"`, `"layer_abc"`)
-    ///   per FR-001. Holdouts trigger the fallback today because they
-    ///   legitimately default `layerId` to `""`; the rule also acts as a safety
-    ///   net for any future malformed input.
-    /// - `variation_id` keeps the stricter numeric-string contract (FR-003):
-    ///   it becomes `nil` (emitted as JSON `null`) when the raw value is not a
-    ///   non-empty decimal-digit string.
+    /// - `campaign_id` (mirrored as `events[].entity_id`) accepts any non-empty
+    ///   string and falls back to `experiment_id` only on empty/whitespace
+    ///   input. Opaque IDs (e.g. `"layer_abc"`) pass through.
+    /// - `variation_id` must be a non-empty decimal-digit string; anything
+    ///   else becomes `nil` (encoded as JSON `null`).
+    /// - `experiment_id` is never validated here — it is always passed
+    ///   through so the event is never dropped.
     static func normalizeDecisionIds(rawCampaignId: String,
                                      rawVariationId: String?,
                                      experimentId: String) -> (campaignId: String, variationId: String?) {
-        // FR-001/FR-002: campaign_id is valid if it is any non-empty string
-        // (numeric or opaque). The fallback to experiment_id fires only on
-        // empty / whitespace-only inputs. The upstream experiment_id is passed
-        // through unchanged even if it is itself invalid (FR-006 — never drop
-        // the event).
         let campaignId = isValidStringId(rawCampaignId) ? rawCampaignId : experimentId
 
-        // FR-003/FR-004: variation_id must be a decimal-digit string or JSON
-        // null. Anything else (empty, whitespace, opaque non-numeric) becomes
-        // nil so the encoder emits JSON `null`.
         let variationId: String?
         if let raw = rawVariationId, isValidNumericIdString(raw) {
             variationId = raw
@@ -101,28 +89,19 @@ class BatchEventBuilder {
         return (campaignId, variationId)
     }
 
-    /// Returns true iff `value` is a non-empty string of length ≥ 1 carrying
-    /// at least one non-whitespace character. Used for the relaxed
-    /// `campaign_id` / `entity_id` contract (FR-001 / FR-009): any character
-    /// content is allowed (opaque IDs like `"default-12345"` or `"layer_abc"`
-    /// are valid). The whitespace-only check is a defensive normalization so
-    /// pure-whitespace inputs are treated as empty and trigger the fallback.
+    /// True iff `value` is non-empty and contains at least one non-whitespace
+    /// character. Used for the relaxed `campaign_id` / `entity_id` contract.
     static func isValidStringId(_ value: String) -> Bool {
         guard !value.isEmpty else { return false }
         return value.contains { !$0.isWhitespace }
     }
 
-    /// Returns true iff `value` is a non-empty string consisting entirely of
-    /// decimal digits `[0-9]`. Empty strings, whitespace-only strings, and any
-    /// string containing non-digit characters return false. Leading zeros are
-    /// allowed because Optimizely IDs are opaque identifiers (see spec).
-    /// Used for the stricter `variation_id` contract (FR-003).
+    /// True iff `value` is a non-empty ASCII decimal-digit string `[0-9]+`.
+    /// Used for the strict `variation_id` contract. We walk unicode scalars
+    /// directly because `CharacterSet.decimalDigits` would also accept
+    /// non-ASCII digit forms (e.g. Arabic-Indic).
     static func isValidNumericIdString(_ value: String) -> Bool {
         guard !value.isEmpty else { return false }
-        // `CharacterSet.decimalDigits` includes non-ASCII digit forms (e.g.
-        // Arabic-Indic digits). Spec restricts validity to ASCII `[0-9]`, so we
-        // walk the unicode scalars explicitly instead of using
-        // `rangeOfCharacter(from: CharacterSet.decimalDigits.inverted)`.
         for scalar in value.unicodeScalars {
             if scalar.value < 0x30 || scalar.value > 0x39 {
                 return false

--- a/Sources/Implementation/Events/BatchEventBuilder.swift
+++ b/Sources/Implementation/Events/BatchEventBuilder.swift
@@ -62,30 +62,35 @@ class BatchEventBuilder {
                                 dispatchEvents: [dispatchEvent])
     }
 
-    // MARK: - Decision Event ID Normalization (FSSDK-12813)
+    // MARK: - Decision Event ID Normalization (FSSDK-12813, FSSDK-12834)
 
     /// Normalizes `campaign_id` and `variation_id` so every dispatched decision
     /// event carries pipeline-valid values, regardless of decision type
     /// (experiment, feature test, rollout, or holdout). See spec FR-001–FR-005.
     ///
-    /// - `campaign_id` falls back to `experiment_id` when the raw value is not a
-    ///   non-empty decimal-digit string. For well-formed datafiles this is a
-    ///   no-op for non-holdout decisions; the fallback fires on holdout events
-    ///   (which legitimately may lack `layerId`) and acts as a safety net for
-    ///   any future malformed input.
-    /// - `variation_id` becomes `nil` (emitted as JSON `null`) when the raw
-    ///   value is not a non-empty decimal-digit string.
+    /// - `campaign_id` (and the mirrored `events[].entity_id`, FR-009) falls
+    ///   back to `experiment_id` ONLY when the raw value is empty, whitespace-
+    ///   only, null, or missing. Any other non-empty string passes through
+    ///   unchanged — IDs may be opaque (e.g. `"default-12345"`, `"layer_abc"`)
+    ///   per FR-001. Holdouts trigger the fallback today because they
+    ///   legitimately default `layerId` to `""`; the rule also acts as a safety
+    ///   net for any future malformed input.
+    /// - `variation_id` keeps the stricter numeric-string contract (FR-003):
+    ///   it becomes `nil` (emitted as JSON `null`) when the raw value is not a
+    ///   non-empty decimal-digit string.
     static func normalizeDecisionIds(rawCampaignId: String,
                                      rawVariationId: String?,
                                      experimentId: String) -> (campaignId: String, variationId: String?) {
-        // campaign_id must be a numeric string, otherwise fall back to
-        // experiment_id. The upstream experiment_id is passed through unchanged
-        // even if it is itself invalid (FR-006 — never drop the event).
-        let campaignId = isValidNumericIdString(rawCampaignId) ? rawCampaignId : experimentId
+        // FR-001/FR-002: campaign_id is valid if it is any non-empty string
+        // (numeric or opaque). The fallback to experiment_id fires only on
+        // empty / whitespace-only inputs. The upstream experiment_id is passed
+        // through unchanged even if it is itself invalid (FR-006 — never drop
+        // the event).
+        let campaignId = isValidStringId(rawCampaignId) ? rawCampaignId : experimentId
 
-        // variation_id must be a numeric string or JSON null. Anything else
-        // (empty, whitespace, non-numeric) becomes nil so the encoder emits
-        // JSON `null`.
+        // FR-003/FR-004: variation_id must be a decimal-digit string or JSON
+        // null. Anything else (empty, whitespace, opaque non-numeric) becomes
+        // nil so the encoder emits JSON `null`.
         let variationId: String?
         if let raw = rawVariationId, isValidNumericIdString(raw) {
             variationId = raw
@@ -96,10 +101,22 @@ class BatchEventBuilder {
         return (campaignId, variationId)
     }
 
+    /// Returns true iff `value` is a non-empty string of length ≥ 1 carrying
+    /// at least one non-whitespace character. Used for the relaxed
+    /// `campaign_id` / `entity_id` contract (FR-001 / FR-009): any character
+    /// content is allowed (opaque IDs like `"default-12345"` or `"layer_abc"`
+    /// are valid). The whitespace-only check is a defensive normalization so
+    /// pure-whitespace inputs are treated as empty and trigger the fallback.
+    static func isValidStringId(_ value: String) -> Bool {
+        guard !value.isEmpty else { return false }
+        return value.contains { !$0.isWhitespace }
+    }
+
     /// Returns true iff `value` is a non-empty string consisting entirely of
     /// decimal digits `[0-9]`. Empty strings, whitespace-only strings, and any
     /// string containing non-digit characters return false. Leading zeros are
     /// allowed because Optimizely IDs are opaque identifiers (see spec).
+    /// Used for the stricter `variation_id` contract (FR-003).
     static func isValidNumericIdString(_ value: String) -> Bool {
         guard !value.isEmpty else { return false }
         // `CharacterSet.decimalDigits` includes non-ASCII digit forms (e.g.

--- a/Tests/OptimizelyTests-Common/BatchEventBuilderTests_Events.swift
+++ b/Tests/OptimizelyTests-Common/BatchEventBuilderTests_Events.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2019-2021, 2023 Optimizely, Inc. and contributors
+// Copyright 2019-2021, 2023, 2026 Optimizely, Inc. and contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -27,19 +27,27 @@ class BatchEventBuilderTests_Events: XCTestCase {
     var project: Project!
     let datafile = OTUtils.loadJSONDatafile("api_datafile")!
     
+    // FSSDK-12813: holdout fixture uses numeric-string IDs so the post-fix
+    // event-id normalization (campaign_id falls back to experiment_id when
+    // layerId is invalid; variation_id becomes JSON null when invalid) is a
+    // no-op for the happy-path holdout tests below. Per spec FR-011, every
+    // pre-existing test that builds an event payload must use valid
+    // decimal-digit string IDs (or have its expected output updated to match
+    // the normalized post-fix value). These tests exercise routing/metadata,
+    // not the invalid-input path, so the IDs are now realistic numeric strings.
     var sampleHoldout: [String: Any] {
         return [
             "status": "Running",
-            "id": "holdout_4444444",
+            "id": "4444444",
             "key": "holdout_key",
             "trafficAllocation": [
-                ["entityId": "holdout_variation_a11", "endOfRange": 10000] // 100% traffic allocation
+                ["entityId": "4444411", "endOfRange": 10000] // 100% traffic allocation
             ],
             "audienceIds": [],
             "variations": [
                 [
                     "variables": [],
-                    "id": "holdout_variation_a11",
+                    "id": "4444411",
                     "key": "holdout_a"
                 ]
             ]

--- a/Tests/OptimizelyTests-Common/BatchEventBuilderTests_Events.swift
+++ b/Tests/OptimizelyTests-Common/BatchEventBuilderTests_Events.swift
@@ -27,14 +27,17 @@ class BatchEventBuilderTests_Events: XCTestCase {
     var project: Project!
     let datafile = OTUtils.loadJSONDatafile("api_datafile")!
     
-    // FSSDK-12813: holdout fixture uses numeric-string IDs so the post-fix
-    // event-id normalization (campaign_id falls back to experiment_id when
-    // layerId is invalid; variation_id becomes JSON null when invalid) is a
-    // no-op for the happy-path holdout tests below. Per spec FR-011, every
-    // pre-existing test that builds an event payload must use valid
-    // decimal-digit string IDs (or have its expected output updated to match
-    // the normalized post-fix value). These tests exercise routing/metadata,
-    // not the invalid-input path, so the IDs are now realistic numeric strings.
+    // FSSDK-12813: holdout fixture uses valid IDs so the post-fix event-id
+    // normalization is a no-op for the happy-path holdout tests below. Under
+    // the spec, `campaign_id` and `events[].entity_id` accept any non-empty
+    // string (fallback to `experiment_id` only when the source is empty/null/
+    // missing), while `variation_id` retains the stricter decimal-digit-only
+    // contract (anything else normalizes to JSON null). Per FR-011, every
+    // pre-existing event-construction fixture must either supply a valid
+    // placeholder or update its expected output to the normalized value.
+    // Numeric strings are used here for both `id` fields because that form is
+    // valid under either rule (campaign_id non-empty-string, variation_id
+    // digits-only) and keeps the fixtures uniform.
     var sampleHoldout: [String: Any] {
         return [
             "status": "Running",

--- a/Tests/OptimizelyTests-Common/BatchEventBuilderTests_Events.swift
+++ b/Tests/OptimizelyTests-Common/BatchEventBuilderTests_Events.swift
@@ -27,17 +27,9 @@ class BatchEventBuilderTests_Events: XCTestCase {
     var project: Project!
     let datafile = OTUtils.loadJSONDatafile("api_datafile")!
     
-    // FSSDK-12813: holdout fixture uses valid IDs so the post-fix event-id
-    // normalization is a no-op for the happy-path holdout tests below. Under
-    // the spec, `campaign_id` and `events[].entity_id` accept any non-empty
-    // string (fallback to `experiment_id` only when the source is empty/null/
-    // missing), while `variation_id` retains the stricter decimal-digit-only
-    // contract (anything else normalizes to JSON null). Per FR-011, every
-    // pre-existing event-construction fixture must either supply a valid
-    // placeholder or update its expected output to the normalized value.
-    // Numeric strings are used here for both `id` fields because that form is
-    // valid under either rule (campaign_id non-empty-string, variation_id
-    // digits-only) and keeps the fixtures uniform.
+    // Numeric strings used for both id fields: campaign_id accepts any
+    // non-empty string, variation_id requires digits-only. Numeric satisfies
+    // both and keeps fixtures uniform.
     var sampleHoldout: [String: Any] {
         return [
             "status": "Running",

--- a/Tests/OptimizelyTests-Common/BatchEventBuilderTests_HoldoutIds.swift
+++ b/Tests/OptimizelyTests-Common/BatchEventBuilderTests_HoldoutIds.swift
@@ -14,39 +14,29 @@
 // limitations under the License.
 //
 
-// Tests for FSSDK-12813 (P1) + FSSDK-12834 (P2): every decision event
-// (experiment, feature test, rollout, or holdout) must carry:
-//   - `campaign_id` (and the mirrored `events[].entity_id`, FR-009) as any
-//     non-empty string — numeric OR opaque (e.g. `"default-12345"`,
-//     `"layer_abc"`). Fallback to `experiment_id` fires only on empty /
-//     whitespace-only / null source values. (FR-001 / FR-002)
-//   - `variation_id` as a decimal-digit string OR explicit JSON `null`.
-//     Non-numeric strings normalize to null. (FR-003 / FR-004)
-// The normalization is uniform across decision types per FR-005.
+// Tests for decision-event id normalization:
+//   campaign_id / events[].entity_id: any non-empty string; fallback to
+//     experiment_id on empty / whitespace / null.
+//   variation_id: decimal-digit string only; otherwise JSON null.
 
 import XCTest
 
 class BatchEventBuilderTests_HoldoutIds: XCTestCase {
 
-    // MARK: - isValidStringId (FR-001: relaxed contract for campaign_id / entity_id)
+    // MARK: - isValidStringId (relaxed contract for campaign_id / entity_id)
 
     func testIsValidStringId_nonEmptyContent() {
-        // Any non-empty string with at least one non-whitespace character is
-        // valid — numeric, opaque, or mixed. This is the relaxed P2 contract.
         XCTAssertTrue(BatchEventBuilder.isValidStringId("12345"))
         XCTAssertTrue(BatchEventBuilder.isValidStringId("default-12345"))
         XCTAssertTrue(BatchEventBuilder.isValidStringId("layer_abc"))
         XCTAssertTrue(BatchEventBuilder.isValidStringId("a"))
         XCTAssertTrue(BatchEventBuilder.isValidStringId("0"))
         XCTAssertTrue(BatchEventBuilder.isValidStringId("not_a_number"))
-        // Non-ASCII content is accepted — campaign_id has no character set
-        // restriction (unlike variation_id).
+        // Non-ASCII content is accepted; no character-set restriction.
         XCTAssertTrue(BatchEventBuilder.isValidStringId("\u{0660}\u{0661}"))
     }
 
     func testIsValidStringId_emptyOrWhitespaceOnly() {
-        // Empty and whitespace-only strings are treated as invalid and
-        // trigger the experiment_id fallback (FR-002).
         XCTAssertFalse(BatchEventBuilder.isValidStringId(""))
         XCTAssertFalse(BatchEventBuilder.isValidStringId(" "))
         XCTAssertFalse(BatchEventBuilder.isValidStringId("   "))
@@ -55,12 +45,12 @@ class BatchEventBuilderTests_HoldoutIds: XCTestCase {
         XCTAssertFalse(BatchEventBuilder.isValidStringId(" \t\n "))
     }
 
-    // MARK: - isValidNumericIdString (FR-003: stricter contract for variation_id)
+    // MARK: - isValidNumericIdString (strict contract for variation_id)
 
     func testIsValidNumericIdString_validDigits() {
         XCTAssertTrue(BatchEventBuilder.isValidNumericIdString("12345"))
         XCTAssertTrue(BatchEventBuilder.isValidNumericIdString("0"))
-        // Leading zeros are allowed because IDs are opaque.
+        // Leading zeros allowed: IDs are opaque.
         XCTAssertTrue(BatchEventBuilder.isValidNumericIdString("007"))
         XCTAssertTrue(BatchEventBuilder.isValidNumericIdString("10390977714"))
     }
@@ -81,14 +71,13 @@ class BatchEventBuilderTests_HoldoutIds: XCTestCase {
         XCTAssertFalse(BatchEventBuilder.isValidNumericIdString("+12345"))
         XCTAssertFalse(BatchEventBuilder.isValidNumericIdString("12 45"))
         XCTAssertFalse(BatchEventBuilder.isValidNumericIdString("1e10"))
-        // Non-ASCII digit forms (e.g. Arabic-Indic) are NOT valid per spec.
+        // Non-ASCII digit forms (e.g. Arabic-Indic) are NOT valid.
         XCTAssertFalse(BatchEventBuilder.isValidNumericIdString("\u{0660}\u{0661}"))
     }
 
-    // MARK: - normalizeDecisionIds — valid IDs pass through unchanged (SC-003)
+    // MARK: - normalizeDecisionIds — happy path
 
     func testNormalize_validCampaignAndVariation_passThrough() {
-        // The dominant production case: both IDs already valid. No change.
         let (campaign, variation) = BatchEventBuilder.normalizeDecisionIds(
             rawCampaignId: "555",
             rawVariationId: "777",
@@ -98,8 +87,6 @@ class BatchEventBuilderTests_HoldoutIds: XCTestCase {
     }
 
     func testNormalize_validCampaignAndNilVariation_variationStaysNil() {
-        // Valid campaign, no variation supplied (e.g. holdout with no variation
-        // assigned). variation_id must be JSON null, not empty string.
         let (campaign, variation) = BatchEventBuilder.normalizeDecisionIds(
             rawCampaignId: "555",
             rawVariationId: nil,
@@ -108,11 +95,10 @@ class BatchEventBuilderTests_HoldoutIds: XCTestCase {
         XCTAssertNil(variation)
     }
 
-    // MARK: - normalizeDecisionIds — campaign_id (FR-001/FR-002) applied uniformly
+    // MARK: - normalizeDecisionIds — campaign_id
 
     func testNormalize_emptyCampaignFallsBackToExperimentId() {
-        // FR-002: empty source value triggers the experiment_id fallback.
-        // This is the canonical holdout case (layerId defaults to "").
+        // Canonical holdout case: layerId defaults to "".
         let (campaign, _) = BatchEventBuilder.normalizeDecisionIds(
             rawCampaignId: "",
             rawVariationId: "777",
@@ -121,8 +107,6 @@ class BatchEventBuilderTests_HoldoutIds: XCTestCase {
     }
 
     func testNormalize_whitespaceOnlyCampaignFallsBackToExperimentId() {
-        // FSSDK-12834: whitespace-only strings are treated as empty per the
-        // defensive normalization in isValidStringId and fall back.
         let (campaign, _) = BatchEventBuilder.normalizeDecisionIds(
             rawCampaignId: "   ",
             rawVariationId: "777",
@@ -131,9 +115,6 @@ class BatchEventBuilderTests_HoldoutIds: XCTestCase {
     }
 
     func testNormalize_opaqueCampaignPassesThroughUnchanged() {
-        // FSSDK-12834 (FR-001): an opaque non-numeric string is a valid
-        // campaign_id under the relaxed P2 contract and MUST pass through
-        // unchanged — no fallback to experiment_id.
         let (campaign, _) = BatchEventBuilder.normalizeDecisionIds(
             rawCampaignId: "default-12345",
             rawVariationId: "777",
@@ -142,9 +123,6 @@ class BatchEventBuilderTests_HoldoutIds: XCTestCase {
     }
 
     func testNormalize_nonNumericCampaignPassesThroughUnchanged() {
-        // FSSDK-12834 (FR-001): any non-empty string passes through; only
-        // empty/null source values trigger the fallback. This assertion was
-        // inverted under P1 (digits-only) and is corrected here for P2.
         let (campaign, _) = BatchEventBuilder.normalizeDecisionIds(
             rawCampaignId: "not_a_number",
             rawVariationId: "777",
@@ -153,8 +131,6 @@ class BatchEventBuilderTests_HoldoutIds: XCTestCase {
     }
 
     func testNormalize_opaquePrefixedLayerIdPassesThroughUnchanged() {
-        // FSSDK-12834 (FR-001): typical opaque layerId shape like
-        // "layer_abc123" must pass through unchanged.
         let (campaign, _) = BatchEventBuilder.normalizeDecisionIds(
             rawCampaignId: "layer_abc123",
             rawVariationId: "777",
@@ -171,8 +147,7 @@ class BatchEventBuilderTests_HoldoutIds: XCTestCase {
     }
 
     func testNormalize_invalidExperimentIdStillPassedThrough() {
-        // FR-006: never drop the event; pass invalid experiment_id through if
-        // that is all we have for the fallback.
+        // Never drop the event — pass the invalid fallback through.
         let (campaign, _) = BatchEventBuilder.normalizeDecisionIds(
             rawCampaignId: "",
             rawVariationId: "777",
@@ -180,7 +155,7 @@ class BatchEventBuilderTests_HoldoutIds: XCTestCase {
         XCTAssertEqual(campaign, "")
     }
 
-    // MARK: - normalizeDecisionIds — variation_id (FR-003/FR-004) applied uniformly
+    // MARK: - normalizeDecisionIds — variation_id
 
     func testNormalize_emptyVariationBecomesNil() {
         let (_, variation) = BatchEventBuilder.normalizeDecisionIds(
@@ -240,14 +215,13 @@ class BatchEventBuilderTests_HoldoutIds: XCTestCase {
         let data = try JSONEncoder().encode(decision)
         let json = try JSONSerialization.jsonObject(with: data, options: .allowFragments) as! [String: Any]
 
-        // JSONSerialization surfaces JSON `null` as `NSNull`. Verify the key is
-        // PRESENT with an explicit null (not omitted by encodeIfPresent).
+        // JSONSerialization surfaces JSON `null` as `NSNull`. The key must be
+        // present with explicit null (not omitted).
         XCTAssertTrue(json.keys.contains("variation_id"),
                       "variation_id must be present in the JSON payload")
         XCTAssertTrue(json["variation_id"] is NSNull,
                       "variation_id must serialize as explicit JSON null when nil")
 
-        // Sanity-check other fields are unchanged.
         XCTAssertEqual(json["campaign_id"] as? String, "12345")
         XCTAssertEqual(json["experiment_id"] as? String, "67890")
     }
@@ -272,7 +246,7 @@ class BatchEventBuilderTests_HoldoutIds: XCTestCase {
         XCTAssertFalse(json["variation_id"] is NSNull)
     }
 
-    // MARK: - Impression event entity_id (FR-009 / SC-006)
+    // MARK: - Impression event entity_id
 
     /// End-to-end: a holdout impression event has an empty source `layerId`,
     /// so both `decisions[0].campaign_id` AND `events[0].entity_id` must fall
@@ -280,7 +254,7 @@ class BatchEventBuilderTests_HoldoutIds: XCTestCase {
     func testImpressionEvent_holdout_entityIdMirrorsNormalizedCampaignId() throws {
         let datafile = OTUtils.loadJSONDatafile("api_datafile")!
         let eventDispatcher = MockEventDispatcher()
-        var optimizely: OptimizelyClient! = OptimizelyClient(sdkKey: "fssdk_12813_entity_id",
+        var optimizely: OptimizelyClient! = OptimizelyClient(sdkKey: "holdout_entity_id_test",
                                                              eventDispatcher: eventDispatcher)
         defer {
             optimizely?.close()
@@ -288,9 +262,7 @@ class BatchEventBuilderTests_HoldoutIds: XCTestCase {
         }
         try optimizely.start(datafile: datafile)
 
-        // Holdout struct defaults layerId to "" (see Holdout.swift) — the
-        // canonical case this fix targets. id is the fallback used by both
-        // campaign_id (FR-002) and entity_id (FR-009).
+        // Holdout defaults layerId to "" — the canonical case this targets.
         let holdoutJSON: [String: Any] = [
             "status": "Running",
             "id": "holdout_4444444",
@@ -325,29 +297,20 @@ class BatchEventBuilderTests_HoldoutIds: XCTestCase {
         let campaignId = decision["campaign_id"] as? String
         let entityId = dispatchEvent["entity_id"] as? String
 
-        // FR-002: campaign_id falls back to experiment_id (holdout.id).
         XCTAssertEqual(campaignId, holdout.id,
                        "campaign_id must fall back to holdout.id when layerId is empty")
-        // FR-009: entity_id falls back the same way.
         XCTAssertEqual(entityId, holdout.id,
                        "entity_id must fall back to holdout.id when layerId is empty")
-        // SC-006: the two fields share source + fallback; they must never diverge.
+        // entity_id mirrors normalized campaign_id; they must never diverge.
         XCTAssertEqual(campaignId, entityId,
                        "campaign_id and entity_id must hold the same normalized value")
     }
 
-    /// FSSDK-12834: under the relaxed campaign_id contract, an opaque
-    /// non-numeric source value (e.g. `"layer_abc123"`) passes through
-    /// `normalizeDecisionIds` unchanged. Together with the existing holdout
-    /// end-to-end test above (which exercises the empty-layerId fallback
-    /// path), this covers both branches of FR-001 / FR-002 for
-    /// `campaign_id` and, via FR-009, for `events[].entity_id`.
+    /// Opaque non-numeric source passes through normalization unchanged.
+    /// entity_id is assigned from the normalized campaign_id in
+    /// createImpressionEvent, so proving campaign_id passthrough also proves
+    /// entity_id passthrough on the wire.
     func testNormalize_opaqueLayerIdPassesThroughForBothCampaignAndEntity() {
-        // Production wiring (see BatchEventBuilder.createImpressionEvent):
-        // events[].entity_id is assigned the same value as decisions[].campaign_id
-        // AFTER normalization. Therefore proving the normalized value is the
-        // opaque source is sufficient to prove entity_id is also the opaque
-        // source on the wire (SC-006 invariant: the two must be byte-equal).
         let opaqueLayerId = "layer_abc123"
         let (campaignId, variationId) = BatchEventBuilder.normalizeDecisionIds(
             rawCampaignId: opaqueLayerId,

--- a/Tests/OptimizelyTests-Common/BatchEventBuilderTests_HoldoutIds.swift
+++ b/Tests/OptimizelyTests-Common/BatchEventBuilderTests_HoldoutIds.swift
@@ -14,16 +14,48 @@
 // limitations under the License.
 //
 
-// Tests for FSSDK-12813: every decision event (experiment, feature test,
-// rollout, or holdout) must carry a valid numeric `campaign_id` (falling back
-// to `experiment_id` if invalid) and either a valid numeric `variation_id` or
-// JSON `null`. The normalization is uniform across decision types per FR-005.
+// Tests for FSSDK-12813 (P1) + FSSDK-12834 (P2): every decision event
+// (experiment, feature test, rollout, or holdout) must carry:
+//   - `campaign_id` (and the mirrored `events[].entity_id`, FR-009) as any
+//     non-empty string — numeric OR opaque (e.g. `"default-12345"`,
+//     `"layer_abc"`). Fallback to `experiment_id` fires only on empty /
+//     whitespace-only / null source values. (FR-001 / FR-002)
+//   - `variation_id` as a decimal-digit string OR explicit JSON `null`.
+//     Non-numeric strings normalize to null. (FR-003 / FR-004)
+// The normalization is uniform across decision types per FR-005.
 
 import XCTest
 
 class BatchEventBuilderTests_HoldoutIds: XCTestCase {
 
-    // MARK: - isValidNumericIdString
+    // MARK: - isValidStringId (FR-001: relaxed contract for campaign_id / entity_id)
+
+    func testIsValidStringId_nonEmptyContent() {
+        // Any non-empty string with at least one non-whitespace character is
+        // valid — numeric, opaque, or mixed. This is the relaxed P2 contract.
+        XCTAssertTrue(BatchEventBuilder.isValidStringId("12345"))
+        XCTAssertTrue(BatchEventBuilder.isValidStringId("default-12345"))
+        XCTAssertTrue(BatchEventBuilder.isValidStringId("layer_abc"))
+        XCTAssertTrue(BatchEventBuilder.isValidStringId("a"))
+        XCTAssertTrue(BatchEventBuilder.isValidStringId("0"))
+        XCTAssertTrue(BatchEventBuilder.isValidStringId("not_a_number"))
+        // Non-ASCII content is accepted — campaign_id has no character set
+        // restriction (unlike variation_id).
+        XCTAssertTrue(BatchEventBuilder.isValidStringId("\u{0660}\u{0661}"))
+    }
+
+    func testIsValidStringId_emptyOrWhitespaceOnly() {
+        // Empty and whitespace-only strings are treated as invalid and
+        // trigger the experiment_id fallback (FR-002).
+        XCTAssertFalse(BatchEventBuilder.isValidStringId(""))
+        XCTAssertFalse(BatchEventBuilder.isValidStringId(" "))
+        XCTAssertFalse(BatchEventBuilder.isValidStringId("   "))
+        XCTAssertFalse(BatchEventBuilder.isValidStringId("\t"))
+        XCTAssertFalse(BatchEventBuilder.isValidStringId("\n"))
+        XCTAssertFalse(BatchEventBuilder.isValidStringId(" \t\n "))
+    }
+
+    // MARK: - isValidNumericIdString (FR-003: stricter contract for variation_id)
 
     func testIsValidNumericIdString_validDigits() {
         XCTAssertTrue(BatchEventBuilder.isValidNumericIdString("12345"))
@@ -79,6 +111,8 @@ class BatchEventBuilderTests_HoldoutIds: XCTestCase {
     // MARK: - normalizeDecisionIds — campaign_id (FR-001/FR-002) applied uniformly
 
     func testNormalize_emptyCampaignFallsBackToExperimentId() {
+        // FR-002: empty source value triggers the experiment_id fallback.
+        // This is the canonical holdout case (layerId defaults to "").
         let (campaign, _) = BatchEventBuilder.normalizeDecisionIds(
             rawCampaignId: "",
             rawVariationId: "777",
@@ -86,7 +120,9 @@ class BatchEventBuilderTests_HoldoutIds: XCTestCase {
         XCTAssertEqual(campaign, "exp_42")
     }
 
-    func testNormalize_whitespaceCampaignFallsBackToExperimentId() {
+    func testNormalize_whitespaceOnlyCampaignFallsBackToExperimentId() {
+        // FSSDK-12834: whitespace-only strings are treated as empty per the
+        // defensive normalization in isValidStringId and fall back.
         let (campaign, _) = BatchEventBuilder.normalizeDecisionIds(
             rawCampaignId: "   ",
             rawVariationId: "777",
@@ -94,12 +130,36 @@ class BatchEventBuilderTests_HoldoutIds: XCTestCase {
         XCTAssertEqual(campaign, "exp_42")
     }
 
-    func testNormalize_nonNumericCampaignFallsBackToExperimentId() {
+    func testNormalize_opaqueCampaignPassesThroughUnchanged() {
+        // FSSDK-12834 (FR-001): an opaque non-numeric string is a valid
+        // campaign_id under the relaxed P2 contract and MUST pass through
+        // unchanged — no fallback to experiment_id.
+        let (campaign, _) = BatchEventBuilder.normalizeDecisionIds(
+            rawCampaignId: "default-12345",
+            rawVariationId: "777",
+            experimentId: "exp_42")
+        XCTAssertEqual(campaign, "default-12345")
+    }
+
+    func testNormalize_nonNumericCampaignPassesThroughUnchanged() {
+        // FSSDK-12834 (FR-001): any non-empty string passes through; only
+        // empty/null source values trigger the fallback. This assertion was
+        // inverted under P1 (digits-only) and is corrected here for P2.
         let (campaign, _) = BatchEventBuilder.normalizeDecisionIds(
             rawCampaignId: "not_a_number",
             rawVariationId: "777",
             experimentId: "exp_42")
-        XCTAssertEqual(campaign, "exp_42")
+        XCTAssertEqual(campaign, "not_a_number")
+    }
+
+    func testNormalize_opaquePrefixedLayerIdPassesThroughUnchanged() {
+        // FSSDK-12834 (FR-001): typical opaque layerId shape like
+        // "layer_abc123" must pass through unchanged.
+        let (campaign, _) = BatchEventBuilder.normalizeDecisionIds(
+            rawCampaignId: "layer_abc123",
+            rawVariationId: "777",
+            experimentId: "exp_42")
+        XCTAssertEqual(campaign, "layer_abc123")
     }
 
     func testNormalize_validNumericCampaignKept() {
@@ -274,5 +334,28 @@ class BatchEventBuilderTests_HoldoutIds: XCTestCase {
         // SC-006: the two fields share source + fallback; they must never diverge.
         XCTAssertEqual(campaignId, entityId,
                        "campaign_id and entity_id must hold the same normalized value")
+    }
+
+    /// FSSDK-12834: under the relaxed campaign_id contract, an opaque
+    /// non-numeric source value (e.g. `"layer_abc123"`) passes through
+    /// `normalizeDecisionIds` unchanged. Together with the existing holdout
+    /// end-to-end test above (which exercises the empty-layerId fallback
+    /// path), this covers both branches of FR-001 / FR-002 for
+    /// `campaign_id` and, via FR-009, for `events[].entity_id`.
+    func testNormalize_opaqueLayerIdPassesThroughForBothCampaignAndEntity() {
+        // Production wiring (see BatchEventBuilder.createImpressionEvent):
+        // events[].entity_id is assigned the same value as decisions[].campaign_id
+        // AFTER normalization. Therefore proving the normalized value is the
+        // opaque source is sufficient to prove entity_id is also the opaque
+        // source on the wire (SC-006 invariant: the two must be byte-equal).
+        let opaqueLayerId = "layer_abc123"
+        let (campaignId, variationId) = BatchEventBuilder.normalizeDecisionIds(
+            rawCampaignId: opaqueLayerId,
+            rawVariationId: "777",
+            experimentId: "exp_999")
+        XCTAssertEqual(campaignId, opaqueLayerId,
+                       "opaque layerId must pass through to campaign_id unchanged")
+        XCTAssertEqual(variationId, "777",
+                       "valid numeric variation_id must pass through unchanged")
     }
 }

--- a/Tests/OptimizelyTests-Common/DecisionListenerTest_Holdouts.swift
+++ b/Tests/OptimizelyTests-Common/DecisionListenerTest_Holdouts.swift
@@ -39,10 +39,13 @@ class DecisionListenerTests_Holdouts: XCTestCase {
     let kVariableValueDouble = 4.2
     let kVariableValueBool = true
     
-    // FSSDK-12813: holdout fixture uses numeric-string IDs so the post-fix
-    // event-id normalization is a no-op for the happy-path decision-listener
-    // tests below. Per spec FR-011, every pre-existing test that builds an
-    // event payload must use valid decimal-digit string IDs.
+    // FSSDK-12813: holdout fixture uses valid IDs so the post-fix event-id
+    // normalization is a no-op for the happy-path decision-listener tests
+    // below. `campaign_id` / `entity_id` accept any non-empty string, while
+    // `variation_id` retains the decimal-digit-only contract. Per FR-011 the
+    // variation `id` (and the matching `trafficAllocation[].entityId`) must
+    // be a numeric string; numeric strings are used for the holdout `id` too
+    // to keep the fixture uniform.
     var sampleHoldout: [String: Any] {
         return [
             "status": "Running",

--- a/Tests/OptimizelyTests-Common/DecisionListenerTest_Holdouts.swift
+++ b/Tests/OptimizelyTests-Common/DecisionListenerTest_Holdouts.swift
@@ -39,13 +39,9 @@ class DecisionListenerTests_Holdouts: XCTestCase {
     let kVariableValueDouble = 4.2
     let kVariableValueBool = true
     
-    // FSSDK-12813: holdout fixture uses valid IDs so the post-fix event-id
-    // normalization is a no-op for the happy-path decision-listener tests
-    // below. `campaign_id` / `entity_id` accept any non-empty string, while
-    // `variation_id` retains the decimal-digit-only contract. Per FR-011 the
-    // variation `id` (and the matching `trafficAllocation[].entityId`) must
-    // be a numeric string; numeric strings are used for the holdout `id` too
-    // to keep the fixture uniform.
+    // variation id and trafficAllocation entityId must be numeric strings
+    // (variation_id contract). Holdout id uses numeric too for fixture
+    // uniformity, though any non-empty string would satisfy campaign_id.
     var sampleHoldout: [String: Any] {
         return [
             "status": "Running",

--- a/Tests/OptimizelyTests-Common/DecisionListenerTest_Holdouts.swift
+++ b/Tests/OptimizelyTests-Common/DecisionListenerTest_Holdouts.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2022, Optimizely, Inc. and contributors 
+// Copyright 2022, 2026, Optimizely, Inc. and contributors
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");  
 // you may not use this file except in compliance with the License.
@@ -39,20 +39,24 @@ class DecisionListenerTests_Holdouts: XCTestCase {
     let kVariableValueDouble = 4.2
     let kVariableValueBool = true
     
+    // FSSDK-12813: holdout fixture uses numeric-string IDs so the post-fix
+    // event-id normalization is a no-op for the happy-path decision-listener
+    // tests below. Per spec FR-011, every pre-existing test that builds an
+    // event payload must use valid decimal-digit string IDs.
     var sampleHoldout: [String: Any] {
         return [
             "status": "Running",
-            "id": "id_holdout",
+            "id": "9999900001",
             "key": "key_holdout",
             "layerId": "10420273888",
             "trafficAllocation": [
-                ["entityId": "id_holdout_variation", "endOfRange": 500]
+                ["entityId": "9999900002", "endOfRange": 500]
             ],
             "audienceIds": [],
             "variations": [
                 [
                     "variables": [],
-                    "id": "id_holdout_variation",
+                    "id": "9999900002",
                     "key": "key_holdout_variation"
                 ]
             ]

--- a/Tests/OptimizelyTests-Common/DecisionServiceTests_LocalHoldouts.swift
+++ b/Tests/OptimizelyTests-Common/DecisionServiceTests_LocalHoldouts.swift
@@ -30,15 +30,8 @@ class DecisionServiceTests_LocalHoldouts: XCTestCase {
     let experimentRuleId = "10390977673"  // From decide_datafile
     let deliveryRuleId = "3332020515"     // From decide_datafile rollout
 
-    // FSSDK-12813: holdout fixture uses valid IDs so any event payload that
-    // downstream tests dispatch from this decision carries pipeline-valid
-    // values and the post-fix normalization is a no-op. `campaign_id` /
-    // `entity_id` accept any non-empty string; `variation_id` retains the
-    // decimal-digit-only contract. Per FR-011 the variation `id` (and the
-    // matching `trafficAllocation[].entityId`) must be a numeric string;
-    // numeric strings are used for the holdout `id` too to keep the fixture
-    // uniform. Keys (`holdout_test_key`, `holdout_variation_key`) are
-    // arbitrary identifiers and are left as descriptive strings.
+    // variation id and trafficAllocation entityId must be numeric strings.
+    // Holdout id uses numeric too for fixture uniformity. Keys are arbitrary.
     var sampleHoldout: [String: Any] {
         return [
             "status": "Running",

--- a/Tests/OptimizelyTests-Common/DecisionServiceTests_LocalHoldouts.swift
+++ b/Tests/OptimizelyTests-Common/DecisionServiceTests_LocalHoldouts.swift
@@ -30,13 +30,15 @@ class DecisionServiceTests_LocalHoldouts: XCTestCase {
     let experimentRuleId = "10390977673"  // From decide_datafile
     let deliveryRuleId = "3332020515"     // From decide_datafile rollout
 
-    // FSSDK-12813: holdout fixture uses numeric-string IDs so any event
-    // payload that downstream tests dispatch from this decision carries
-    // pipeline-valid IDs and the post-fix normalization is a no-op. Per
-    // spec FR-011, every pre-existing test that builds an event payload
-    // must use valid decimal-digit string IDs. Keys (`holdout_test_key`,
-    // `holdout_variation_key`) are arbitrary identifiers and are left as
-    // descriptive strings.
+    // FSSDK-12813: holdout fixture uses valid IDs so any event payload that
+    // downstream tests dispatch from this decision carries pipeline-valid
+    // values and the post-fix normalization is a no-op. `campaign_id` /
+    // `entity_id` accept any non-empty string; `variation_id` retains the
+    // decimal-digit-only contract. Per FR-011 the variation `id` (and the
+    // matching `trafficAllocation[].entityId`) must be a numeric string;
+    // numeric strings are used for the holdout `id` too to keep the fixture
+    // uniform. Keys (`holdout_test_key`, `holdout_variation_key`) are
+    // arbitrary identifiers and are left as descriptive strings.
     var sampleHoldout: [String: Any] {
         return [
             "status": "Running",

--- a/Tests/OptimizelyTests-Common/DecisionServiceTests_LocalHoldouts.swift
+++ b/Tests/OptimizelyTests-Common/DecisionServiceTests_LocalHoldouts.swift
@@ -30,19 +30,26 @@ class DecisionServiceTests_LocalHoldouts: XCTestCase {
     let experimentRuleId = "10390977673"  // From decide_datafile
     let deliveryRuleId = "3332020515"     // From decide_datafile rollout
 
+    // FSSDK-12813: holdout fixture uses numeric-string IDs so any event
+    // payload that downstream tests dispatch from this decision carries
+    // pipeline-valid IDs and the post-fix normalization is a no-op. Per
+    // spec FR-011, every pre-existing test that builds an event payload
+    // must use valid decimal-digit string IDs. Keys (`holdout_test_key`,
+    // `holdout_variation_key`) are arbitrary identifiers and are left as
+    // descriptive strings.
     var sampleHoldout: [String: Any] {
         return [
             "status": "Running",
-            "id": "holdout_test_id",
+            "id": "9999900010",
             "key": "holdout_test_key",
             "trafficAllocation": [
-                ["entityId": "holdout_variation_id", "endOfRange": 5000] // 50% traffic
+                ["entityId": "9999900020", "endOfRange": 5000] // 50% traffic
             ],
             "audienceIds": [],
             "variations": [
                 [
                     "variables": [],
-                    "id": "holdout_variation_id",
+                    "id": "9999900020",
                     "key": "holdout_variation_key",
                     "featureEnabled": false
                 ]

--- a/Tests/OptimizelyTests-Common/OptimizelyUserContextTests_Decide_Holdouts.swift
+++ b/Tests/OptimizelyTests-Common/OptimizelyUserContextTests_Decide_Holdouts.swift
@@ -24,14 +24,16 @@ class OptimizelyUserContextTests_Decide_Holdouts: XCTestCase {
     var kAttributesCountryMatch: [String: Any] = ["country": "US"]
     var kAttributesCountryNotMatch: [String: Any] = ["country": "ca"]
     
-    // FSSDK-12813: holdout fixture uses numeric-string IDs so the post-fix
-    // event-id normalization (campaign_id falls back to experiment_id when
-    // layerId is invalid; variation_id becomes JSON null when invalid) is a
-    // no-op for the happy-path decide-API tests below. Per spec FR-011, every
-    // pre-existing test that builds an event payload must use valid
-    // decimal-digit string IDs. These tests exercise the decide() API surface
-    // (variationKey / ruleKey / metadata), not the invalid-id path, so the
-    // IDs are now realistic numeric strings.
+    // FSSDK-12813: holdout fixture uses valid IDs so the post-fix event-id
+    // normalization is a no-op for the happy-path decide-API tests below.
+    // `campaign_id` and `entity_id` accept any non-empty string (fallback to
+    // `experiment_id` only when empty/null/missing); `variation_id` retains
+    // the decimal-digit-only contract (anything else normalizes to JSON null).
+    // Per FR-011 the variation `id` (and the matching
+    // `trafficAllocation[].entityId`) must be a numeric string; numeric
+    // strings are used for the holdout `id` too to keep the fixture uniform.
+    // These tests exercise the decide() API surface (variationKey / ruleKey /
+    // metadata), not the invalid-id path.
     var sampleHoldout: [String: Any] {
         return [
             "status": "Running",
@@ -500,10 +502,12 @@ extension OptimizelyUserContextTests_Decide_Holdouts {
         let desc = eventSent.description
         XCTAssert(desc.contains("campaign_activated"))
         
-        // FSSDK-12813: sampleHoldout now uses numeric-string IDs ("9999900001"
-        // for the holdout id, "9999900002" for the variation), so the
-        // post-fix normalization is a no-op here and variation_id is emitted
-        // as a numeric string rather than JSON null.
+        // FSSDK-12813: sampleHoldout now uses valid numeric IDs ("9999900001"
+        // for the holdout id, "9999900002" for the variation), so the post-fix
+        // normalization is a no-op here. variation_id retains the decimal-
+        // digit-only contract and is emitted as a numeric string (rather than
+        // JSON null, which would be the result under the prior non-numeric
+        // placeholder).
         XCTAssertEqual(eventDecision.experimentID, "9999900001")
         XCTAssertEqual(eventDecision.variationID, "9999900002")
         

--- a/Tests/OptimizelyTests-Common/OptimizelyUserContextTests_Decide_Holdouts.swift
+++ b/Tests/OptimizelyTests-Common/OptimizelyUserContextTests_Decide_Holdouts.swift
@@ -24,16 +24,9 @@ class OptimizelyUserContextTests_Decide_Holdouts: XCTestCase {
     var kAttributesCountryMatch: [String: Any] = ["country": "US"]
     var kAttributesCountryNotMatch: [String: Any] = ["country": "ca"]
     
-    // FSSDK-12813: holdout fixture uses valid IDs so the post-fix event-id
-    // normalization is a no-op for the happy-path decide-API tests below.
-    // `campaign_id` and `entity_id` accept any non-empty string (fallback to
-    // `experiment_id` only when empty/null/missing); `variation_id` retains
-    // the decimal-digit-only contract (anything else normalizes to JSON null).
-    // Per FR-011 the variation `id` (and the matching
-    // `trafficAllocation[].entityId`) must be a numeric string; numeric
-    // strings are used for the holdout `id` too to keep the fixture uniform.
-    // These tests exercise the decide() API surface (variationKey / ruleKey /
-    // metadata), not the invalid-id path.
+    // variation id and trafficAllocation entityId must be numeric strings.
+    // Holdout id uses numeric too for fixture uniformity. These tests
+    // exercise the decide() API surface, not the invalid-id path.
     var sampleHoldout: [String: Any] {
         return [
             "status": "Running",
@@ -502,12 +495,7 @@ extension OptimizelyUserContextTests_Decide_Holdouts {
         let desc = eventSent.description
         XCTAssert(desc.contains("campaign_activated"))
         
-        // FSSDK-12813: sampleHoldout now uses valid numeric IDs ("9999900001"
-        // for the holdout id, "9999900002" for the variation), so the post-fix
-        // normalization is a no-op here. variation_id retains the decimal-
-        // digit-only contract and is emitted as a numeric string (rather than
-        // JSON null, which would be the result under the prior non-numeric
-        // placeholder).
+        // Numeric variation id is emitted unchanged (not JSON null).
         XCTAssertEqual(eventDecision.experimentID, "9999900001")
         XCTAssertEqual(eventDecision.variationID, "9999900002")
         

--- a/Tests/OptimizelyTests-Common/OptimizelyUserContextTests_Decide_Holdouts.swift
+++ b/Tests/OptimizelyTests-Common/OptimizelyUserContextTests_Decide_Holdouts.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2022, Optimizely, Inc. and contributors 
+// Copyright 2022, 2026, Optimizely, Inc. and contributors
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");  
 // you may not use this file except in compliance with the License.
@@ -24,19 +24,27 @@ class OptimizelyUserContextTests_Decide_Holdouts: XCTestCase {
     var kAttributesCountryMatch: [String: Any] = ["country": "US"]
     var kAttributesCountryNotMatch: [String: Any] = ["country": "ca"]
     
+    // FSSDK-12813: holdout fixture uses numeric-string IDs so the post-fix
+    // event-id normalization (campaign_id falls back to experiment_id when
+    // layerId is invalid; variation_id becomes JSON null when invalid) is a
+    // no-op for the happy-path decide-API tests below. Per spec FR-011, every
+    // pre-existing test that builds an event payload must use valid
+    // decimal-digit string IDs. These tests exercise the decide() API surface
+    // (variationKey / ruleKey / metadata), not the invalid-id path, so the
+    // IDs are now realistic numeric strings.
     var sampleHoldout: [String: Any] {
         return [
             "status": "Running",
-            "id": "id_holdout",
+            "id": "9999900001",
             "key": "key_holdout",
             "trafficAllocation": [
-                ["entityId": "id_holdout_variation", "endOfRange": 500]
+                ["entityId": "9999900002", "endOfRange": 500]
             ],
             "audienceIds": [],
             "variations": [
                 [
                     "variables": [],
-                    "id": "id_holdout_variation",
+                    "id": "9999900002",
                     "key": "key_holdout_variation"
                 ]
             ]
@@ -492,8 +500,12 @@ extension OptimizelyUserContextTests_Decide_Holdouts {
         let desc = eventSent.description
         XCTAssert(desc.contains("campaign_activated"))
         
-        XCTAssertEqual(eventDecision.experimentID, "id_holdout")
-        XCTAssertNil(eventDecision.variationID)
+        // FSSDK-12813: sampleHoldout now uses numeric-string IDs ("9999900001"
+        // for the holdout id, "9999900002" for the variation), so the
+        // post-fix normalization is a no-op here and variation_id is emitted
+        // as a numeric string rather than JSON null.
+        XCTAssertEqual(eventDecision.experimentID, "9999900001")
+        XCTAssertEqual(eventDecision.variationID, "9999900002")
         
         XCTAssertEqual(metadata.flagKey, "feature_2")
         XCTAssertEqual(metadata.ruleKey, "key_holdout")

--- a/Tests/OptimizelyTests-Common/OptimizelyUserContextTests_Decide_With_Holdouts_Reasons.swift
+++ b/Tests/OptimizelyTests-Common/OptimizelyUserContextTests_Decide_With_Holdouts_Reasons.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2022, Optimizely, Inc. and contributors 
+// Copyright 2022, 2026, Optimizely, Inc. and contributors
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");  
 // you may not use this file except in compliance with the License.
@@ -23,19 +23,25 @@ class OptimizelyUserContextTests_Decide_With_Holdouts_Reasons: XCTestCase {
     var kAttributesCountryMatch: [String: Any] = ["country": "US"]
     var kAttributesCountryNotMatch: [String: Any] = ["country": "ca"]
     
+    // FSSDK-12813: holdout fixture uses numeric-string IDs so the post-fix
+    // event-id normalization (campaign_id falls back to experiment_id when
+    // layerId is invalid; variation_id becomes JSON null when invalid) is a
+    // no-op for the happy-path decide-reasons tests below. Per spec FR-011,
+    // every pre-existing test that builds an event payload must use valid
+    // decimal-digit string IDs.
     var sampleHoldout: [String: Any] {
         return [
             "status": "Running",
-            "id": "id_holdout",
+            "id": "9999900001",
             "key": "key_holdout",
             "trafficAllocation": [
-                ["entityId": "id_holdout_variation", "endOfRange": 500]
+                ["entityId": "9999900002", "endOfRange": 500]
             ],
             "audienceIds": [],
             "variations": [
                 [
                     "variables": [],
-                    "id": "id_holdout_variation",
+                    "id": "9999900002",
                     "key": "key_holdout_variation"
                 ]
             ]
@@ -103,7 +109,7 @@ class OptimizelyUserContextTests_Decide_With_Holdouts_Reasons: XCTestCase {
         let featureId_2 = "4482920078"
         
         var holdout2 = holdout1
-        holdout2.id = "id_holdout_2"
+        holdout2.id = "9999900003"  // FSSDK-12813: numeric-string ID
         holdout2.key = "key_holdout_2"
         
         // Local holdout with 10% traffic (excludes feature_2 by targeting no rules)

--- a/Tests/OptimizelyTests-Common/OptimizelyUserContextTests_Decide_With_Holdouts_Reasons.swift
+++ b/Tests/OptimizelyTests-Common/OptimizelyUserContextTests_Decide_With_Holdouts_Reasons.swift
@@ -23,12 +23,14 @@ class OptimizelyUserContextTests_Decide_With_Holdouts_Reasons: XCTestCase {
     var kAttributesCountryMatch: [String: Any] = ["country": "US"]
     var kAttributesCountryNotMatch: [String: Any] = ["country": "ca"]
     
-    // FSSDK-12813: holdout fixture uses numeric-string IDs so the post-fix
-    // event-id normalization (campaign_id falls back to experiment_id when
-    // layerId is invalid; variation_id becomes JSON null when invalid) is a
-    // no-op for the happy-path decide-reasons tests below. Per spec FR-011,
-    // every pre-existing test that builds an event payload must use valid
-    // decimal-digit string IDs.
+    // FSSDK-12813: holdout fixture uses valid IDs so the post-fix event-id
+    // normalization is a no-op for the happy-path decide-reasons tests below.
+    // `campaign_id` and `entity_id` accept any non-empty string (fallback to
+    // `experiment_id` only when empty/null/missing); `variation_id` retains
+    // the decimal-digit-only contract. Per FR-011 the variation `id` (and the
+    // matching `trafficAllocation[].entityId`) must be a numeric string;
+    // numeric strings are used for the holdout `id` too to keep the fixture
+    // uniform.
     var sampleHoldout: [String: Any] {
         return [
             "status": "Running",

--- a/Tests/OptimizelyTests-Common/OptimizelyUserContextTests_Decide_With_Holdouts_Reasons.swift
+++ b/Tests/OptimizelyTests-Common/OptimizelyUserContextTests_Decide_With_Holdouts_Reasons.swift
@@ -23,14 +23,8 @@ class OptimizelyUserContextTests_Decide_With_Holdouts_Reasons: XCTestCase {
     var kAttributesCountryMatch: [String: Any] = ["country": "US"]
     var kAttributesCountryNotMatch: [String: Any] = ["country": "ca"]
     
-    // FSSDK-12813: holdout fixture uses valid IDs so the post-fix event-id
-    // normalization is a no-op for the happy-path decide-reasons tests below.
-    // `campaign_id` and `entity_id` accept any non-empty string (fallback to
-    // `experiment_id` only when empty/null/missing); `variation_id` retains
-    // the decimal-digit-only contract. Per FR-011 the variation `id` (and the
-    // matching `trafficAllocation[].entityId`) must be a numeric string;
-    // numeric strings are used for the holdout `id` too to keep the fixture
-    // uniform.
+    // variation id and trafficAllocation entityId must be numeric strings.
+    // Holdout id uses numeric too for fixture uniformity.
     var sampleHoldout: [String: Any] {
         return [
             "status": "Running",
@@ -111,7 +105,7 @@ class OptimizelyUserContextTests_Decide_With_Holdouts_Reasons: XCTestCase {
         let featureId_2 = "4482920078"
         
         var holdout2 = holdout1
-        holdout2.id = "9999900003"  // FSSDK-12813: numeric-string ID
+        holdout2.id = "9999900003"
         holdout2.key = "key_holdout_2"
         
         // Local holdout with 10% traffic (excludes feature_2 by targeting no rules)


### PR DESCRIPTION
## Summary
Per FR-011 / SC-007 of the decision-event ID normalization spec, every pre-existing test that constructs an event payload must use valid decimal-digit string IDs. Non-numeric holdout placeholders implicitly relied on the pre-fix pass-through behavior and would either silently change their on-the-wire output after the normalization landed or assert the wrong thing.

## Changes
- Replace non-numeric holdout `id`, variation `id`, and trafficAllocation `entityId` placeholders with numeric-string IDs across all holdout-related test fixtures whose tests dispatch impression events (BatchEventBuilder, DecisionListener, decide-API, decide-reasons, local-holdout suites).
- Update the one event-level assertion that previously expected the non-numeric placeholder to fall through, so it now asserts the realistic numeric IDs and a numeric `variation_id` (matching the post-fix happy-path normalization).
- Leave the dedicated invalid-input-path tests in `BatchEventBuilderTests_HoldoutIds.swift` and the no-dispatch `DecisionServiceTests_Holdouts.swift` fixtures unchanged — the former intentionally exercises the fallback contract, the latter never reaches the event builder.

## Jira Ticket
[FSSDK-12834](https://optimizely-ext.atlassian.net/browse/FSSDK-12834)

[FSSDK-12834]: https://optimizely-ext.atlassian.net/browse/FSSDK-12834?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ