### PR TITLE
[FSSDK-12346] fix: defer NWPathMonitor creation to avoid crash during multi-SDK startup

### DIFF
--- a/Sources/Utils/NetworkReachability.swift
+++ b/Sources/Utils/NetworkReachability.swift
@@ -18,10 +18,11 @@ import Foundation
 import Network
 
 class NetworkReachability {
-    
+
     var monitor: AnyObject?
     let queue = DispatchQueue(label: "reachability")
-    
+    private var monitorStarted = false
+
     // the number of contiguous download failures (reachability)
     var numContiguousFails = 0
     // the maximum number of contiguous network connection failures allowed before reachability checking
@@ -33,7 +34,7 @@ class NetworkReachability {
     #else
     private var connected = true        // initially true for safety in production
     #endif
-    
+
     var isConnected: Bool {
         get {
             var result = false
@@ -49,30 +50,37 @@ class NetworkReachability {
             }
         }
     }
-    
+
     init(maxContiguousFails: Int? = nil) {
         self.maxContiguousFails = maxContiguousFails ?? NetworkReachability.defaultMaxContiguousFails
-     
-        if #available(macOS 10.14, iOS 12.0, watchOS 5.0, tvOS 12.0, *) {
-            
-            // NOTE: test with real devices only (simulator not updating properly)
+    }
 
-            self.monitor = NWPathMonitor()
-            
-            (monitor as! NWPathMonitor).pathUpdateHandler = { [weak self] (path: NWPath) -> Void in
-                // "Reachability path: satisfied (Path is satisfied), interface: en0, ipv4, ipv6, dns, expensive, constrained"
-                // "Reachability path: unsatisfied (No network route)"
-                // print("Reachability path: \(path)")
-                
+    // NOTE: NWPathMonitor can only be tested with real devices (simulator not updating properly)
+    func startMonitorIfNeeded() {
+        var shouldStart = false
+        queue.sync {
+            guard !monitorStarted else { return }
+            monitorStarted = true
+            shouldStart = true
+        }
+
+        guard shouldStart else { return }
+
+        if #available(macOS 10.14, iOS 12.0, watchOS 5.0, tvOS 12.0, *) {
+            let pathMonitor = NWPathMonitor()
+            self.monitor = pathMonitor
+
+            pathMonitor.pathUpdateHandler = { [weak self] (path: NWPath) -> Void in
                 // this task runs in sync queue. set private variable (instead of isConnected to avoid deadlock)
                 self?.connected = (path.status == .satisfied)
             }
-            
-            (monitor as! NWPathMonitor).start(queue: queue)
+
+            pathMonitor.start(queue: queue)
         }
     }
-    
+
     func stop() {
+        monitorStarted = true
         if #available(macOS 10.14, iOS 12.0, watchOS 5.0, tvOS 12.0, *) {
             guard let monitor = monitor as? NWPathMonitor else { return }
 
@@ -80,14 +88,16 @@ class NetworkReachability {
             monitor.cancel()
         }
     }
-    
+
     func updateNumContiguousFails(isError: Bool) {
         numContiguousFails = isError ? (numContiguousFails + 1) : 0
     }
-            
+
     /// Skip network access when reachability is down (optimization for iOS12+ only)
     /// - Returns: true when network access should be blocked
     func shouldBlockNetworkAccess() -> Bool {
+        startMonitorIfNeeded()
+
         if numContiguousFails < maxContiguousFails { return false }
 
         if #available(macOS 10.14, iOS 12.0, watchOS 5.0, tvOS 12.0, *) {
@@ -96,5 +106,5 @@ class NetworkReachability {
             return false
         }
     }
-    
+
 }

--- a/Sources/Utils/NetworkReachability.swift
+++ b/Sources/Utils/NetworkReachability.swift
@@ -1,10 +1,10 @@
 //
-// Copyright 2021, Optimizely, Inc. and contributors 
-// 
-// Licensed under the Apache License, Version 2.0 (the "License");  
+// Copyright 2021, Optimizely, Inc. and contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at   
-// 
+// You may obtain a copy of the License at
+//
 //    http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
@@ -19,102 +19,100 @@ import Network
 
 class NetworkReachability {
 
-    var monitor: AnyObject?
-    let queue = DispatchQueue(label: "reachability")
-    private var monitorStarted = false
+    private let queue = DispatchQueue(label: "reachability")
 
-    // the number of contiguous download failures (reachability)
-    var numContiguousFails = 0
-    // the maximum number of contiguous network connection failures allowed before reachability checking
-    var maxContiguousFails: Int
-    static let defaultMaxContiguousFails = 1
+    // All mutable state — only accessed within queue
+    private var monitor: AnyObject?
+    private var monitorStarted = false
+    private var _numContiguousFails = 0
+    private var _maxContiguousFails: Int
 
     #if targetEnvironment(simulator)
-    private var connected = false       // initially false for testing support
+    private var _connected = false       // initially false for testing support
     #else
-    private var connected = true        // initially true for safety in production
+    private var _connected = true        // initially true for safety in production
     #endif
 
+    static let defaultMaxContiguousFails = 1
+
+    // MARK: - Thread-safe accessors
+
     var isConnected: Bool {
-        get {
-            var result = false
-            queue.sync {
-                result = connected
-            }
-            return result
-        }
-        // for test support only
-        set {
-            queue.sync {
-                connected = newValue
-            }
-        }
+        get { queue.sync { _connected } }
+        set { queue.sync { _connected = newValue } }
     }
 
-    init(maxContiguousFails: Int? = nil) {
-        self.maxContiguousFails = maxContiguousFails ?? NetworkReachability.defaultMaxContiguousFails
+    var numContiguousFails: Int {
+        get { queue.sync { _numContiguousFails } }
+        set { queue.sync { _numContiguousFails = newValue } }
     }
+
+    var maxContiguousFails: Int {
+        get { queue.sync { _maxContiguousFails } }
+        set { queue.sync { _maxContiguousFails = newValue } }
+    }
+
+    var isMonitorActive: Bool {
+        queue.sync { monitor != nil }
+    }
+
+    // MARK: - Init
+
+    init(maxContiguousFails: Int? = nil) {
+        self._maxContiguousFails = maxContiguousFails ?? Self.defaultMaxContiguousFails
+    }
+
+    // MARK: - Monitor lifecycle
 
     // NOTE: NWPathMonitor can only be tested with real devices (simulator not updating properly)
     func startMonitorIfNeeded() {
-        var shouldStart = false
-        queue.sync {
-            guard !monitorStarted else { return }
-            monitorStarted = true
-            shouldStart = true
-        }
-
-        guard shouldStart else { return }
-
         if #available(macOS 10.14, iOS 12.0, watchOS 5.0, tvOS 12.0, *) {
-            let pathMonitor = NWPathMonitor()
-            self.monitor = pathMonitor
+            var monitorToStart: NWPathMonitor?
+            queue.sync {
+                guard !monitorStarted else { return }
+                monitorStarted = true
 
-            pathMonitor.pathUpdateHandler = { [weak self] (path: NWPath) -> Void in
-                // this task runs in sync queue. set private variable (instead of isConnected to avoid deadlock)
-                self?.connected = (path.status == .satisfied)
+                let pathMonitor = NWPathMonitor()
+                self.monitor = pathMonitor
+                pathMonitor.pathUpdateHandler = { [weak self] path in
+                    self?._connected = (path.status == .satisfied)
+                }
+                monitorToStart = pathMonitor
             }
-
-            pathMonitor.start(queue: queue)
+            monitorToStart?.start(queue: queue)
         }
     }
 
     func stop() {
         queue.sync {
             monitorStarted = true
-        }
-        if #available(macOS 10.14, iOS 12.0, watchOS 5.0, tvOS 12.0, *) {
-            guard let monitor = monitor as? NWPathMonitor else { return }
-
-            monitor.pathUpdateHandler = nil
-            monitor.cancel()
+            if #available(macOS 10.14, iOS 12.0, watchOS 5.0, tvOS 12.0, *) {
+                (monitor as? NWPathMonitor)?.pathUpdateHandler = nil
+                (monitor as? NWPathMonitor)?.cancel()
+            }
+            monitor = nil
         }
     }
+
+    // MARK: - Network state
 
     func updateNumContiguousFails(isError: Bool) {
         queue.sync {
-            numContiguousFails = isError ? (numContiguousFails + 1) : 0
+            _numContiguousFails = isError ? (_numContiguousFails + 1) : 0
         }
     }
 
-    /// Skip network access when reachability is down (optimization for iOS12+ only)
-    /// - Returns: true when network access should be blocked
     func shouldBlockNetworkAccess() -> Bool {
         startMonitorIfNeeded()
 
-        var shouldBlock = false
-        queue.sync {
-            if numContiguousFails >= maxContiguousFails {
-                shouldBlock = true
+        return queue.sync {
+            guard _numContiguousFails >= _maxContiguousFails else { return false }
+
+            if #available(macOS 10.14, iOS 12.0, watchOS 5.0, tvOS 12.0, *) {
+                return !_connected
+            } else {
+                return false
             }
-        }
-
-        guard shouldBlock else { return false }
-
-        if #available(macOS 10.14, iOS 12.0, watchOS 5.0, tvOS 12.0, *) {
-            return !isConnected
-        } else {
-            return false
         }
     }
 

--- a/Sources/Utils/NetworkReachability.swift
+++ b/Sources/Utils/NetworkReachability.swift
@@ -92,7 +92,9 @@ class NetworkReachability {
     }
 
     func updateNumContiguousFails(isError: Bool) {
-        numContiguousFails = isError ? (numContiguousFails + 1) : 0
+        queue.sync {
+            numContiguousFails = isError ? (numContiguousFails + 1) : 0
+        }
     }
 
     /// Skip network access when reachability is down (optimization for iOS12+ only)
@@ -100,7 +102,14 @@ class NetworkReachability {
     func shouldBlockNetworkAccess() -> Bool {
         startMonitorIfNeeded()
 
-        if numContiguousFails < maxContiguousFails { return false }
+        var shouldBlock = false
+        queue.sync {
+            if numContiguousFails >= maxContiguousFails {
+                shouldBlock = true
+            }
+        }
+
+        guard shouldBlock else { return false }
 
         if #available(macOS 10.14, iOS 12.0, watchOS 5.0, tvOS 12.0, *) {
             return !isConnected

--- a/Sources/Utils/NetworkReachability.swift
+++ b/Sources/Utils/NetworkReachability.swift
@@ -80,7 +80,9 @@ class NetworkReachability {
     }
 
     func stop() {
-        monitorStarted = true
+        queue.sync {
+            monitorStarted = true
+        }
         if #available(macOS 10.14, iOS 12.0, watchOS 5.0, tvOS 12.0, *) {
             guard let monitor = monitor as? NWPathMonitor else { return }
 

--- a/Tests/OptimizelyTests-Common/NetworkReachabilityTests.swift
+++ b/Tests/OptimizelyTests-Common/NetworkReachabilityTests.swift
@@ -122,10 +122,10 @@ class NetworkReachabilityTests: XCTestCase {
     func testMonitorNotCreatedDuringInit() {
         if #available(macOS 10.14, iOS 12.0, watchOS 5.0, tvOS 12.0, *) {
             let reachability = NetworkReachability()
-            XCTAssertNil(reachability.monitor, "NWPathMonitor should not be created during init")
+            XCTAssertFalse(reachability.isMonitorActive, "NWPathMonitor should not be created during init")
 
             _ = reachability.shouldBlockNetworkAccess()
-            XCTAssertNotNil(reachability.monitor, "NWPathMonitor should be created after shouldBlockNetworkAccess")
+            XCTAssertTrue(reachability.isMonitorActive, "NWPathMonitor should be created after shouldBlockNetworkAccess")
 
             reachability.stop()
         }
@@ -137,7 +137,7 @@ class NetworkReachabilityTests: XCTestCase {
             reachability.stop()
 
             _ = reachability.shouldBlockNetworkAccess()
-            XCTAssertNil(reachability.monitor, "NWPathMonitor should not be created after stop was called")
+            XCTAssertFalse(reachability.isMonitorActive, "NWPathMonitor should not be created after stop was called")
         }
     }
 

--- a/Tests/OptimizelyTests-Common/NetworkReachabilityTests.swift
+++ b/Tests/OptimizelyTests-Common/NetworkReachabilityTests.swift
@@ -96,11 +96,12 @@ class NetworkReachabilityTests: XCTestCase {
     
     func testReachabilityMonitoring() throws {
         if #available(macOS 10.14, iOS 12.0, watchOS 5.0, tvOS 12.0, *) {
-            
+
             let reachability = NetworkReachability()
-            
+            reachability.startMonitorIfNeeded()
+
             // isConnected is initially false (simulators only), and will be updated to true on updateHandler.
-            
+
             let exp = expectation(description: "x")
             DispatchQueue.global().async {
                 while true {
@@ -118,6 +119,28 @@ class NetworkReachabilityTests: XCTestCase {
         }
     }
     
+    func testMonitorNotCreatedDuringInit() {
+        if #available(macOS 10.14, iOS 12.0, watchOS 5.0, tvOS 12.0, *) {
+            let reachability = NetworkReachability()
+            XCTAssertNil(reachability.monitor, "NWPathMonitor should not be created during init")
+
+            _ = reachability.shouldBlockNetworkAccess()
+            XCTAssertNotNil(reachability.monitor, "NWPathMonitor should be created after shouldBlockNetworkAccess")
+
+            reachability.stop()
+        }
+    }
+
+    func testMonitorNotCreatedAfterStop() {
+        if #available(macOS 10.14, iOS 12.0, watchOS 5.0, tvOS 12.0, *) {
+            let reachability = NetworkReachability()
+            reachability.stop()
+
+            _ = reachability.shouldBlockNetworkAccess()
+            XCTAssertNil(reachability.monitor, "NWPathMonitor should not be created after stop was called")
+        }
+    }
+
     func testFetchDatafile_numContiguousFails() {
         let handler = MockDatafileHandler(withError: true, localResponseData: "{}")
         let reachability = handler.reachability

--- a/Tests/OptimizelyTests-Common/NetworkReachabilityTests.swift
+++ b/Tests/OptimizelyTests-Common/NetworkReachabilityTests.swift
@@ -141,6 +141,31 @@ class NetworkReachabilityTests: XCTestCase {
         }
     }
 
+    func testConcurrentAccessToNumContiguousFails() {
+        let reachability = NetworkReachability(maxContiguousFails: 100)
+        reachability.stop()
+        reachability.isConnected = false
+
+        let iterations = 1000
+        let exp = expectation(description: "concurrent")
+        exp.expectedFulfillmentCount = iterations * 2
+
+        for _ in 0..<iterations {
+            DispatchQueue.global().async {
+                reachability.updateNumContiguousFails(isError: true)
+                exp.fulfill()
+            }
+            DispatchQueue.global().async {
+                _ = reachability.shouldBlockNetworkAccess()
+                exp.fulfill()
+            }
+        }
+
+        wait(for: [exp], timeout: 10)
+        XCTAssertGreaterThan(reachability.numContiguousFails, 0)
+        reachability.stop()
+    }
+
     func testFetchDatafile_numContiguousFails() {
         let handler = MockDatafileHandler(withError: true, localResponseData: "{}")
         let reachability = handler.reachability


### PR DESCRIPTION
## Summary
- Deferred `NWPathMonitor` creation from `NetworkReachability.init` to first `shouldBlockNetworkAccess()` call
- Removed force casts (`as! NWPathMonitor`) in favor of local variable binding
- Added `monitorStarted` flag in `stop()` to prevent late monitor creation after teardown
- Added tests verifying monitor is not created during init and not created after `stop()`

In Flutter apps with multiple SDKs (Firebase, Datadog, MParticle) on iOS 16, `NWPathMonitor` was eagerly created during `DefaultEventDispatcher` stored-property initialization. This caused a null function pointer crash (`EXC_BAD_ACCESS` at `0x0`) due to dyld contention over the weak-linked Network framework during concurrent framework loading. The crash did not reproduce on iOS 17+ (improved dyld concurrency) or in sample apps (no competing SDKs).

By deferring `NWPathMonitor` creation to first use during event dispatch, the Network framework symbols are resolved well after app startup contention has settled.

## Test plan
- Added `testMonitorNotCreatedDuringInit` — confirms `monitor` is nil after init, non-nil after `shouldBlockNetworkAccess()`
- Added `testMonitorNotCreatedAfterStop` — confirms monitor stays nil if `stop()` was called before first use
- Updated `testReachabilityMonitoring` to explicitly trigger monitor start
- All existing `NetworkReachabilityTests` and `EventDispatcherRetryTests` pass

## Issues
- FSSDK-12346