### PR TITLE
[FSSDK-12729] fix: prevent EXC_BAD_ACCESS from premature URLSession deallocation

### DIFF
--- a/Sources/Customization/DefaultDatafileHandler.swift
+++ b/Sources/Customization/DefaultDatafileHandler.swift
@@ -71,6 +71,9 @@ open class DefaultDatafileHandler: OPTDatafileHandler {
             let session = self.getSession(resourceTimeoutInterval: resourceTimeoutInterval)
 
             guard let request = self.getRequest(sdkKey: sdkKey) else {
+                let optError = OptimizelyError.datafileDownloadFailed("Invalid URL for sdkKey: \(sdkKey)")
+                self.logger.e(optError)
+                completionHandler(.failure(optError))
                 session.finishTasksAndInvalidate()
                 return
             }

--- a/Sources/Customization/DefaultDatafileHandler.swift
+++ b/Sources/Customization/DefaultDatafileHandler.swift
@@ -69,14 +69,15 @@ open class DefaultDatafileHandler: OPTDatafileHandler {
             }
             
             let session = self.getSession(resourceTimeoutInterval: resourceTimeoutInterval)
-            // without this the URLSession will leak, see docs on URLSession and https://stackoverflow.com/questions/67318867
-            defer { session.finishTasksAndInvalidate() }
-            
-            guard let request = self.getRequest(sdkKey: sdkKey) else { return }
-            
+
+            guard let request = self.getRequest(sdkKey: sdkKey) else {
+                session.finishTasksAndInvalidate()
+                return
+            }
+
             let task = session.downloadTask(with: request) { (url, response, error) in
                 var result = OptimizelyResult<Data?>.failure(.generic)
-                
+
                 if error != nil {
                     let optError = OptimizelyError.datafileDownloadFailed(error.debugDescription)
                     self.logger.e(optError)
@@ -91,7 +92,7 @@ open class DefaultDatafileHandler: OPTDatafileHandler {
                         }
                     case 304:
                         self.logger.d("The datafile was not modified and won't be downloaded again")
-                        
+
                         if returnCacheIfNoChange {
                             result = returnCached()
                         } else {
@@ -102,10 +103,11 @@ open class DefaultDatafileHandler: OPTDatafileHandler {
                         result = returnCached() // error recovery
                     }
                 }
-                
+
                 self.reachability.updateNumContiguousFails(isError: (error != nil))
-                
+
                 completionHandler(result)
+                session.finishTasksAndInvalidate()
             }
             
             task.resume()

--- a/Sources/Customization/DefaultEventDispatcher.swift
+++ b/Sources/Customization/DefaultEventDispatcher.swift
@@ -225,25 +225,24 @@ open class DefaultEventDispatcher: BackgroundingCallbacks, OPTEventDispatcher {
         }
         
         let session = getSession()
-        // without this the URLSession will leak, see docs on URLSession and https://stackoverflow.com/questions/67318867
-        defer { session.finishTasksAndInvalidate() }
-        
+
         var request = URLRequest(url: event.url)
         request.httpMethod = "POST"
         request.addValue("application/json", forHTTPHeaderField: "Content-Type")
-        
+
         // send notification BEFORE sending event to the server
         NotificationCenter.default.post(name: .willSendOptimizelyEvents, object: event)
 
-        let task = session.uploadTask(with: request, from: event.body) { (_, _, error) in            
+        let task = session.uploadTask(with: request, from: event.body) { (_, _, error) in
             if let error = error {
                 completionHandler(.failure(.eventDispatchFailed(error.localizedDescription)))
             } else {
                 self.logger.d("Event Sent")
                 completionHandler(.success(event.body))
             }
-            
+
             self.reachability.updateNumContiguousFails(isError: (error != nil))
+            session.finishTasksAndInvalidate()
         }
         
         task.resume()

--- a/Sources/ODP/OdpEventApiManager.swift
+++ b/Sources/ODP/OdpEventApiManager.swift
@@ -63,19 +63,18 @@ open class OdpEventApiManager {
         urlRequest.addValue("application/json", forHTTPHeaderField: "content-type")
         
         let session = self.getSession()
-        // without this the URLSession will leak, see docs on URLSession and https://stackoverflow.com/questions/67318867
-        defer { session.finishTasksAndInvalidate() }
 
         let task = session.dataTask(with: urlRequest) { data, response, error in
             var errMessage: String?
             var canRetry: Bool = true
-            
+
             defer {
                 if let errMessage = errMessage {
                     completionHandler(.odpEventFailed(errMessage, canRetry))
                 } else {
                     completionHandler(nil)
                 }
+                session.finishTasksAndInvalidate()
             }
             
             if let error = error {

--- a/Sources/ODP/OdpSegmentApiManager.swift
+++ b/Sources/ODP/OdpSegmentApiManager.swift
@@ -129,15 +129,14 @@ open class OdpSegmentApiManager {
         urlRequest.setValue(apiKey, forHTTPHeaderField: "x-api-key")
         
         let session = self.getSession()
-        // without this the URLSession will leak, see docs on URLSession and https://stackoverflow.com/questions/67318867
-        defer { session.finishTasksAndInvalidate() }
 
         let task = session.dataTask(with: urlRequest) { data, response, error in
             var returnError: OptimizelyError?
             var returnSegments: [String]?
-            
+
             defer {
                 completionHandler(returnSegments, returnError)
+                session.finishTasksAndInvalidate()
             }
 
             guard error == nil, let data = data, let response = response as? HTTPURLResponse else {

--- a/Tests/TestUtils/MockUrlSession.swift
+++ b/Tests/TestUtils/MockUrlSession.swift
@@ -23,12 +23,12 @@ import Foundation
 // the cdn url is used to get the datafile if the datafile is not in cache
 class MockUrlSession: URLSession {
     static var validSessions = 0
+    private static let lock = DispatchQueue(label: "mock-session-lock")
     var statusCode: Int
     var withError: Bool
     var localResponseData: String?
     var settingsMap: [String: (Int, Bool)]?
     var handler: MockDatafileHandler?
-    let lock = DispatchQueue(label: "mock-session-lock")
     
     class MockDownloadTask: URLSessionDownloadTask {
         var task: () -> Void
@@ -55,7 +55,7 @@ class MockUrlSession: URLSession {
     }
 
     init(handler: MockDatafileHandler? = nil, statusCode: Int = 0, withError: Bool = false, localResponseData: String? = nil) {
-        lock.sync {
+        Self.lock.sync {
             Self.validSessions += 1
         }
         self.handler = handler
@@ -65,7 +65,7 @@ class MockUrlSession: URLSession {
     }
 
     init(handler: MockDatafileHandler? = nil, settingsMap: [String: (Int, Bool)]) {
-        lock.sync {
+        Self.lock.sync {
             Self.validSessions += 1
         }
         self.handler = handler
@@ -118,7 +118,7 @@ class MockUrlSession: URLSession {
     }
 
     override func finishTasksAndInvalidate() {
-        lock.sync {
+        Self.lock.sync {
             Self.validSessions -= 1
         }
     }

--- a/Tests/TestUtils/MockUrlSession.swift
+++ b/Tests/TestUtils/MockUrlSession.swift
@@ -55,7 +55,7 @@ class MockUrlSession: URLSession {
     }
 
     init(handler: MockDatafileHandler? = nil, statusCode: Int = 0, withError: Bool = false, localResponseData: String? = nil) {
-        lock.async {
+        lock.sync {
             Self.validSessions += 1
         }
         self.handler = handler
@@ -63,9 +63,9 @@ class MockUrlSession: URLSession {
         self.withError = withError
         self.localResponseData = localResponseData
     }
-   
+
     init(handler: MockDatafileHandler? = nil, settingsMap: [String: (Int, Bool)]) {
-        lock.async {
+        lock.sync {
             Self.validSessions += 1
         }
         self.handler = handler
@@ -118,7 +118,7 @@ class MockUrlSession: URLSession {
     }
 
     override func finishTasksAndInvalidate() {
-        lock.async {
+        lock.sync {
             Self.validSessions -= 1
         }
     }


### PR DESCRIPTION
## Summary

- Move `session.finishTasksAndInvalidate()` from `defer` block (synchronous scope exit) into async completion callbacks across all four network modules
- Prevents EXC_BAD_ACCESS crash caused by URLSession being invalidated before the async callback fires
- Particularly impactful when Firebase Performance Monitoring swizzles URLSession delegate methods, widening the race window

## Root Cause

Swift `defer` executes when the enclosing scope exits — which for these methods is *before* the URLSession async callback fires. The session is invalidated while the network request is still in-flight, causing use-after-free crashes.

## Changes

| File | Fix |
|------|-----|
| `DefaultDatafileHandler.swift` | Moved invalidation to end of `downloadTask` callback + guard-failure path |
| `DefaultEventDispatcher.swift` | Moved invalidation to end of `uploadTask` callback |
| `OdpEventApiManager.swift` | Moved invalidation into inner `defer` block after `completionHandler` |
| `OdpSegmentApiManager.swift` | Moved invalidation into inner `defer` block after `completionHandler` |

## Test plan

- [x] `swift build` passes
- [x] Code review: session invalidated exactly once on every code path (success + error) in all 4 modules
- [x] No `defer { session.finishTasksAndInvalidate() }` remains in any affected file
- [ ] Existing Xcode test suite passes unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Issue
- [FSSDK-12729](https://optimizely-ext.atlassian.net/browse/FSSDK-12729)

[FSSDK-12729]: https://optimizely-ext.atlassian.net/browse/FSSDK-12729?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ