### PR TITLE
[AI-FSSDK] [FSSDK-12873] prepare for release swift v5.4.2

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -17,7 +17,7 @@ on:
         description: release
 
 env:
-  VERSION: 5.4.1
+  VERSION: 5.4.2
 
 jobs:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Optimizely Swift SDK Changelog
 
+## 5.4.2
+July 9, 2026
+
+### Fixes
+
+- Use attribute id instead of key for CMAB prediction requests ([#648](https://github.com/optimizely/swift-sdk/pull/648))
+- fix: defer NWPathMonitor creation to avoid crash during multi-SDK startup ([#650](https://github.com/optimizely/swift-sdk/pull/650))
+- fix: prevent EXC_BAD_ACCESS from premature URLSession deallocation ([#649](https://github.com/optimizely/swift-sdk/pull/649))
+- Replace non-numeric holdout placeholder IDs in event-construction tests ([#646](https://github.com/optimizely/swift-sdk/pull/646))
+
 ## 5.4.1
 June 24, 2026
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ If you have a name conflict with other swift packages when you add the Optimizel
 #### CocoaPods 
 1. Add the following lines to the _Podfile_:<pre>
 ```use_frameworks!```
-```pod 'OptimizelySwiftSDK', '~> 5.4.1'```
+```pod 'OptimizelySwiftSDK', '~> 5.4.2'```
 </pre>
 
 2. Run the following command: <pre>``` pod install ```</pre>


### PR DESCRIPTION
## Summary

Prepare for releasing swift v5.4.2

## Release Details
- Version Bump: v5.4.1 → v5.4.2 (patch)

## Changes
- `e4162cb` [FSSDK-12873] bump version to 5.4.2
- `efefb02` [FSSDK-12873] update CHANGELOG for swift v5.4.2

## Jira Ticket
[FSSDK-12873](https://optimizely-ext.atlassian.net/browse/FSSDK-12873)

[FSSDK-12873]: https://optimizely-ext.atlassian.net/browse/FSSDK-12873?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FSSDK-12873]: https://optimizely-ext.atlassian.net/browse/FSSDK-12873?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FSSDK-12873]: https://optimizely-ext.atlassian.net/browse/FSSDK-12873?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ